### PR TITLE
Improve data loading workflow 

### DIFF
--- a/src/captest/io.py
+++ b/src/captest/io.py
@@ -479,7 +479,7 @@ def load_data(
         cd.data_loader = dl
         # group columns
         if callable(group_columns):
-            cd.column_groups = group_columns(cd.data)
+            cd.column_groups = cg.ColumnGroups(group_columns(cd.data))
         elif isinstance(group_columns, str):
             p = Path(group_columns)
             if p.suffix == ".json":


### PR DESCRIPTION
Collection of changes and updates to improve the data loading workflow:

- removes to numeric conversion from file reader that did not use coerce and would result in a file with a string (e.g. "N/A") to not load which would cause subsequent files not to load. There is still a to numeric with coerce in join files, so the combined data in CapData.data should be numeric, but the dataframes from each file in data loader may not be.
- adds list of files that did not load to DataLoader
- adds try except to file reading loop
- add verbose option to load method which will print which files are loading, which makes it easier to identify which file does not load
- add print_errors options which will print the error for files that don't load