### PR TITLE
Change get_reg_cols method to allow any custom regression_cols dict

### DIFF
--- a/captest/capdata.py
+++ b/captest/capdata.py
@@ -1760,27 +1760,25 @@ class CapData(object):
         self.data.drop(columns, axis=1, inplace=True)
         self.data_filtered.drop(columns, axis=1, inplace=True)
 
-    def get_reg_cols(self, reg_vars=['power', 'poa', 't_amb', 'w_vel'],
-                     filtered_data=True):
+    def get_reg_cols(self, reg_vars=None, filtered_data=True):
         """
-        Get and rename the regression columns.
+        Get regression columns renamed with keys from `regression_cols`.
 
         Parameters
         ----------
-        reg_vars : list or str
-            Default is all of 'power', 'poa', 't_amb', 'w_vel'.  Any
-            combination of the four is valid.
-            Pass any of the four as a string to get only one regression column.
+        reg_vars : list or str, default None
+            By default returns all columns identified in `regression_cols`.
+            A list with any combination of the keys of `regression_cols` is valid
+            or pass a single key as a string.
         filtered_data : bool, default true
-            Return filtered or unfiltered dataself.
+            Return filtered or unfiltered data.
+
         Returns
         -------
         DataFrame
-
-        Todo
-        ----
-        Pass list of reg coeffs to rename default all of them.
         """
+        if reg_vars is None:
+            reg_vars = list(self.regression_cols.keys())
         df = self.rview(reg_vars, filtered_data=filtered_data).copy()
         rename = {df.columns[0]: reg_vars}
 

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -969,6 +969,29 @@ class TestGetRegCols(unittest.TestCase):
                          df['w_vel'].iloc[100],
                          'Data in column labeled w_vel is not w_vel.')
 
+    def test_all_coeffs_custom_regression_columns(self):
+        self.das.regression_cols = {
+            'power':'Elkor Production Meter KW, kW',
+            'poa_front':'Weather Station 1 Sun, W/m^2',
+            'wind_speed':'Weather Station 2 WindSpeed, mph',
+        }
+        print(self.das.data.columns)
+        cols = ['power', 'poa_front', 'wind_speed']
+        df = self.das.get_reg_cols()
+        self.assertEqual(len(df.columns), 3,
+                         'Returned number of columns is incorrect.')
+        self.assertEqual(df.columns.to_list(), cols,
+                         'Columns are not renamed properly.')
+        self.assertEqual(self.das.data['Elkor Production Meter KW, kW'].iloc[100],
+                         df['power'].iloc[100],
+                         'Data in column labeled power is not power.')
+        self.assertEqual(self.das.data['Weather Station 1 Sun, W/m^2'].iloc[100],
+                         df['poa_front'].iloc[100],
+                         'Data in column labeled poa is not poa.')
+        self.assertEqual(self.das.data['Weather Station 2 WindSpeed, mph'].iloc[100],
+                         df['wind_speed'].iloc[100],
+                         'Data in column labeled wind_speed is not wind speed.')
+
     def test_poa_power(self):
         self.das.agg_sensors()
         cols = ['poa', 'power']


### PR DESCRIPTION
The `get_reg_cols` method would by default return columns that match the keys and values of the `regression_cols` dictionary when using the `set_regression_cols` method, the keys of which match the default terms used in the `regression_formula` attribute of a CapData object.

This limited the users flexibility to directly assign the `regression_cols` attribute with a dictionary that has keys matching terms in a user assigned (not the default) `regression_formula`. 

The change made here allows fitting a regression against any user defined regression formula and columns. This should facilitate bifacial testing and tests using regression equations different than the one defined in ASTM E2848.