### PR TITLE
Linked timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `load_data` now checks if any individual files were loaded when loading multiple files from a directory.
+- Adds underlay curve of unfiltered power to the linked timeseries created when calling `scatter_hv` with `timeseries=True`.
+- Changes selected points on scatter plot and linked timeseries produced by `scatter_hv` to red.
 
 [0.12.0]: https://github.com/pvcaptest/pvcaptest/compare/v0.11.2...v0.12.0
 ## [0.12.0] - 2023-08-27

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1791,6 +1791,8 @@ class CapData(object):
             legend_position='right',
             height=400,
             width=400,
+            selection_fill_color='red',
+            selection_line_color='red',
         )
         # layout_scatter = (poa_vs_kw).opts(opt_dict)
         if timeseries:
@@ -1798,6 +1800,8 @@ class CapData(object):
                 tools=['hover', 'lasso_select', 'box_select'],
                 height=400,
                 width=800,
+                selection_fill_color='red',
+                selection_line_color='red',
             )
             power_col, poa_col = self.loc[['power', 'poa']].columns
             poa_vs_time_underlay = hv.Curve(

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1794,12 +1794,25 @@ class CapData(object):
         )
         # layout_scatter = (poa_vs_kw).opts(opt_dict)
         if timeseries:
-            poa_vs_time = hv.Curve(df, 'index', ['power', 'poa']).opts(
+            poa_vs_time = hv.Scatter(df, 'index', ['power', 'poa']).opts(
                 tools=['hover', 'lasso_select', 'box_select'],
                 height=400,
                 width=800,
             )
-            layout_timeseries = (poa_vs_kw + poa_vs_time)
+            power_col, poa_col = self.loc[['power', 'poa']].columns
+            poa_vs_time_underlay = hv.Curve(
+                self.data,
+                'Timestamp',
+                [power_col, poa_col],
+            ).opts(
+                tools=['hover', 'lasso_select', 'box_select'],
+                height=400,
+                width=800,
+                line_color='gray',
+                line_width=1,
+                line_alpha=0.4,
+            )
+            layout_timeseries = (poa_vs_kw + poa_vs_time * poa_vs_time_underlay)
             DataLink(poa_vs_kw, poa_vs_time)
             return(layout_timeseries.cols(1))
         else:


### PR DESCRIPTION
Improves the linked timeseries plot of power generated when passing `timeseries=True` to the `scatter_hv` method. Previously the timeseries would show only the points remaining after filtering which was often hard to read without the context of the points removed by filtering. There are two improvements: adds and underlay curve of the unfiltered power data and changes the color of selected points to red so they are clearly visible.