### PR TITLE
Fixes bug with index of first timeseries filter scatter plot

### DIFF
--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1928,7 +1928,7 @@ class CapData(object):
         )
         plots.append(plt_no_filtering)
 
-        d1 = data.loc[self.removed[0]['index'], 'power']
+        d1 = data.loc[self.removed[0]['index'], ['power', 'Timestamp']]
         plt_first_filter = hv.Scatter(
             d1, ['Timestamp'], ['power'], label=self.removed[0]['name']
         )

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2367,8 +2367,6 @@ class TestTimeseriesFilters():
         })
         meas.filter_irr(200, 900)
         meas.filter_irr(400, 800)
-        # meas.data.index.name = 'Timestamp'
-        # meas.data_filtered.index.name = 'Timestamp'
         overlay = meas.timeseries_filters()
         assert 'index' not in meas.data.columns
         assert 'index' not in meas.data_filtered.columns


### PR DESCRIPTION
The `timeseries_fitler` method creates a timeseries overlay of the power with a different scatter plot in the overlay for each filter. The first scatter plot in the overlay was not including the Timestamp column (resulting in an object for the x-axis), which could not be overalayed with the other plots.