### PR TITLE
Refine TEST_SETUPS: add description field, rename bifi_power_tc presets, add meas_tbom tests, update docs

### DIFF
--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -80,3 +80,52 @@ Standalone functions used alongside :py:class:`~captest.captest.CapTest`.
    :toctree: generated/
 
    captest.load_config
+   captest.validate_test_setup
+   captest.resolve_test_setup
+   captest.perc_wrap
+
+.. _test-setups:
+
+Predefined Test Setups
+----------------------
+
+:data:`~captest.captest.TEST_SETUPS` is a dict that maps preset names to
+fully-validated test-setup entries. Each entry bundles a regression formula,
+column mappings for measured and modeled data, default reporting conditions,
+and a scatter-plot callable. Pass the preset name as ``test_setup`` when
+constructing a :py:class:`~captest.captest.CapTest`.
+
+.. data:: captest.TEST_SETUPS
+
+   Registry of predefined capacity-test presets. Keys are preset-name strings;
+   values are dicts with required keys ``description``, ``reg_cols_meas``,
+   ``reg_cols_sim``, ``reg_fml``, ``scatter_plots``, and ``rep_conditions``.
+
+The built-in presets are:
+
+``e2848_default``
+   Standard ASTM E2848 regression of AC power against front-side POA irradiance,
+   ambient temperature, and wind speed using the full four-term formula. Default
+   setup for monofacial capacity tests.
+
+``bifi_e2848_etotal``
+   Standard ASTM E2848 regression form with total effective irradiance replacing
+   front-side POA as the independent variable.
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
+   modified bifacial approach.
+
+``bifi_power_tc_meas_tbom``
+   Temperature-corrected power regressed against front and rear irradiance.
+   Back-of-module temperature is taken directly from field measurements and used
+   to calculate cell temperature via the Sandia PV Array Performance Model.
+
+``bifi_power_tc_calc_tbom``
+   Temperature-corrected power regressed against front and rear irradiance.
+   Back-of-module and cell temperature are both calculated from POA irradiance,
+   ambient temperature, and wind speed via the Sandia model; no dedicated BOM
+   sensor is required.
+
+``e2848_spec_corrected_poa``
+   Standard ASTM E2848 regression with a First Solar spectral correction applied
+   to front-side POA before fitting. Requires relative humidity and station
+   pressure on the measured side and precipitable water from the PVsyst output.

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -80,9 +80,9 @@ Standalone functions used alongside :py:class:`~captest.captest.CapTest`.
    :toctree: generated/
 
    captest.load_config
-   captest.validate_test_setup
-   captest.resolve_test_setup
-   captest.perc_wrap
+   captest.captest.validate_test_setup
+   captest.captest.resolve_test_setup
+   captest.captest.perc_wrap
 
 .. _test-setups:
 
@@ -127,5 +127,5 @@ The built-in presets are:
 
 ``e2848_spec_corrected_poa``
    Standard ASTM E2848 regression with a First Solar spectral correction applied
-   to front-side POA before fitting. Requires relative humidity and station
+   to front-side POA before fitting. Requires relative humidity and atmospheric
    pressure on the measured side and precipitable water from the PVsyst output.

--- a/docs/source/api_reference/classes.rst
+++ b/docs/source/api_reference/classes.rst
@@ -9,8 +9,8 @@ configuring test parameters, and loading data.
 .. autosummary::
    :toctree: generated/
 
-   capdata.CapData
    captest.CapTest
+   capdata.CapData
    io.DataLoader
    columngroups.ColumnGroups
    prtest.PrResults

--- a/docs/source/api_reference/classes.rst
+++ b/docs/source/api_reference/classes.rst
@@ -9,7 +9,7 @@ configuring test parameters, and loading data.
 .. autosummary::
    :toctree: generated/
 
-   captest.CapTest
+   CapTest
    capdata.CapData
    io.DataLoader
    columngroups.ColumnGroups

--- a/docs/source/api_reference/generated/captest.captest.perc_wrap.rst
+++ b/docs/source/api_reference/generated/captest.captest.perc_wrap.rst
@@ -1,0 +1,6 @@
+﻿captest.captest.perc\_wrap
+==========================
+
+.. currentmodule:: captest.captest
+
+.. autofunction:: perc_wrap

--- a/docs/source/api_reference/generated/captest.captest.resolve_test_setup.rst
+++ b/docs/source/api_reference/generated/captest.captest.resolve_test_setup.rst
@@ -1,0 +1,6 @@
+﻿captest.captest.resolve\_test\_setup
+====================================
+
+.. currentmodule:: captest.captest
+
+.. autofunction:: resolve_test_setup

--- a/docs/source/api_reference/generated/captest.captest.validate_test_setup.rst
+++ b/docs/source/api_reference/generated/captest.captest.validate_test_setup.rst
@@ -1,0 +1,6 @@
+﻿captest.captest.validate\_test\_setup
+=====================================
+
+.. currentmodule:: captest.captest
+
+.. autofunction:: validate_test_setup

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -98,10 +98,18 @@ The built-in options are:
     where :math:`\varphi` is the bifaciality factor. This is useful for the
     NREL modified bifacial approach described in :ref:`bifacial`.
 
-``bifi_power_tc``
+``bifi_power_tc_meas_tbom``
     Uses temperature-corrected power as the dependent variable and regresses it
-    against front and rear irradiance. This setup creates a two-panel scatter
-    plot so the front- and rear-side relationships can be reviewed separately.
+    against front and rear irradiance. Back-of-module temperature is taken
+    directly from field measurements and used to calculate cell temperature
+    via the Sandia PV Array Performance Model.
+
+``bifi_power_tc_calc_tbom``
+    Same regression as ``bifi_power_tc_meas_tbom`` but back-of-module
+    temperature is calculated from POA irradiance, ambient temperature, and
+    wind speed rather than measured directly. Both setups create a two-panel
+    scatter plot so the front- and rear-side relationships can be reviewed
+    separately.
 
 ``e2848_spec_corrected_poa``
     Uses the standard ASTM E2848 regression form, but applies a First Solar
@@ -124,7 +132,10 @@ The built-in options are:
 
     - ``irr_poa`` — front-side plane-of-array irradiance (all setups)
     - ``irr_rpoa`` — rear-side plane-of-array irradiance
-      (``bifi_e2848_etotal``, ``bifi_power_tc``)
+      (``bifi_e2848_etotal``, ``bifi_power_tc_meas_tbom``,
+      ``bifi_power_tc_calc_tbom``)
+    - ``temp_bom`` — back-of-module temperature
+      (``bifi_power_tc_meas_tbom`` only)
     - ``real_pwr_mtr`` — AC power meter (all setups)
     - ``temp_amb`` — ambient temperature (all setups)
     - ``wind_speed`` — wind speed (all setups)
@@ -245,7 +256,7 @@ setup and the temperature-corrected power setup.
       bifaciality: 0.15
 
     captest_bifi_power_tc:
-      test_setup: bifi_power_tc
+      test_setup: bifi_power_tc_calc_tbom
       meas_path: ./data/measured/
       sim_path: ./data/pvsyst.csv
       ac_nameplate: 6_000_000

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -180,6 +180,11 @@ def scatter_bifi_power_tc(cd, **kwargs):
 
 TEST_SETUPS = {
     "e2848_default": {
+        "description": (
+            "Standard ASTM E2848 regression of AC power against front-side POA irradiance, "
+            "ambient temperature, and wind speed using the full four-term formula. "
+            "This is the default setup for monofacial capacity tests."
+        ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
             "poa": ("irr_poa", "mean"),
@@ -206,6 +211,11 @@ TEST_SETUPS = {
         },
     },
     "bifi_e2848_etotal": {
+        "description": (
+            "Standard ASTM E2848 regression form with total effective irradiance replacing "
+            "front-side POA as the independent variable. Total irradiance is calculated as "
+            "E_Total = E_POA + E_Rear * bifaciality, following the NREL modified bifacial approach."
+        ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
             "poa": (
@@ -246,7 +256,62 @@ TEST_SETUPS = {
             },
         },
     },
-    "bifi_power_tc": {
+    "bifi_power_tc_meas_tbom": {
+        "description": (
+            "The regression equation is temperature corrected power regressed against "
+            "front POA and rear POA. The back of module temperature is from field"
+            "measurements and the cell temperature is calculated using the Sandia PV Array "
+            "Performance Model from the POA irradiance and measured BOM temperature."
+            "Note that the PVsyst temperature correction uses the 'TArray' output variable."
+        ),
+        "reg_cols_meas": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": ("real_pwr_mtr", "sum"),
+                    "cell_temp": (
+                        cell_temp,
+                        {
+                            "poa": ("irr_poa", "mean"),
+                            "bom": ("temp_bom", "mean"),
+                        },
+                    ),
+                },
+            ),
+            "poa": ("irr_poa", "mean"),
+            "rpoa": ("irr_rpoa", "mean"),
+        },
+        "reg_cols_sim": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": "E_Grid",
+                    "cell_temp": "TArray",
+                },
+            ),
+            "poa": "GlobInc",
+            "rpoa": (rpoa_pvsyst, {"globbak": "GlobBak", "backshd": "BackShd"}),
+        },
+        "reg_fml": "power ~ poa + rpoa",
+        "scatter_plots": scatter_bifi_power_tc,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "front_poa": "poa",
+            "func": {
+                "poa": perc_wrap(60),
+                "rpoa": "mean",
+            },
+        },
+    },
+    "bifi_power_tc_calc_tbom": {
+        "description": (
+            "The regression equation is temperature corrected power regressed against "
+            "front POA and rear POA. The back of module and cell temperature are "
+            "calculated using the Sandia PV Array Performance Model from the POA "
+            "irradiance, ambient temperature, and wind speed. Note that the PVsyst "
+            "temperature correction uses the 'TArray' output variable."
+        ),
         "reg_cols_meas": {
             "power": (
                 power_temp_correct,
@@ -295,6 +360,11 @@ TEST_SETUPS = {
         },
     },
     "e2848_spec_corrected_poa": {
+        "description": (
+            "Standard ASTM E2848 regression with a First Solar spectral correction applied to "
+            "front-side POA irradiance before fitting. Requires relative humidity and atmospheric"
+            "pressure on the measured side and precipitable water from the PVsyst output."
+        ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
             "poa": (
@@ -373,7 +443,14 @@ TEST_SETUPS = {
 }
 
 _TEST_SETUP_REQUIRED_KEYS = frozenset(
-    {"reg_cols_meas", "reg_cols_sim", "reg_fml", "scatter_plots", "rep_conditions"}
+    {
+        "description",
+        "reg_cols_meas",
+        "reg_cols_sim",
+        "reg_fml",
+        "scatter_plots",
+        "rep_conditions",
+    }
 )
 
 

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -555,6 +555,7 @@ def resolve_test_setup(name, overrides=None):
                 f"missing: {sorted(missing)}"
             )
         base = {
+            "description": overrides.get("description", ""),
             "reg_cols_meas": copy.deepcopy(overrides["reg_cols_meas"]),
             "reg_cols_sim": copy.deepcopy(overrides["reg_cols_sim"]),
             "reg_fml": overrides["reg_fml"],

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -362,7 +362,7 @@ TEST_SETUPS = {
     "e2848_spec_corrected_poa": {
         "description": (
             "Standard ASTM E2848 regression with a First Solar spectral correction applied to "
-            "front-side POA irradiance before fitting. Requires relative humidity and atmospheric"
+            "front-side POA irradiance before fitting. Requires relative humidity and atmospheric "
             "pressure on the measured side and precipitable water from the PVsyst output."
         ),
         "reg_cols_meas": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,8 +195,9 @@ def meas_cd_default():
     Column groups are renamed so the shipped ``e2848_default`` preset matches
     without extra overrides: ``real_pwr_mtr``, ``irr_poa``, ``temp_amb``,
     ``wind_speed``. A synthetic ``irr_rpoa`` group is added (scaled fraction
-    of the POA sensors) so the ``bifi_e2848_etotal`` and ``bifi_power_tc``
-    presets also resolve against this fixture without additional wiring.
+    of the POA sensors) so the ``bifi_e2848_etotal`` and
+    ``bifi_power_tc_calc_tbom`` presets also resolve against this fixture
+    without additional wiring.
     """
     cd = pvc.CapData("meas")
     df = pd.read_csv(
@@ -230,7 +231,8 @@ def sim_cd_default():
 
     Synthetic ``GlobBak`` and ``BackShd`` columns are added so presets that
     rely on ``rpoa_pvsyst(globbak=..., backshd=...)`` (``bifi_e2848_etotal``,
-    ``bifi_power_tc``) resolve without needing a new PVsyst export.
+    ``bifi_power_tc_meas_tbom``, ``bifi_power_tc_calc_tbom``) resolve without
+    needing a new PVsyst export.
     """
     cd = load_pvsyst(path="./tests/data/pvsyst_example_HourlyRes_2.CSV")
     cd.data["GlobBak"] = cd.data["GlobInc"] * 0.15
@@ -266,9 +268,9 @@ def ct_etotal(meas_cd_default, sim_cd_default):
 
 @pytest.fixture
 def ct_bifi_power_tc(meas_cd_default, sim_cd_default):
-    """CapTest for the bifi_power_tc preset with setup() run."""
+    """CapTest for the bifi_power_tc_calc_tbom preset with setup() run."""
     return CapTest.from_params(
-        test_setup="bifi_power_tc",
+        test_setup="bifi_power_tc_calc_tbom",
         meas=meas_cd_default,
         sim=sim_cd_default,
         ac_nameplate=6_000_000,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,6 +282,43 @@ def ct_bifi_power_tc(meas_cd_default, sim_cd_default):
 
 
 @pytest.fixture
+def meas_cd_bom_temp(meas_cd_default):
+    """Measured CapData extended with a synthetic back-of-module temperature group.
+
+    Needed to exercise the ``bifi_power_tc_meas_tbom`` preset, whose meas
+    tree requires a ``temp_bom`` column group. BOM temperature is synthesized
+    as ambient temperature plus a solar-heating offset (``poa * 0.025``),
+    giving roughly 15-25 °C above ambient at 1000 W/m², which is in a
+    realistic range for a bifacial module in field conditions.
+    """
+    cd = meas_cd_default
+    df = cd.data
+    df["met1_bom_temp"] = df["met1_amb_temp"] + df["met1_poa_pyranometer"] * 0.025
+    df["met2_bom_temp"] = df["met2_amb_temp"] + df["met2_poa_pyranometer"] * 0.025
+    cd.data = df
+    cd.data_filtered = cd.data.copy(deep=True)
+    groups = dict(cd.column_groups)
+    groups["temp_bom"] = ["met1_bom_temp", "met2_bom_temp"]
+    cd.column_groups = cg.ColumnGroups(groups)
+    return cd
+
+
+@pytest.fixture
+def ct_bifi_power_tc_meas_tbom(meas_cd_bom_temp, sim_cd_default):
+    """CapTest for the bifi_power_tc_meas_tbom preset with setup() run."""
+    return CapTest.from_params(
+        test_setup="bifi_power_tc_meas_tbom",
+        meas=meas_cd_bom_temp,
+        sim=sim_cd_default,
+        ac_nameplate=6_000_000,
+        bifaciality=0.15,
+        power_temp_coeff=-0.32,
+        base_temp=25,
+        test_tolerance="- 4",
+    )
+
+
+@pytest.fixture
 def meas_cd_spec_corrected(meas_cd_default):
     """Measured CapData extended with humidity, pressure, and a site dict.
 

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -29,7 +29,9 @@ from captest.calcparams import (
 # whose required column_groups and site attributes are satisfied by the
 # default fixtures; otherwise add a dedicated fixture and a targeted test.
 _DEFAULT_FIXTURE_PRESETS = [
-    p for p in ct.TEST_SETUPS.keys() if p != "e2848_spec_corrected_poa"
+    p
+    for p in ct.TEST_SETUPS.keys()
+    if p not in {"e2848_spec_corrected_poa", "bifi_power_tc_meas_tbom"}
 ]
 
 
@@ -66,8 +68,8 @@ class TestTestSetupsRegistry:
         assert isinstance(meas_poa, tuple)
         assert meas_poa[0] is e_total
 
-    def test_bifi_power_tc_uses_power_temp_correct(self):
-        entry = ct.TEST_SETUPS["bifi_power_tc"]
+    def test_bifi_power_tc_calc_tbom_uses_power_temp_correct(self):
+        entry = ct.TEST_SETUPS["bifi_power_tc_calc_tbom"]
         meas_power = entry["reg_cols_meas"]["power"]
         assert isinstance(meas_power, tuple)
         assert meas_power[0] is power_temp_correct
@@ -928,7 +930,7 @@ class TestDownstreamPropagation:
         self, meas_cd_default, sim_cd_default
     ):
         capt = CapTest.from_params(
-            test_setup="bifi_power_tc",
+            test_setup="bifi_power_tc_calc_tbom",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.15,
@@ -949,7 +951,7 @@ class TestDownstreamPropagation:
         self, meas_cd_default, sim_cd_default
     ):
         capt = CapTest.from_params(
-            test_setup="bifi_power_tc",
+            test_setup="bifi_power_tc_calc_tbom",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.15,

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -18,6 +18,7 @@ import yaml
 from captest import CapTest, captest as ct
 from captest.calcparams import (
     apparent_zenith_pvsyst,
+    cell_temp,
     e_total,
     poa_spec_corrected,
     power_temp_correct,
@@ -73,6 +74,19 @@ class TestTestSetupsRegistry:
         meas_power = entry["reg_cols_meas"]["power"]
         assert isinstance(meas_power, tuple)
         assert meas_power[0] is power_temp_correct
+
+    def test_bifi_power_tc_meas_tbom_uses_measured_bom(self):
+        """meas-side BOM temp is a direct column-group ref, not a calc tuple."""
+        entry = ct.TEST_SETUPS["bifi_power_tc_meas_tbom"]
+        meas_power = entry["reg_cols_meas"]["power"]
+        assert isinstance(meas_power, tuple)
+        assert meas_power[0] is power_temp_correct
+        cell_temp_node = meas_power[1]["cell_temp"]
+        assert isinstance(cell_temp_node, tuple)
+        assert cell_temp_node[0] is cell_temp
+        # BOM temperature comes from field measurements (direct column-group ref).
+        bom_spec = cell_temp_node[1]["bom"]
+        assert bom_spec == ("temp_bom", "mean")
 
     def test_e2848_spec_corrected_poa_meas_tree_uses_spectral_factor(self):
         """The meas-side poa tree ends with spectral_factor_firstsolar."""
@@ -962,6 +976,23 @@ class TestDownstreamPropagation:
         expected = first["E_Grid"] / (1 + (-0.32 / 100) * (first["TArray"] - 35))
         assert first["power_temp_correct"] == pytest.approx(expected)
 
+    def test_power_temp_coeff_flows_into_power_temp_correct_meas_tbom(
+        self, meas_cd_bom_temp, sim_cd_default
+    ):
+        """For meas_tbom preset, power_temp_coeff flows through to the sim side."""
+        capt = CapTest.from_params(
+            test_setup="bifi_power_tc_meas_tbom",
+            meas=meas_cd_bom_temp,
+            sim=sim_cd_default,
+            bifaciality=0.15,
+            power_temp_coeff=-0.5,
+            base_temp=25,
+        )
+        sim_df = capt.sim.data
+        first = sim_df.loc[sim_df["E_Grid"] > 0].iloc[0]
+        expected = first["E_Grid"] / (1 + (-0.5 / 100) * (first["TArray"] - 25))
+        assert first["power_temp_correct"] == pytest.approx(expected)
+
 
 class TestCapTestSpectralCorrection:
     """End-to-end behavior of the e2848_spec_corrected_poa preset."""
@@ -1774,4 +1805,25 @@ class TestIntegration:
 
         self._run_canonical_sequence(ct_bifi_power_tc)
         cap_ratio = ct_bifi_power_tc.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+
+    def test_end_to_end_bifi_power_tc_meas_tbom(self, ct_bifi_power_tc_meas_tbom):
+        """bifi_power_tc_meas_tbom preset runs end-to-end.
+
+        Verifies that the ``power_temp_correct`` calculated column was added to
+        both CapData instances during ``setup()`` using the measured BOM
+        temperature on the meas side, and that the scatter layout has two
+        panels. Cap ratio is checked for plausibility.
+        """
+        assert "power_temp_correct" in ct_bifi_power_tc_meas_tbom.meas.data.columns
+        assert "power_temp_correct" in ct_bifi_power_tc_meas_tbom.sim.data.columns
+
+        layout = ct_bifi_power_tc_meas_tbom.scatter_plots()
+        import holoviews as hv
+
+        assert isinstance(layout, hv.Layout)
+        assert len(layout) == 2
+
+        self._run_canonical_sequence(ct_bifi_power_tc_meas_tbom)
+        cap_ratio = ct_bifi_power_tc_meas_tbom.captest_results(print_res=False)
         assert 0.8 < cap_ratio < 1.2

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -848,6 +848,7 @@ class TestSetup:
         resolved = ct_default._resolved_setup
         assert resolved is not None
         assert set(resolved.keys()) == {
+            "description",
             "reg_cols_meas",
             "reg_cols_sim",
             "reg_fml",


### PR DESCRIPTION
## Summary

Adds a `description` field to every `TEST_SETUPS` preset, renames the old `bifi_power_tc` preset into two explicit variants (`bifi_power_tc_meas_tbom` / `bifi_power_tc_calc_tbom`), adds full test coverage for the new `bifi_power_tc_meas_tbom` preset, and extends the API reference documentation with a Predefined Test Setups section.

## Changes

- **`src/captest/captest.py`** — Add `"description"` to `_TEST_SETUP_REQUIRED_KEYS`; add description strings to `e2848_default`, `bifi_e2848_etotal`, and `e2848_spec_corrected_poa` (the two `bifi_power_tc_*` presets already had them); add `"description"` default in the `resolve_test_setup` custom path; fix concatenation bug in the `e2848_spec_corrected_poa` description (missing space between "atmospheric" and "pressure"); update `scatter_plots` docstring to reference both new preset names.
- **`tests/test_captest.py`** — Update `_DEFAULT_FIXTURE_PRESETS` to also exclude `bifi_power_tc_meas_tbom`; rename `test_bifi_power_tc_uses_power_temp_correct` and two `TestDownstreamPropagation` tests to use `bifi_power_tc_calc_tbom`; update `test_setup_assigns_resolved_setup` to expect `"description"` in the resolved key set; add `test_bifi_power_tc_meas_tbom_uses_measured_bom`, `test_power_temp_coeff_flows_into_power_temp_correct_meas_tbom`, and `test_end_to_end_bifi_power_tc_meas_tbom`.
- **`tests/conftest.py`** — Update `ct_bifi_power_tc` fixture and related docstrings to use `bifi_power_tc_calc_tbom`; add `meas_cd_bom_temp` fixture (extends default with a synthetic `temp_bom` column group) and `ct_bifi_power_tc_meas_tbom` fixture.
- **`docs/user_guide/captest.rst`** — Replace the single `bifi_power_tc` preset entry with entries for both new names; update the `irr_rpoa` column-group note; add a `temp_bom` note; update the YAML example.
- **`docs/source/api_reference/captest.rst`** — Add `validate_test_setup`, `resolve_test_setup`, `perc_wrap` to Module-level Functions (using `captest.captest.*` qualified names); add a Predefined Test Setups section with a `.. data::` directive for `TEST_SETUPS` and a definition list of all five built-in presets.
- **`docs/source/api_reference/classes.rst`** — Move `captest.CapTest` to first position in the autosummary to resolve a stub-ordering issue that caused CapTest to be absent from the rendered Classes section.

## Testing

582 tests pass (`just test`). Lint clean (`just lint`). New tests exercise: the `description` key in validation and resolved-setup assertions; the `bifi_power_tc_meas_tbom` preset structure, downstream propagation, and end-to-end cap-ratio calculation.

## Notes

The `bifi_power_tc` preset name no longer exists — it has been replaced by two explicit variants. Any downstream code referencing `test_setup="bifi_power_tc"` will need to be updated to one of the two new names.

---
Oz conversation: https://app.warp.dev/conversation/81e9be67-c20c-42fc-a15d-0497d60af979
Plan: https://app.warp.dev/drive/notebook/oB11qe7oAvCUQtkyAzX0Zf