### PR TITLE
Removes use of hvplot package

### DIFF
--- a/docs/examples/reporting_conditions.ipynb
+++ b/docs/examples/reporting_conditions.ipynb
@@ -15,7 +15,9 @@
    "source": [
     "import pandas as pd\n",
     "import matplotlib as plt\n",
-    "import captest as ct"
+    "import captest as ct\n",
+    "import holoviews as hv\n",
+    "hv.extension('bokeh')"
    ]
   },
   {


### PR DESCRIPTION
Replace use of hvplot with holoviews in the `plot` method of  the `ReportingIrradiance` class to avoid having to add hvplot as a dependency.