### PR TITLE
Remove plot function dependency on a string index column in data and data_filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds underlay curve of unfiltered power to the linked timeseries created when calling `scatter_hv` with `timeseries=True`.
 - Changes selected points on scatter plot and linked timeseries produced by `scatter_hv` to red.
 - Tolerances may now be fractions eg '- 3.5'
+- The plotting methods `scatter_hv`, `scatter_filters`, and `timeseries_filters` do not require a column labeled 'index' with string datetimes in the `data` DataFrame anymore. Also, the index of the `data` DataFrame does not need to be named 'Timeseries'.
 
 [0.12.0]: https://github.com/pvcaptest/pvcaptest/compare/v0.11.2...v0.12.0
 ## [0.12.0] - 2023-08-27

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1805,7 +1805,7 @@ class CapData(object):
             )
             power_col, poa_col = self.loc[['power', 'poa']].columns
             poa_vs_time_underlay = hv.Curve(
-                self.data,
+                self.data.rename_axis('Timestamp', axis='index'),
                 'Timestamp',
                 [power_col, poa_col],
             ).opts(

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1983,7 +1983,7 @@ class CapData(object):
         scatters = []
 
         data = self.get_reg_cols(reg_vars=['power', 'poa'], filtered_data=False)
-        data['index'] = self.data.loc[:, 'index']
+        data['index'] = self.data.index
         plt_no_filtering = hv.Scatter(data, 'poa', ['power', 'index']).relabel('all')
         scatters.append(plt_no_filtering)
 

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1785,9 +1785,19 @@ class CapData(object):
         vdims = ['power', 'index']
         if all_reg_columns:
             vdims.extend(list(df.columns.difference(vdims)))
+        hover = HoverTool(
+            tooltips=[
+                ('datetime', '@index{%Y-%m-%d %H:%M}'),
+                ('poa', '@poa{0,0.0}'),
+                ('power', '@power{0,0.0}'),
+            ],
+            formatters={
+                '@index': 'datetime',
+            }
+        )
         poa_vs_kw = hv.Scatter(df, 'poa', vdims).opts(
             size=5,
-            tools=['hover', 'lasso_select', 'box_select'],
+            tools=[hover, 'lasso_select', 'box_select'],
             legend_position='right',
             height=400,
             width=400,
@@ -1797,20 +1807,20 @@ class CapData(object):
         )
         # layout_scatter = (poa_vs_kw).opts(opt_dict)
         if timeseries:
-            poa_vs_time = hv.Scatter(df, 'index', ['power', 'poa']).opts(
-                tools=['hover', 'lasso_select', 'box_select'],
+            power_vs_time = hv.Scatter(df, 'index', ['power', 'poa']).opts(
+                tools=[hover, 'lasso_select', 'box_select'],
                 height=400,
                 width=800,
                 selection_fill_color='red',
                 selection_line_color='red',
             )
             power_col, poa_col = self.loc[['power', 'poa']].columns
-            poa_vs_time_underlay = hv.Curve(
-                self.data.rename_axis('Timestamp', axis='index'),
-                'Timestamp',
+            power_vs_time_underlay = hv.Curve(
+                self.data.rename_axis('index', axis='index'),
+                'index',
                 [power_col, poa_col],
             ).opts(
-                tools=['hover', 'lasso_select', 'box_select'],
+                tools=['lasso_select', 'box_select'],
                 height=400,
                 width=800,
                 line_color='gray',
@@ -1818,8 +1828,8 @@ class CapData(object):
                 line_alpha=0.4,
                 yformatter=NumeralTickFormatter(format='0,0'),
             )
-            layout_timeseries = (poa_vs_kw + poa_vs_time * poa_vs_time_underlay)
-            DataLink(poa_vs_kw, poa_vs_time)
+            layout_timeseries = (poa_vs_kw + power_vs_time * power_vs_time_underlay)
+            DataLink(poa_vs_kw, power_vs_time)
             return(layout_timeseries.cols(1))
         else:
             return(poa_vs_kw)
@@ -2005,6 +2015,16 @@ class CapData(object):
             scatters.append(plt)
 
         scatter_overlay = hv.Overlay(scatters)
+        hover = HoverTool(
+            tooltips=[
+                ('datetime', '@index{%Y-%m-%d %H:%M}'),
+                ('poa', '@poa{0,0.0}'),
+                ('power', '@power{0,0.0}'),
+            ],
+            formatters={
+                '@index': 'datetime',
+            }
+        )
         scatter_overlay.opts(
             hv.opts.Scatter(
                 size=5,
@@ -2013,7 +2033,7 @@ class CapData(object):
                 muted_fill_alpha=0,
                 fill_alpha=0.4,
                 line_width=0,
-                tools=['hover'],
+                tools=[hover],
                 yformatter=NumeralTickFormatter(format='0,0'),
             ),
             hv.opts.Overlay(
@@ -2063,13 +2083,22 @@ class CapData(object):
             plots.append(plt)
 
         scatter_overlay = hv.Overlay(plots)
+        hover = HoverTool(
+            tooltips=[
+                ('datetime', '@Timestamp{%Y-%m-%d %H:%M}'),
+                ('power', '@power{0,0.0}'),
+            ],
+            formatters={
+                '@Timestamp': 'datetime',
+            }
+        )
         scatter_overlay.opts(
             hv.opts.Scatter(
                 size=5,
                 muted_fill_alpha=0,
                 fill_alpha=1,
                 line_width=0,
-                tools=['hover'],
+                tools=[hover],
                 yformatter=NumeralTickFormatter(format='0,0'),
             ),
             hv.opts.Overlay(

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2031,8 +2031,8 @@ class CapData(object):
         plots = []
 
         data = self.get_reg_cols(reg_vars='power', filtered_data=False)
-        data = data.rename_axis('Timestamp', axis='index').reset_index()
-        plt_no_filtering  = hv.Curve(data, ['Timestamp'], ['power'], label='all')
+        data['Timestamp'] = data.index
+        plt_no_filtering = hv.Curve(data, ['Timestamp'], ['power'], label='all')
         plt_no_filtering.opts(
             line_color='black',
             line_width=1,
@@ -2042,9 +2042,10 @@ class CapData(object):
         plots.append(plt_no_filtering)
 
         d1 = self.rview('power').loc[self.removed[0]['index'], :]
+        d1 = data.loc[self.removed[0]['index'], :]
         plt_first_filter = hv.Scatter(
-            (d1.index, d1.iloc[:, 0]),
-            label=self.removed[0]['name'])
+            d1, ['Timestamp'], ['power'], label=self.removed[0]['name']
+        )
         plots.append(plt_first_filter)
 
         for i, filtering_step in enumerate(self.kept):
@@ -2052,8 +2053,10 @@ class CapData(object):
                 break
             else:
                 flt_legend = self.kept[i + 1]['name']
-            d_flt = self.rview('power').loc[filtering_step['index'], :]
-            plt = hv.Scatter((d_flt.index, d_flt.iloc[:, 0]), label=flt_legend)
+            d_flt = data.loc[filtering_step['index'], :]
+            plt = hv.Scatter(
+                d_flt, ['Timestamp'], ['power'], label=flt_legend
+            )
             plots.append(plt)
 
         scatter_overlay = hv.Overlay(plots)

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -40,7 +40,7 @@ from bokeh.io import show
 from bokeh.plotting import figure
 from bokeh.palettes import Category10
 from bokeh.layouts import gridplot
-from bokeh.models import Legend, HoverTool, ColumnDataSource
+from bokeh.models import Legend, HoverTool, ColumnDataSource, NumeralTickFormatter
 
 import param
 
@@ -1793,6 +1793,7 @@ class CapData(object):
             width=400,
             selection_fill_color='red',
             selection_line_color='red',
+            yformatter=NumeralTickFormatter(format='0,0'),
         )
         # layout_scatter = (poa_vs_kw).opts(opt_dict)
         if timeseries:
@@ -1815,6 +1816,7 @@ class CapData(object):
                 line_color='gray',
                 line_width=1,
                 line_alpha=0.4,
+                yformatter=NumeralTickFormatter(format='0,0'),
             )
             layout_timeseries = (poa_vs_kw + poa_vs_time * poa_vs_time_underlay)
             DataLink(poa_vs_kw, poa_vs_time)
@@ -2012,6 +2014,7 @@ class CapData(object):
                 fill_alpha=0.4,
                 line_width=0,
                 tools=['hover'],
+                yformatter=NumeralTickFormatter(format='0,0'),
             ),
             hv.opts.Overlay(
                 legend_position='right',
@@ -2067,6 +2070,7 @@ class CapData(object):
                 fill_alpha=1,
                 line_width=0,
                 tools=['hover'],
+                yformatter=NumeralTickFormatter(format='0,0'),
             ),
             hv.opts.Overlay(
                 legend_position='bottom',

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2031,7 +2031,7 @@ class CapData(object):
         plots = []
 
         data = self.get_reg_cols(reg_vars='power', filtered_data=False)
-        data.reset_index(inplace=True)
+        data = data.rename_axis('Timestamp', axis='index').reset_index()
         plt_no_filtering  = hv.Curve(data, ['Timestamp'], ['power'], label='all')
         plt_no_filtering.opts(
             line_color='black',

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2068,5 +2068,23 @@ class TestScatterHv():
         assert isinstance(plot, hv.core.layout.Layout)
 
 
+class TestScatterFilters():
+    """Test the scatter_filters method of the CapData class."""
+    def test_returns_overlay(self, meas):
+        """
+        Test that the scatter_filters method of the CapData class returns a
+        holoviews overlay object.
+        """
+        meas.agg_sensors(agg_map={
+            'irr_poa_pyran': 'mean', 'temp_amb': 'mean', 'wind': 'mean'
+        })
+        meas.filter_irr(200, 900)
+        meas.filter_irr(400, 800)
+        overlay = meas.scatter_filters()
+        assert 'index' not in meas.data.columns
+        assert 'index' not in meas.data_filtered.columns
+        assert isinstance(overlay, hv.core.overlay.Overlay)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -8,6 +8,7 @@ import pytz
 import numpy as np
 import pandas as pd
 import statsmodels.formula.api as smf
+import holoviews as hv
 import json
 import warnings
 
@@ -2041,6 +2042,18 @@ class TestDataColumnsToExcel():
         df = pd.read_excel(xlsx_file, header=None)
         assert df.iloc[0, 1] == 'inv1_power'
         os.remove(xlsx_file)
+
+
+class TestScatterHv():
+    """Test scatter_hv method of CapData class."""
+    def test_no_index_str_column_in_data(self, meas):
+        "Check that plot function works when there is no index column in the data."
+        meas.agg_sensors(agg_map={
+            'irr_poa_pyran': 'mean', 'temp_amb': 'mean', 'wind': 'mean'
+        })
+        assert 'index' not in meas.data.columns
+        plot = meas.scatter_hv()
+        assert isinstance(plot, hv.element.chart.Scatter)
 
 
 if __name__ == '__main__':

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2055,6 +2055,18 @@ class TestScatterHv():
         plot = meas.scatter_hv()
         assert isinstance(plot, hv.element.chart.Scatter)
 
+    def test_curve_timeseries(self, meas):
+        """Test that the curve_timeseries method works. Shouldn't require `data` index
+        to have a specific name.
+        """
+        meas.agg_sensors(agg_map={
+            'irr_poa_pyran': 'mean', 'temp_amb': 'mean', 'wind': 'mean'
+        })
+        assert 'index' not in meas.data.columns
+        assert meas.data.index.name is None
+        plot = meas.scatter_hv(timeseries=True)
+        assert isinstance(plot, hv.core.layout.Layout)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2086,5 +2086,25 @@ class TestScatterFilters():
         assert isinstance(overlay, hv.core.overlay.Overlay)
 
 
+class TestTimeseriesFilters():
+    """Test the timeseries_filters method of the CapData class."""
+    def test_returns_overlay(self, meas):
+        """
+        Test that the timeseries_filters method of the CapData class returns a
+        holoviews overlay object.
+        """
+        meas.agg_sensors(agg_map={
+            'irr_poa_pyran': 'mean', 'temp_amb': 'mean', 'wind': 'mean'
+        })
+        meas.filter_irr(200, 900)
+        meas.filter_irr(400, 800)
+        # meas.data.index.name = 'Timestamp'
+        # meas.data_filtered.index.name = 'Timestamp'
+        overlay = meas.timeseries_filters()
+        assert 'index' not in meas.data.columns
+        assert 'index' not in meas.data_filtered.columns
+        assert isinstance(overlay, hv.core.overlay.Overlay)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Will finish addressing #59 except for the `plot` method, which will be addressed by replacing that method with a new plotting dashboard.

Will remove any other use of the string index column.