### PR TITLE
fix: guard pvlib import in calcparams with importlib.util.find_spec

### DIFF
--- a/src/captest/calcparams.py
+++ b/src/captest/calcparams.py
@@ -6,11 +6,21 @@ Sandia module temperature model.
 """
 
 import copy
+import importlib
 import warnings
 
 import numpy as np
-import pvlib
-from pvlib.location import Location
+
+pvlib_spec = importlib.util.find_spec("pvlib")
+if pvlib_spec is not None:
+    import pvlib
+    from pvlib.location import Location
+else:
+    warnings.warn(
+        "Functions that calculate solar position or spectral correction "
+        "(apparent_zenith, absolute_airmass, precipitable_water_gueymard, "
+        "spectral_factor_firstsolar) will not work without the pvlib package."
+    )
 
 # Global record surface-pressure extremes (mBar) used by
 # :func:`absolute_airmass` to sanity-check pressure inputs. Low: ~870 mBar


### PR DESCRIPTION
## Summary

`pvlib` is an optional dependency but was imported unconditionally at module level in `calcparams.py`. This caused a `ModuleNotFoundError` when `captest` was imported without `pvlib` installed, breaking the smoke test on the minimal PyPI install (the test that validates the built wheel/sdist before publishing a release).

## Changes

- `src/captest/calcparams.py`: Added `import importlib` and wrapped `import pvlib` / `from pvlib.location import Location` in an `importlib.util.find_spec("pvlib")` guard, matching the pattern already used in `capdata.py` (lines 74–83). When `pvlib` is absent, a `UserWarning` is emitted listing the affected functions instead of raising at import time.

## Testing

- Full test suite passes (`just test`: 576 passed).
- Pre-commit hooks (ruff check + ruff format) passed on commit.

## Notes

The functions that actually call `pvlib` at runtime (`apparent_zenith`, `apparent_zenith_pvsyst`, `absolute_airmass`, `precipitable_water_gueymard`, `spectral_factor_firstsolar`) will still fail with a `NameError` if called without `pvlib` installed — this is consistent with the existing behavior for the analogous pvlib-backed functions in `capdata.py`.

---
[Warp conversation](https://app.warp.dev/conversation/d03dce46-a70e-430a-a2e0-9d368fcf4c14)