### PR TITLE
Fix for 112 - Dashboard doesn't plot more than 25 curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Unreleased]
+### Fixed
+- Issue 112 - plotting tool would plot only last curve for plots with more than 25 curves.
 
 [0.13.0]: https://github.com/pvcaptest/pvcaptest/compare/v0.12.1...v0.13.0
 ## [0.13.0] - 2024-05-05

--- a/src/captest/plotting.py
+++ b/src/captest/plotting.py
@@ -175,30 +175,27 @@ def plot_tag(data, tag, width=1500, height=250):
         curves = {}
         for column in tag:
             try:
-                print(column)
                 curves[column] = hv.Curve(data[column])
             except KeyError:
-                print(f'Column {column} not found in data.')
                 continue
         plot = hv.NdOverlay(curves)
-    return curves
-    # elif len(tag) == 0:
-    #     plot = hv.Curve(pd.DataFrame(
-    #         {'no_data': [np.NaN] * data.shape[0]},
-    #         index=data.index
-    #     ))
-    # plot.opts(
-    #     opts.Curve(
-    #         line_width=1,
-    #         width=width,
-    #         height=height,
-    #         muted_alpha=0,
-    #         tools=['hover'],
-    #         yformatter=NumeralTickFormatter(format='0,0'),
-    #     ),
-    #     opts.NdOverlay(width=width, height=height, legend_position='right')
-    # )
-    # return plot
+    elif len(tag) == 0:
+        plot = hv.Curve(pd.DataFrame(
+            {'no_data': [np.NaN] * data.shape[0]},
+            index=data.index
+        ))
+    plot.opts(
+        opts.Curve(
+            line_width=1,
+            width=width,
+            height=height,
+            muted_alpha=0,
+            tools=['hover'],
+            yformatter=NumeralTickFormatter(format='0,0'),
+        ),
+        opts.NdOverlay(width=width, height=height, legend_position='right')
+    )
+    return plot
 
 
 def group_tag_overlay(group_tags, column_tags):

--- a/src/captest/plotting.py
+++ b/src/captest/plotting.py
@@ -193,7 +193,9 @@ def plot_tag(data, tag, width=1500, height=250):
             tools=['hover'],
             yformatter=NumeralTickFormatter(format='0,0'),
         ),
-        opts.NdOverlay(width=width, height=height, legend_position='right')
+        opts.NdOverlay(
+            width=width, height=height, legend_position='right', batched=False
+        )
     )
     return plot
 

--- a/src/captest/plotting.py
+++ b/src/captest/plotting.py
@@ -175,27 +175,30 @@ def plot_tag(data, tag, width=1500, height=250):
         curves = {}
         for column in tag:
             try:
+                print(column)
                 curves[column] = hv.Curve(data[column])
             except KeyError:
+                print(f'Column {column} not found in data.')
                 continue
         plot = hv.NdOverlay(curves)
-    elif len(tag) == 0:
-        plot = hv.Curve(pd.DataFrame(
-            {'no_data': [np.NaN] * data.shape[0]},
-            index=data.index
-        ))
-    plot.opts(
-        opts.Curve(
-            line_width=1,
-            width=width,
-            height=height,
-            muted_alpha=0,
-            tools=['hover'],
-            yformatter=NumeralTickFormatter(format='0,0'),
-        ),
-        opts.NdOverlay(width=width, height=height, legend_position='right')
-    )
-    return plot
+    return curves
+    # elif len(tag) == 0:
+    #     plot = hv.Curve(pd.DataFrame(
+    #         {'no_data': [np.NaN] * data.shape[0]},
+    #         index=data.index
+    #     ))
+    # plot.opts(
+    #     opts.Curve(
+    #         line_width=1,
+    #         width=width,
+    #         height=height,
+    #         muted_alpha=0,
+    #         tools=['hover'],
+    #         yformatter=NumeralTickFormatter(format='0,0'),
+    #     ),
+    #     opts.NdOverlay(width=width, height=height, legend_position='right')
+    # )
+    # return plot
 
 
 def group_tag_overlay(group_tags, column_tags):


### PR DESCRIPTION
The default for the `batched` option of Holoviews `NdOverlay` is True, which is causing plots with more than 25 curves to show only the last one.

This changes `batched` to `False` to fix this issue.

Addresses issue #112 