### PR TITLE
Update pvcaptest for compatability with Bokeh 3.0.0+

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false  # don't cancel other matrix jobs when one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a user guide section to the documentation with an overview and bifacial tests section.
 
 ### Changed
-- Updates to make captest compatible with pvlib 0.10 and scipy 1.11
+- Updates to make pvcaptest compatible with pvlib 0.10 and scipy 1.11
+- Update to make pvcaptest compatible with bokeh v3.0.0, change `plot_width` and `plot_height` to `width` and `height`
+- Make bokeh v3 minimum version
+- Drop support for python 3.7
 
 [0.11.2]: https://github.com/pvcaptest/pvcaptest/compare/v0.11.1...v0.11.2
 ## [0.11.2] - 2023-04-20

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ author = 'Ben Taylor'
 
 
 # -- General configuration ---------------------------------------------------
+master_doc = 'index'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES=[
     'matplotlib>=2',
     'statsmodels>=0.8',
     'scikit-learn>=0.19',
-    'bokeh>=1',
+    'bokeh>=3',
     'colorcet',
     'param',
 ]
@@ -56,7 +56,7 @@ setup(
     url='http://github.com/bt-/pvcaptest',
     license='MIT',
     author='Ben Taylor',
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     author_email='benjaming.taylor@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES=[
     'matplotlib>=2',
     'statsmodels>=0.8',
     'scikit-learn>=0.19',
-    'bokeh>=3',
+    'bokeh>=3.0.0',
     'colorcet',
     'param',
 ]

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1805,9 +1805,9 @@ class CapData(object):
         else:
             return(poa_vs_kw)
 
-    def plot(self, marker='line', ncols=2, width=400, height=350,
+    def plot(self, marker='line', ncols=1, width=1500, height=250,
              legends=False, merge_grps=['irr', 'temp'], subset=None,
-             filtered=False, use_abrev_name=True, **kwargs):
+             filtered=False, use_abrev_name=False, **kwargs):
         """
         Create a plot for each group of sensors in self.column_groups.
 

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1898,12 +1898,12 @@ class CapData(object):
             cols = df.columns.tolist()
 
             if x_axis is None:
-                p = figure(title=key, plot_width=width, plot_height=height,
+                p = figure(title=key, width=width, height=height,
                            x_axis_type='datetime', tools=tools)
                 p.tools.append(hover)
                 x_axis = p.x_range
             if j > 0:
-                p = figure(title=key, plot_width=width, plot_height=height,
+                p = figure(title=key, width=width, height=height,
                            x_axis_type='datetime', x_range=x_axis, tools=tools)
                 p.tools.append(hover)
             legend_items = []


### PR DESCRIPTION
Makes Bokeh 3.0 the minimum version and changes the use of `plot_width` and `plot_height` to `width` and `height`.