### PR TITLE
Fix failing ci tests

### DIFF
--- a/captest/capdata.py
+++ b/captest/capdata.py
@@ -2448,7 +2448,7 @@ class CapData(object):
         """
         ix_all_days = None
         for day in days:
-            ix_day = self.data_filtered[day].index
+            ix_day = self.data_filtered.loc[day].index
             if ix_all_days is None:
                 ix_all_days = ix_day
             else:

--- a/captest/capdata.py
+++ b/captest/capdata.py
@@ -475,7 +475,7 @@ def filter_irr(df, irr_col, low, high, ref_val=None):
     return df.loc[indx, :]
 
 
-def filter_grps(grps, rcs, irr_col, low, high, **kwargs):
+def filter_grps(grps, rcs, irr_col, low, high, freq, **kwargs):
     """
     Apply irradiance filter around passsed reporting irradiances to groupby.
 
@@ -489,6 +489,14 @@ def filter_grps(grps, rcs, irr_col, low, high, **kwargs):
     rcs : pandas DataFrame
         Dataframe of reporting conditions.  Use the rep_cond method to generate
         a dataframe for this argument.
+    irr_col : str
+        String that is the name of the column with the irradiance data.
+    low : float
+        Minimum value as fraction e.g. 0.8. 
+    high : float
+        Max value as fraction e.g. 1.2.
+    freq : str
+        Frequency to groupby e.g. 'MS' for month start.
     **kwargs
         Passed to pandas Grouper to control label and closed side of intervals.
         See pandas Grouper doucmentation for details. Default is left labeled
@@ -499,7 +507,6 @@ def filter_grps(grps, rcs, irr_col, low, high, **kwargs):
     pandas groupby
     """
     flt_dfs = []
-    freq = list(grps.groups.keys())[0].freq
     for grp_name, grp_df in grps:
         ref_val = rcs.loc[grp_name, 'poa']
         grp_df_flt = filter_irr(grp_df, irr_col, low, high, ref_val=ref_val)
@@ -792,11 +799,11 @@ def predict(regs, rcs):
     -------
     Pandas series of predicted values.
     """
-    pred_cap = pd.Series()
+    pred_cap = list()
     for i, mod in enumerate(regs):
         RC_df = pd.DataFrame(rcs.iloc[i, :]).T
-        pred_cap = pred_cap.append(mod.predict(RC_df))
-    return pred_cap
+        pred_cap.append(mod.predict(RC_df).values[0])
+    return pd.Series(pred_cap)
 
 
 def pred_summary(grps, rcs, allowance, **kwargs):
@@ -2920,7 +2927,7 @@ class CapData(object):
             Can pass a string function ('mean') to calculate each reporting
             condition the same way.
         freq: str
-            String pandas offset alias to specify aggregattion frequency
+            String pandas offset alias to specify aggregation frequency
             for reporting condition calculation. Ex '60D' for 60 Days or
             'MS' for months start.
         w_vel: int
@@ -2979,7 +2986,6 @@ class CapData(object):
             df_grpd = df.groupby(pd.Grouper(freq=freq, **grouper_kwargs))
 
             if irr_bal:
-                freq = list(df_grpd.groups.keys())[0].freq
                 ix = pd.DatetimeIndex(list(df_grpd.groups.keys()), freq=freq)
                 poa_RC = []
                 temp_RC = []
@@ -3052,11 +3058,10 @@ class CapData(object):
         grps = df.groupby(by=pd.Grouper(freq=freq, **kwargs))
 
         if irr_filter:
-            grps = filter_grps(grps, self.rc, 'poa', low, high)
+            grps = filter_grps(grps, self.rc, 'poa', low, high, freq)
 
         error = float(self.tolerance.split(sep=' ')[1]) / 100
-        results = pred_summary(grps, self.rc, error,
-                               fml=self.regression_formula)
+        results = pred_summary(grps, self.rc, error, fml=self.regression_formula)
 
         return results
 

--- a/captest/capdata.py
+++ b/captest/capdata.py
@@ -1179,7 +1179,7 @@ def captest_results(sim, das, nameplate, tolerance, check_pvalues=False,
 
     if check_pvalues:
         for cd in [sim_int, das_int]:
-            for key, val in cd.regression_results.pvalues.iteritems():
+            for key, val in cd.regression_results.pvalues.items():
                 if val > pval:
                     cd.regression_results.params[key] = 0
 

--- a/captest/io.py
+++ b/captest/io.py
@@ -229,6 +229,7 @@ class DataLoader:
         Set `files_to_load` attribute to a list of filepaths.
         """
         self.files_to_load = [file for file in self.path.glob("*." + extension)]
+        self.files_to_load.sort()
         if len(self.files_to_load) == 0:
             return warnings.warn(
                 "No files with .{} extension were found in the directory: {}".format(

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -1259,7 +1259,7 @@ class TestPredictCapacities():
         df = df.rename(columns=rename)
         reg = pvc.fit_model(df)
         july_manual = reg.predict(pvsyst_irr_filter.rc)[0]
-        assert pytest.approx(july_manual, july_grpby, abs=1e-5)
+        assert july_manual == pytest.approx(july_grpby)
 
     def test_no_irr_filter(self, pvsyst_irr_filter):
         pvsyst_irr_filter.rep_cond(freq='M')

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -184,29 +184,38 @@ class TestTopLevelFuncs(unittest.TestCase):
         self.assertEqual(col_set_length, col_length,
                          'There is a duplicate column name in the results df.')
 
-        pt_qty_exp = [341, 330, 392, 390, 403, 406,
-                           456, 386, 390, 346, 331, 341]
-        gaur_cap_exp = [3089550.4039329495, 3103610.4635679387,
-                        3107035.251399103, 3090681.1145782764,
-                        3058186.270209293, 3059784.2309170915,
-                        3088294.50827525, 3087081.0026879036,
-                        3075251.990424683, 3093287.331878834,
-                        3097089.7852036236, 3084318.093294242]
+        pt_qty_exp = [341, 330, 392, 390, 403, 406, 456, 386, 390, 346, 331, 341]
+        gaur_cap_exp = [
+            3089550.4039329495,
+            3103610.4635679387,
+            3107035.251399103,
+            3090681.1145782764,
+            3058186.270209293,
+            3059784.2309170915,
+            3088294.50827525,
+            3087081.0026879036,
+            3075251.990424683,
+            3093287.331878834,
+            3097089.7852036236,
+            3084318.093294242,
+        ]
         for i, mnth in enumerate(results.index):
-            self.assertLess(results.loc[mnth, 'guaranteedCap'],
-                            results.loc[mnth, 'PredCap'],
-                            'Gauranteed capacity is greater than predicted in'
-                            'month {}'.format(mnth))
-            self.assertGreater(results.loc[mnth, 'guaranteedCap'], 0,
-                               'Gauranteed capacity is less than 0 in'
-                               'month {}'.format(mnth))
-            self.assertAlmostEqual(results.loc[mnth, 'guaranteedCap'],
-                                   gaur_cap_exp[i], 7,
-                                   'Gauranted capacity not equal to expected'
-                                   'value in {}'.format(mnth))
-            self.assertEqual(results.loc[mnth, 'pt_qty'], pt_qty_exp[i],
-                               'Point quantity not equal to expected values in'
-                               '{}'.format(mnth))
+            self.assertLess(
+                results.loc[mnth, 'guaranteedCap'],
+                results.loc[mnth, 'PredCap'],
+                'Gauranteed cap is greater than predicted in month {}'.format(mnth)
+            )
+            self.assertGreater(
+                results.loc[mnth, 'guaranteedCap'], 0,
+                'Gauranteed capacity is less than 0 in month {}'.format(mnth)
+            )
+            self.assertAlmostEqual(
+                results.loc[mnth, 'guaranteedCap'], gaur_cap_exp[i], 7,
+                'Gauranted capacity not equal to expected value in {}'.format(mnth))
+            self.assertEqual(
+                results.loc[mnth, 'pt_qty'], pt_qty_exp[i],
+                'Point quantity not equal to expected values in {}'.format(mnth)
+            )
 
     def test_perc_bounds_perc(self):
         bounds = pvc.perc_bounds(20)
@@ -231,7 +240,7 @@ class TestTopLevelFuncs(unittest.TestCase):
         grps = pvsyst.data_filtered.groupby(pd.Grouper(freq='MS', label='left'))
         poa_col = pvsyst.column_groups[pvsyst.regression_cols['poa']][0]
 
-        grps_flt = pvc.filter_grps(grps, pvsyst.rc, poa_col, 0.8, 1.2)
+        grps_flt = pvc.filter_grps(grps, pvsyst.rc, poa_col, 0.8, 1.2, 'MS')
 
         self.assertIsInstance(grps_flt,
                               pd.core.groupby.generic.DataFrameGroupBy,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -190,7 +190,10 @@ class TestFileReader:
         ).to_csv(test_csv)
         test_csv.seek(0)
         df_str = test_csv.getvalue()
-        df_with_blank_row = df_str[0:20] + ",,\n" + df_str[20:]
+        if os.name == 'nt':
+            df_with_blank_row = df_str[0:20] + ",,\r\n" + df_str[20:]
+        else:
+            df_with_blank_row = df_str[0:20] + ",,\n" + df_str[20:]
         with open(csv_path, "w") as f:
             f.write(df_with_blank_row)
         loaded_data = io.file_reader(csv_path)
@@ -419,8 +422,8 @@ class TestDataLoader:
         data = dl._join_files()
         assert data.shape == (24, 4)
         assert data.isna().sum().sum() == 0
-        assert data.dtypes["a"] == "int"
-        assert data.dtypes["b"] == "int"
+        assert data.dtypes["a"] == "int64"
+        assert data.dtypes["b"] == "int64"
         assert data.dtypes["c"] == "float64"
         assert data.dtypes["d"] == "float64"
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -191,13 +191,14 @@ class TestFileReader:
         test_csv.seek(0)
         df_str = test_csv.getvalue()
         if os.name == 'nt':
-            df_with_blank_row = df_str[0:20] + ",,\r\n" + df_str[20:]
+            df_with_blank_row = df_str[0:21] + ",,\r\n" + df_str[21:]
+            with open(csv_path, "w", newline='') as f:
+                f.write(df_with_blank_row)
         else:
             df_with_blank_row = df_str[0:20] + ",,\n" + df_str[20:]
-        with open(csv_path, "w") as f:
-            f.write(df_with_blank_row)
+            with open(csv_path, "w") as f:
+                f.write(df_with_blank_row)
         loaded_data = io.file_reader(csv_path)
-        print(loaded_data)
         assert isinstance(loaded_data, pd.DataFrame)
         assert loaded_data.columns[0] == "met1_poa"
         assert isinstance(loaded_data.index, pd.DatetimeIndex)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -284,8 +284,11 @@ class TestDataLoader:
         assert dl.path == Path("./data/data_for_yyyy-mm-dd.csv")
 
     def test_set_files_to_load(self, tmp_path):
-        """Test that file paths for given extension are stored to list."""
-        for fname in ["a.csv", "b.csv", "c.csv"]:
+        """
+        Test that file paths for given extension are stored to list.
+        Also, check sorting of filenames.
+        """
+        for fname in ["b.csv", "a.csv", "c.csv"]:
             with open(tmp_path / fname, "w") as f:
                 pass
         dl = DataLoader(tmp_path)
@@ -294,6 +297,22 @@ class TestDataLoader:
             tmp_path / "a.csv",
             tmp_path / "b.csv",
             tmp_path / "c.csv",
+        ]
+
+    def test_set_files_to_load_date_filenames(self, tmp_path):
+        """
+        Test that file paths for given extension are stored to list.
+        Also, check sorting of filenames.
+        """
+        for fname in ["2023-04-02.csv", "2023-04-01.csv", "2023-04-03.csv"]:
+            with open(tmp_path / fname, "w") as f:
+                pass
+        dl = DataLoader(tmp_path)
+        dl.set_files_to_load()
+        assert dl.files_to_load == [
+            tmp_path / "2023-04-01.csv",
+            tmp_path / "2023-04-02.csv",
+            tmp_path / "2023-04-03.csv",
         ]
 
     def test_set_files_to_load_not_all_csv(self, tmp_path):


### PR DESCRIPTION
- Fixes misuse of pytest.approx caught in CI due to newer version of pytest.
- Sorts files to load.