### PR TITLE
Warns but loads files that are empty

### DIFF
--- a/src/captest/io.py
+++ b/src/captest/io.py
@@ -210,7 +210,10 @@ def file_reader(path, **kwargs):
             continue
         else:
             break
-    data_file.dropna(how="all", axis=0, inplace=True)
+    if data_file.isna().all().all():
+        warnings.warn("There is no data in the file {}".format(path))
+    else:
+        data_file.dropna(how="all", axis=0, inplace=True)
     if data_file.index.equals(pd.Index(np.arange(len(data_file.index)))):
         kwargs['index_col'] = 1
         data_file = pd.read_csv(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -180,6 +180,22 @@ class TestFileReader:
         assert loaded_data.columns[0] == "met1_poa1"
         assert isinstance(loaded_data.index, pd.DatetimeIndex)
 
+    def test_empty_file(self, tmp_path):
+        """
+        Test loading a csv with ok indices but no data.
+        """
+        csv_path = tmp_path / "no_data.csv"
+        pd.DataFrame(
+            {
+                "met1_poa1": np.nan * 20,
+                "met1_poa2": np.nan * 20,
+            },
+            index=pd.date_range(start="8/1/22", periods=20, freq="1min"),
+        ).to_csv(csv_path)
+        loaded_data = io.file_reader(csv_path)
+        print(loaded_data)
+        assert loaded_data.isna().all().all()
+
     def test_double_headers_with_blank(self, tmp_path):
         """Two header rows followed by a blank line."""
         test_csv = StringIO()


### PR DESCRIPTION
Previous behavior would drop all data which caused error in next line

```python
if data_file.index.equals(pd.Index(np.arange(len(data_file.index)))):
````
because

```python
data_file.dropna(how="all", axis=0, inplace=True)
```
would drop all the data.

New behavior is to warn user when an empty file is loaded and not drop any of the empty rows. The `drop_duplicates` argument of the `load_data` function should still drop these empty rows if desired.