### PR TITLE
Add calc-params CapTest parameters and explicit rear-shade bifacial presets

### DIFF
--- a/.agents/skills/add-test-setup/SKILL.md
+++ b/.agents/skills/add-test-setup/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: add-test-setup
+description: Use when adding a new preset/entry to the captest TEST_SETUPS registry in src/captest/captest.py — turning a brief description of a capacity-test regression (monofacial, bifacial e_total, spectral-corrected, temperature-corrected) into a complete, validated test-setup dict plus its test coverage. Triggers include "add a test setup", "new TEST_SETUPS preset", "add an e2848/bifacial/spectral preset", or a one-line description of a regression form to register.
+---
+
+# Adding a captest TEST_SETUPS preset
+
+`TEST_SETUPS` (in `src/captest/captest.py`) maps a preset name to a dict that
+fully specifies a capacity-test regression: how measured and simulated columns
+map to regression variables, the regression formula, the scatter plot, and the
+reporting conditions. This skill turns a **brief description** into a complete,
+validated entry and a review summary, then (after approval) full test coverage.
+
+**Do not skip the approval gates.** Two things get explicit user sign-off before
+you build downstream: the **regression equation** and the **assembled dict
+summary**. Build nothing past a gate until the user approves it.
+
+## Inputs you expect
+
+- **A brief description** of the test type (required). You will expand it.
+- **A regression equation** (optional). If absent, you propose one and get
+  approval before building the dict.
+- Convention: `reg_cols_meas` leaves are measured **column-group** refs
+  `(group, agg)`; `reg_cols_sim` leaves are PVsyst **column-name** strings.
+
+## Workflow
+
+```
+brief description
+  → 1. expand description to match existing detail level
+  → 2. regression equation: use given, OR propose → APPROVAL GATE
+  → 3. map each variable to reg_cols_meas / reg_cols_sim (building-block catalog)
+  → 4. choose scatter callable
+  → 5. rep_conditions
+  → 6. assemble dict → validate + resolve + end-to-end probe → just fmt
+  → 7. review summary → APPROVAL GATE
+  → 8. (after approval) fixtures + exclusion + 4-layer test coverage
+```
+
+### Step 1 — Expand the description
+
+Match the detail level of the existing `description` fields. A good description
+states, in prose: the regression form (which ASTM E2848 variant), what each
+correction does and **which side it lives on** (modeled vs measured), the
+measured→simulated variable mapping in words, the governing equation, and a
+cross-reference to any sibling variant. Read 2–3 existing entries first and mirror
+their voice and length (~4–10 lines).
+
+### Step 2 — Regression equation (APPROVAL GATE)
+
+If the user gave an equation, use it verbatim. Otherwise propose one and **ask for
+approval before continuing.** The standard four-term E2848 form is:
+
+```
+power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1
+```
+
+- `lhs` must be `power` (a project naming convention enforced by tests).
+- For bifacial e_total presets, `poa` *is* the total-irradiance column — the
+  formula text is unchanged; the meaning of `poa` changes via the calc-tree.
+- `power ~ poa + rpoa` is the two-term bifacial temp-corrected form.
+
+**Formula syntax (Patsy).** Regression formulas use the Patsy formula
+mini-language (the same one statsmodels consumes via `smf.ols`):
+https://patsy.readthedocs.io/en/latest/formulas.html. The string must be a valid
+Patsy expression — e.g. `I(...)` wraps arithmetic so `*` means multiply rather
+than Patsy's interaction operator, and `- 1` drops the intercept. A
+user-supplied formula must parse as valid Patsy.
+
+**Terms must match the reg_cols keys.** Every variable (term) in the formula —
+lhs and rhs — must match a **top-level key** of both `reg_cols_meas` and
+`reg_cols_sim`. `CapData.process_regression_columns` builds, from each reg_cols
+dict, a mapping from regression term (key) → the column name that term resolves
+to in `CapData.data`; a term with no matching key has no column to fit against.
+`validate_test_setup` enforces this: the formula's lhs+rhs must be a subset of
+both reg_cols dicts' keys.
+
+### Step 3 — Map variables to columns (building-block catalog)
+
+Each `reg_cols_*` value is **either** a direct ref **or** a *calc-tuple*
+`(func, {arg: <nested spec>})`, where each nested spec is itself a direct ref or
+another calc-tuple. Direct refs: meas `("group", "agg")`; sim `"ColName"`.
+
+Sim leaves are exact PVsyst output-variable names (e.g. `GlobInc`, `GlobBak`,
+`E_Grid`, `TArray`, `PrecWat`). To confirm a variable exists or find its correct
+abbreviation, check the PVsyst docs — meteo & irradiance variables:
+https://www.pvsyst.com/help/project-design/results/simulation-variables-meteo-and-irradiations.html
+and grid-system variables:
+https://www.pvsyst.com/help/project-design/results/simulation-variables-grid-system.html.
+A variable absent from PVsyst output cannot be a `reg_cols_sim` leaf (the
+sim-side `validate_test_setup` / `process_regression_columns` checks will fail).
+
+Calc functions live in `captest.calcparams`. Catalog (arg → wire as nested spec):
+
+| Function | Computes | Wire as |
+|---|---|---|
+| `e_total` | total effective irr = front + rear·bifaciality·… | `(e_total, {"poa": <front>, "rpoa": <rear>})` |
+| `rpoa_pvsyst` | modeled rear with shading baked in | `(rpoa_pvsyst, {"globbak": "GlobBak", "backshd": "BackShd"})` |
+| `poa_spec_corrected` | spectrally corrected front POA | `(poa_spec_corrected, {"poa": <poa>, "spectral_correction": <spec>})` |
+| `spectral_factor_firstsolar` | First Solar spectral factor | `(spectral_factor_firstsolar, {"precipitable_water": <pw>, "absolute_airmass": <am>})` |
+| `precipitable_water_gueymard` | pw from temp + RH (meas) | `(precipitable_water_gueymard, {"temp_amb": ("temp_amb","mean"), "rel_humidity": ("humidity","mean")})` |
+| `scale` | scale a column (sim pw: PrecWat·100) | `(scale, {"col": "PrecWat", "factor": 100})` |
+| `absolute_airmass` | airmass from zenith (+pressure on meas) | `(absolute_airmass, {"apparent_zenith": <z>, "pressure": ("pressure","mean")})` |
+| `apparent_zenith` / `apparent_zenith_pvsyst` | solar zenith (meas / PVsyst ½-hr shift) | `(apparent_zenith, {})` / `(apparent_zenith_pvsyst, {})` |
+| `power_temp_correct` | temperature-corrected power | `(power_temp_correct, {"power": <p>, "cell_temp": <ct>})` |
+| `cell_temp` | Sandia cell temp from POA + BOM | `(cell_temp, {"poa": ("irr_poa","mean"), "bom": <bom>})` |
+| `bom_temp` | modeled BOM temp | `(bom_temp, {"poa": (...), "temp_amb": (...), "wind_speed": (...)})` |
+
+Scalars like `bifaciality`, `bifacial_frac`, `rear_shade` are **not** wired in the
+dict — they flow in from `CapTest` attributes. `rear_shade` is **meas-only**:
+the `_sim` variant bakes shading into the modeled rear via `rpoa_pvsyst`; the
+`_meas` variant maps sim rear directly to `"GlobBak"` and applies `rear_shade` on
+the measured side. Name variants `..._sim` / `..._meas` accordingly.
+
+Sim spectral note: the PVsyst side uses `apparent_zenith_pvsyst` and **omits
+`pressure`** (pvlib sea-level default); meas uses `apparent_zenith` + measured
+`pressure`.
+
+### Step 4 — Scatter callable
+
+| Regression form | `scatter_plots` |
+|---|---|
+| POA-based / generic | `scatter_default` |
+| e_total-based (incl. spectral e_total) | `scatter_etotal` |
+| `power ~ poa + rpoa` (two-panel) | `scatter_bifi_power_tc` |
+
+### Step 5 — rep_conditions
+
+Default shape (override only with reason):
+
+```python
+"rep_conditions": {
+    "irr_bal": False,
+    "percent_filter": 20,
+    "func": {"poa": perc_wrap(60), "t_amb": "mean", "w_vel": "mean"},
+},
+```
+
+**`func` keys must be exactly the rhs variables of `reg_fml`** — no more, no less.
+`validate_test_setup` raises if `func` has a non-rhs key. Drop a variable from the
+formula → drop it from `func`.
+
+### Step 6 — Assemble, validate, probe, format
+
+Add the entry to the dict, then verify before showing the user:
+
+```python
+import warnings, captest.captest as ct
+from captest import CapTest
+name = "your_new_preset"
+ct.validate_test_setup(ct.TEST_SETUPS[name])   # raises on bad shape
+ct.resolve_test_setup(name)                      # raises on bad formula/cols
+# end-to-end probe with fixtures that satisfy the preset's required inputs
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    capt = CapTest.from_params(test_setup=name, meas=meas_cd, sim=sim_cd,
+                               ac_nameplate=6_000_000, bifaciality=0.15)
+```
+
+Then **always run `just fmt`** — nested dict literals over-indent silently; this
+passes Python and tests but fails formatting. Run `just lint` too.
+
+### Step 7 — Review summary (APPROVAL GATE)
+
+Present a scannable summary and wait for approval before touching tests:
+
+```
+Preset: <name>
+Description: <2-line gist of the expanded description>
+Regression: <reg_fml>
+Variable → meas → sim
+  power : (real_pwr_mtr, sum)        → E_Grid
+  poa   : e_total(spec-corrected …)  → e_total(…, rpoa_pvsyst)
+  t_amb : (temp_amb, mean)           → T_Amb
+  w_vel : (wind_speed, mean)         → WindVel
+Scatter: <scatter_callable>
+Rep conditions: percent_filter=20, func keys = {<rhs vars>}
+Validates: yes | Resolves: yes | End-to-end probe: cap ratio <x>
+Required inputs (for fixtures): <column groups / site / sim cols>
+```
+
+### Step 8 — Test coverage (after the dict is approved)
+
+Use the **unit-tests** skill for conventions. (Optional: delegate this whole step
+to a subagent — see *Optional: using subagents* below.) Mirror the existing
+presets' four layers in `tests/test_captest.py` (see the spec-corrected etotal
+presets as the worked example):
+
+1. **Structural** (`TestTestSetupsRegistry`): assert the calc-tree shape — the
+   identity of each calc function in the meas/sim trees and the `scatter_plots`
+   callable.
+2. **Downstream propagation** (`TestDownstreamPropagation`): assert the *novel*
+   numeric behavior of this preset (e.g. the corrected/total column equals the
+   expected combination of its inputs and the `CapTest` scalars).
+3. **Column existence** (a class like `TestCapTestSpectralCorrection`): the
+   calculated columns materialize on both meas and sim.
+4. **Integration** (`TestIntegration`): run the canonical filter→rep_cond→fit
+   sequence to `0.8 < cap_ratio < 1.2` and assert `regression_cols["poa"]`.
+
+Fixtures (`tests/conftest.py`): reuse before adding. The existing fixtures and
+what they supply:
+
+| Fixture | Supplies |
+|---|---|
+| `meas_cd_default` / `sim_cd_default` | power, POA, amb, wind; `irr_rpoa`; sim `GlobBak`/`BackShd` |
+| `meas_cd_spec_corrected` / `sim_cd_spec_corrected` | adds `humidity`, `pressure`, `cd.site` (meas); `PrecWat` (sim) |
+| `meas_cd_bom_temp` | adds `temp_bom` group |
+
+If the default fixtures don't satisfy the preset's required inputs, **add the
+preset to the `_DEFAULT_FIXTURE_PRESETS` exclusion set** in `tests/test_captest.py`
+(otherwise the parametrized setup / rep_cond tests run it against the default
+fixtures and fail). Add a `ct_*` fixture; for spectral presets, suppress the
+`Propagating meas.site` `UserWarning` in the fixture.
+
+Run `just test-module test_captest.py`, then the full suite, then `just lint` /
+`just fmt`. Commit.
+
+## Optional: using subagents
+
+Default to doing the work in the main conversation — the dict is small, iterated
+with the user, and gated by the two user approvals (a subagent cannot run those
+gates, and an LLM "reviewing" another LLM's dict is a weaker check than the
+objective `validate`/`resolve`/probe steps). **Keep dict generation in the main
+agent.** Reach for subagents only where they earn their keep:
+
+- **Delegate Step 8 test coverage.** Once the dict is approved, the four test
+  layers + fixtures are a bulky, well-specified, independent chunk. Dispatch a
+  subagent to implement them (it can use the **unit-tests** skill); the main agent
+  reviews the diff and runs the suite + `just lint`. Worth it for complex presets;
+  skip it for a trivial monofacial one.
+- **Semantic verification of a complex dict.** `validate_test_setup` catches
+  shape errors but not a valid-but-wrong wiring — e.g. rear mapped to the wrong
+  column, or `apparent_zenith` used where `apparent_zenith_pvsyst` belongs on the
+  sim side. For deeply nested presets, dispatch one subagent prompted to *refute*
+  the mapping against the expanded description and a sibling preset. Optional;
+  overkill for shallow trees.
+- **Batch-adding presets.** Adding several at once → one subagent per preset (each
+  is independent), each running this skill end-to-end.
+
+## Gotchas
+
+| Gotcha | Reality |
+|---|---|
+| Dict over-indentation | Passes Python & tests, fails `just fmt`. Always run `just fmt`. |
+| `func` has a non-rhs key | `validate_test_setup` raises. `func` keys = rhs vars exactly. |
+| Spectral factor NaN at sunrise/sunset | Select test rows on `poa_spec_corrected.notna() & > 0`, not `irr_poa > 0`. |
+| `Propagating meas.site` warning | Fires when sim has no `site`; suppress in spectral `ct_*` fixtures. |
+| New preset breaks parametrized tests | If it needs special fixtures, exclude it from `_DEFAULT_FIXTURE_PRESETS`. |
+| Wiring scalars into the dict | `bifaciality`/`bifacial_frac`/`rear_shade` come from `CapTest`, not the dict. |
+
+## Red flags — you skipped a gate
+
+- You wrote the dict before the user approved the regression equation.
+- You started writing tests before the user approved the dict summary.
+- You reported "done" without running `validate_test_setup`, `resolve_test_setup`,
+  an end-to-end probe, and `just fmt` / `just lint`.
+
+All of these mean: stop, back up to the gate you skipped.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ you will now be passing the WRONG arguments.
 - Updated `CapData.rep_cond` doc string to more clearly describe default calculations defined in `captest.TEST_SETUPS`
 - Removed the redundant `front_poa` parameter from `TEST_SETUPS` presets where `irr_bal` is `False`.
 
+### Fixed
+- `CapData.agg_group` now passes `min_count=1` for `sum` aggregations so a row where every column in the group is `NaN` aggregates to `NaN` instead of `0.0`. This was most visible for single-column power groups (e.g. mapping `power` to `('real_pwr_mtr', 'sum')` in `regression_cols`), where summing is a no-op but previously converted missing values into a real zero that then flowed into filtering and regression.
+
 [0.15.1]: https://github.com/pvcaptest/pvcaptest/compare/v0.15.0...v0.15.1
 ## [0.15.1] - 2026-05-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a required `description` key to `TEST_SETUPS` registry entries and updated validation.
 - Added a "Predefined Test Setups" section to the API reference and updated user guides for new presets.
 - Added Sphinx documentation stubs for `validate_test_setup`, `resolve_test_setup`, and `perc_wrap`.
+- Exposed `test_setups` as a top-level export (`captest.test_setups`) so the available preset names and descriptions can be printed directly.
 
 ### Changed
 - Renamed the `bifi_power_tc` preset test setup to `bifi_power_tc_calc_tbom`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ you will now be passing the WRONG arguments.
 - Updated `CapData.rep_cond` doc string to more clearly describe default calculations defined in `captest.TEST_SETUPS`
 - Removed the redundant `front_poa` parameter from `TEST_SETUPS` presets where `irr_bal` is `False`.
 - `CapData.process_regression_columns` (and `CapTest.setup`) now print a "Reusing existing column '<group>_<func>_agg'; skipping aggregation of the <group> group." message when a pre-aggregated column already exists in the data and aggregation is skipped. Previously the reuse was silent, so verbose output only showed "Aggregating ..." blocks for groups whose agg column was missing.
+- Allowed fully suppressing printed output from load_data function by passing verbose=False, summary=False, and report=False.
 
 ### Fixed
 - `CapData.agg_group` now passes `min_count=1` for `sum` aggregations so a row where every column in the group is `NaN` aggregates to `NaN` instead of `0.0`. This was most visible for single-column power groups (e.g. mapping `power` to `('real_pwr_mtr', 'sum')` in `regression_cols`), where summing is a no-op but previously converted missing values into a real zero that then flowed into filtering and regression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `bifi_power_tc_meas_tbom` preset test setup using field-measured back-of-module temperature.
 - Added `bifi_e2848_etotal_rear_shade_meas` preset test setup that applies rear-shading losses on the measured side via the `e_total` `rear_shade` factor (the modeled rear maps directly to PVsyst `GlobBak`).
+- Added `bifi_power_tc_etotal_rear_shade_sim` and `bifi_power_tc_etotal_rear_shade_meas` preset test setups: temperature-corrected power regressed against total effective irradiance, with rear shading handled in the modeled data or on the measured side, respectively.
+- Added `bifi_e2848_etotal_rear_shade_sim_spec_corrected` and `bifi_e2848_etotal_rear_shade_meas_spec_corrected` preset test setups combining the total-irradiance regression with the First Solar spectral correction applied to front-side POA.
 - Added a required `description` key to `TEST_SETUPS` registry entries and updated validation.
 - Added a "Predefined Test Setups" section to the API reference and updated user guides for new presets.
 - Added Sphinx documentation stubs for `validate_test_setup`, `resolve_test_setup`, and `perc_wrap`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 you will now be passing the WRONG arguments.
 - Updated `CapData.rep_cond` doc string to more clearly describe default calculations defined in `captest.TEST_SETUPS`
 - Removed the redundant `front_poa` parameter from `TEST_SETUPS` presets where `irr_bal` is `False`.
+- `CapData.process_regression_columns` (and `CapTest.setup`) now print a "Reusing existing column '<group>_<func>_agg'; skipping aggregation of the <group> group." message when a pre-aggregated column already exists in the data and aggregation is skipped. Previously the reuse was silent, so verbose output only showed "Aggregating ..." blocks for groups whose agg column was missing.
 
 ### Fixed
 - `CapData.agg_group` now passes `min_count=1` for `sum` aggregations so a row where every column in the group is `NaN` aggregates to `NaN` instead of `0.0`. This was most visible for single-column power groups (e.g. mapping `power` to `('real_pwr_mtr', 'sum')` in `regression_cols`), where summing is a no-op but previously converted missing values into a real zero that then flowed into filtering and regression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `bifi_power_tc_meas_tbom` preset test setup using field-measured back-of-module temperature.
+- Added `bifi_e2848_etotal_rear_shade_meas` preset test setup that applies rear-shading losses on the measured side via the `e_total` `rear_shade` factor (the modeled rear maps directly to PVsyst `GlobBak`).
 - Added a required `description` key to `TEST_SETUPS` registry entries and updated validation.
 - Added a "Predefined Test Setups" section to the API reference and updated user guides for new presets.
 - Added Sphinx documentation stubs for `validate_test_setup`, `resolve_test_setup`, and `perc_wrap`.
 
 ### Changed
 - Renamed the `bifi_power_tc` preset test setup to `bifi_power_tc_calc_tbom`.
+- **Breaking:** Renamed the `bifi_e2848_etotal` preset test setup to `bifi_e2848_etotal_rear_shade_sim` so the name states that rear shading is handled in the modeled (PVsyst) data (`rpoa_pvsyst = GlobBak + BackShd`). The new `bifi_e2848_etotal_rear_shade_meas` variant handles rear shading on the measured side.
 - Modified `CapData.rep_cond` parameter order! If you were relying on the ability to pass kwargs as positional args
 you will now be passing the WRONG arguments.
 - Updated `CapData.rep_cond` doc string to more clearly describe default calculations defined in `captest.TEST_SETUPS`

--- a/docs/examples/captest_class_bifi.ipynb
+++ b/docs/examples/captest_class_bifi.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "## Load Data and Calculate Regressors\n",
     "\n",
-    "By specifying the `test_setup` as `bifi_e2848_etotal` when instantiating the CapTest instance the $E_{total}$ regressors are calculated, added as columns to `data` and `data_filtered`, and the `regression_columns` is updated to map `poa` to `e_total`. These steps are documented by default in output printed."
+    "By specifying the `test_setup` as `bifi_e2848_etotal_rear_shade_sim` when instantiating the CapTest instance the $E_{total}$ regressors are calculated, added as columns to `data` and `data_filtered`, and the `regression_columns` is updated to map `poa` to `e_total`. These steps are documented by default in output printed."
    ]
   },
   {
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "ts = CapTest.from_params(\n",
-    "    test_setup='bifi_e2848_etotal',\n",
+    "    test_setup='bifi_e2848_etotal_rear_shade_sim',\n",
     "    meas_path='./data/example_meas_data_bifi.csv',\n",
     "    sim_path='./data/pvsyst_example_HourlyRes_2_bifi.CSV',\n",
     "    test_tolerance='+/- 3',\n",

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -101,6 +101,11 @@ constructing a :py:class:`~captest.captest.CapTest`.
    values are dicts with required keys ``description``, ``reg_cols_meas``,
    ``reg_cols_sim``, ``reg_fml``, ``scatter_plots``, and ``rep_conditions``.
 
+Every entry carries a human-readable ``description`` key summarizing the setup.
+Read it programmatically with, e.g.,
+``captest.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim"]["description"]``. The
+summaries below mirror those ``description`` strings.
+
 The built-in presets are:
 
 ``e2848_default``
@@ -108,11 +113,21 @@ The built-in presets are:
    ambient temperature, and wind speed using the full four-term formula. Default
    setup for monofacial capacity tests.
 
-``bifi_e2848_etotal``
+``bifi_e2848_etotal_rear_shade_sim``
    Standard ASTM E2848 regression form with total effective irradiance replacing
-   front-side POA as the independent variable.
+   front-side POA as the independent variable. Rear shading and IAM losses are
+   handled in the modeled (PVsyst) data (``rpoa_pvsyst = GlobBak + BackShd``)
+   while the measured rear sensor is used as-measured (``rear_shade = 0``).
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
-   modified bifacial approach.
+   modified bifacial approach. See the *Choosing a test setup* section of the
+   CapTest user guide for the per-side formulas.
+
+``bifi_e2848_etotal_rear_shade_meas``
+   Same regression form as ``bifi_e2848_etotal_rear_shade_sim``, but rear-shading
+   losses are applied on the measured side via the ``e_total`` ``rear_shade``
+   factor while the modeled rear maps directly to PVsyst's unshaded ``GlobBak``.
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi \cdot (1 - s)` on the
+   measured side, where :math:`s` is the ``rear_shade`` fraction.
 
 ``bifi_power_tc_meas_tbom``
    Temperature-corrected power regressed against front and rear irradiance.

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -80,6 +80,7 @@ Standalone functions used alongside :py:class:`~captest.captest.CapTest`.
    :toctree: generated/
 
    captest.load_config
+   captest.captest.test_setups
    captest.captest.validate_test_setup
    captest.captest.resolve_test_setup
    captest.captest.perc_wrap

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -119,8 +119,8 @@ The built-in presets are:
    handled in the modeled (PVsyst) data (``rpoa_pvsyst = GlobBak + BackShd``)
    while the measured rear sensor is used as-measured (``rear_shade = 0``).
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
-   modified bifacial approach. See the *Choosing a test setup* section of the
-   CapTest user guide for the per-side formulas.
+   modified bifacial approach. See :ref:`choosing-test-setup` in the CapTest
+   user guide for the per-side formulas.
 
 ``bifi_e2848_etotal_rear_shade_meas``
    Same regression form as ``bifi_e2848_etotal_rear_shade_sim``, but rear-shading
@@ -140,7 +140,44 @@ The built-in presets are:
    ambient temperature, and wind speed via the Sandia model; no dedicated BOM
    sensor is required.
 
+``bifi_power_tc_etotal_rear_shade_sim``
+   Temperature-corrected power regressed against total effective irradiance.
+   Back-of-module temperature is taken from field measurements and used to
+   calculate cell temperature via the Sandia PV Array Performance Model. Rear
+   shading and IAM losses are handled in the modeled (PVsyst) data
+   (``rpoa_pvsyst = GlobBak + BackShd``) while the measured rear sensor is used
+   as-measured (``rear_shade = 0``).
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
+   modified bifacial approach.
+
+``bifi_power_tc_etotal_rear_shade_meas``
+   Same regression form as ``bifi_power_tc_etotal_rear_shade_sim``, but
+   rear-shading losses are applied on the measured side via the ``e_total``
+   ``rear_shade`` factor while the modeled rear maps directly to PVsyst's
+   unshaded ``GlobBak``.
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi \cdot (1 - s)` on the
+   measured side, where :math:`s` is the ``rear_shade`` fraction.
+
 ``e2848_spec_corrected_poa``
    Standard ASTM E2848 regression with a First Solar spectral correction applied
    to front-side POA before fitting. Requires relative humidity and atmospheric
    pressure on the measured side and precipitable water from the PVsyst output.
+
+``bifi_e2848_etotal_rear_shade_sim_spec_corrected``
+   Standard ASTM E2848 regression with total effective irradiance replacing
+   front-side POA and a First Solar spectral correction applied to the
+   front-side POA used to calculate the total irradiance. Requires relative
+   humidity and atmospheric pressure on the measured side and precipitable
+   water from the PVsyst output. Rear shading and IAM losses are handled in
+   the modeled (PVsyst) data (``rpoa_pvsyst = GlobBak + BackShd``) while the
+   measured rear sensor is used as-measured (``rear_shade = 0``).
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi` with the spectral
+   correction applied to :math:`E_{POA}`.
+
+``bifi_e2848_etotal_rear_shade_meas_spec_corrected``
+   Same regression form as ``bifi_e2848_etotal_rear_shade_sim_spec_corrected``,
+   but rear-shading losses are applied on the measured side via the ``e_total``
+   ``rear_shade`` factor while the modeled rear maps directly to PVsyst's
+   unshaded ``GlobBak``.
+   :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi \cdot (1 - s)` on the
+   measured side, where :math:`s` is the ``rear_shade`` fraction.

--- a/docs/source/api_reference/generated/captest.CapTest.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rst
@@ -37,7 +37,10 @@
    .. autosummary::
    
       ~CapTest.ac_nameplate
+      ~CapTest.airmass_model
+      ~CapTest.altitude_override
       ~CapTest.base_temp
+      ~CapTest.bifacial_frac
       ~CapTest.bifaciality
       ~CapTest.clipping_irr
       ~CapTest.fshdbm
@@ -49,9 +52,12 @@
       ~CapTest.meas_load_kwargs
       ~CapTest.meas_loader
       ~CapTest.min_irr
+      ~CapTest.module_type
       ~CapTest.name
       ~CapTest.param
       ~CapTest.power_temp_coeff
+      ~CapTest.racking
+      ~CapTest.rear_shade
       ~CapTest.reg_cols_meas
       ~CapTest.reg_cols_sim
       ~CapTest.reg_fml

--- a/docs/source/api_reference/generated/captest.captest.test_setups.rst
+++ b/docs/source/api_reference/generated/captest.captest.test_setups.rst
@@ -1,0 +1,6 @@
+﻿captest.captest.test\_setups
+============================
+
+.. currentmodule:: captest.captest
+
+.. autofunction:: test_setups

--- a/docs/superpowers/plans/2026-06-09-spec-corrected-etotal-test-coverage.md
+++ b/docs/superpowers/plans/2026-06-09-spec-corrected-etotal-test-coverage.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Bring the two new `TEST_SETUPS` presets (`bifi_e2848_spec_corrected_etotal_rear_shade_sim` / `_meas`) to full test-coverage parity with the existing presets, and fix the test breakage their addition caused.
+**Goal:** Bring the two new `TEST_SETUPS` presets (`bifi_e2848_etotal_rear_shade_sim_spec_corrected` / `_meas`) to full test-coverage parity with the existing presets, and fix the test breakage their addition caused.
 
 **Architecture:** Four sequential tasks, each TDD red→green→commit. Task 1 fixes the existing parametrized-test breakage. Tasks 2–4 add the four coverage layers (structural calc-tree, downstream propagation, column existence, end-to-end integration), reusing the existing `*_spec_corrected` data fixtures.
 
@@ -53,8 +53,8 @@ _DEFAULT_FIXTURE_PRESETS = [
     not in {
         "e2848_spec_corrected_poa",
         "bifi_power_tc_meas_tbom",
-        "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
-        "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+        "bifi_e2848_etotal_rear_shade_sim_spec_corrected",
+        "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
     }
 ]
 ```
@@ -122,7 +122,7 @@ Add these methods to `class TestTestSetupsRegistry` (after
 ```python
     def test_spec_corrected_etotal_sim_front_spec_corrected_rear_raw(self):
         """_sim meas poa = e_total(front=poa_spec_corrected, rear=raw irr_rpoa)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         meas_poa = entry["reg_cols_meas"]["poa"]
         assert isinstance(meas_poa, tuple)
         assert meas_poa[0] is e_total
@@ -131,14 +131,14 @@ Add these methods to `class TestTestSetupsRegistry` (after
 
     def test_spec_corrected_etotal_sim_rear_uses_rpoa_pvsyst(self):
         """_sim sim-side rear routes through rpoa_pvsyst (shading in model)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         sim_rear = entry["reg_cols_sim"]["poa"][1]["rpoa"]
         assert isinstance(sim_rear, tuple)
         assert sim_rear[0] is rpoa_pvsyst
 
     def test_spec_corrected_etotal_meas_rear_maps_to_globbak(self):
         """_meas sim-side rear maps directly to GlobBak; meas side matches _sim."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_meas"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_meas_spec_corrected"]
         assert entry["reg_cols_sim"]["poa"][1]["rpoa"] == "GlobBak"
         meas_poa = entry["reg_cols_meas"]["poa"]
         assert meas_poa[0] is e_total
@@ -147,7 +147,7 @@ Add these methods to `class TestTestSetupsRegistry` (after
 
     def test_spec_corrected_etotal_sim_routes_through_pvsyst_zenith_and_scale(self):
         """_sim sim-side spectral tree uses apparent_zenith_pvsyst + scale(PrecWat)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         front = entry["reg_cols_sim"]["poa"][1]["poa"]  # poa_spec_corrected tuple
         assert front[0] is poa_spec_corrected
         spec_node = front[1]["spectral_correction"]
@@ -159,8 +159,8 @@ Add these methods to `class TestTestSetupsRegistry` (after
     def test_spec_corrected_etotal_presets_use_scatter_etotal(self):
         """Both presets use scatter_etotal, matching the other e_total presets."""
         for name in (
-            "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
-            "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            "bifi_e2848_etotal_rear_shade_sim_spec_corrected",
+            "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
         ):
             assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
 ```
@@ -172,7 +172,7 @@ Expected: FAIL — only `test_spec_corrected_etotal_presets_use_scatter_etotal` 
 
 - [ ] **Step 4: Switch the source scatter callable on both new presets**
 
-In `src/captest/captest.py`, inside `bifi_e2848_spec_corrected_etotal_rear_shade_sim` and `bifi_e2848_spec_corrected_etotal_rear_shade_meas`, change each `"scatter_plots": scatter_default,` to:
+In `src/captest/captest.py`, inside `bifi_e2848_etotal_rear_shade_sim_spec_corrected` and `bifi_e2848_etotal_rear_shade_meas_spec_corrected`, change each `"scatter_plots": scatter_default,` to:
 
 ```python
             "scatter_plots": scatter_etotal,
@@ -228,7 +228,7 @@ After the `sim_cd_spec_corrected` fixture in `tests/conftest.py`, add:
 ```python
 @pytest.fixture
 def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
-    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_sim preset.
+    """CapTest for the bifi_e2848_etotal_rear_shade_sim_spec_corrected preset.
 
     The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
     setup; that auto-propagation behavior is covered separately by the
@@ -237,7 +237,7 @@ def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Propagating meas.site")
         return CapTest.from_params(
-            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            test_setup="bifi_e2848_etotal_rear_shade_sim_spec_corrected",
             meas=meas_cd_spec_corrected,
             sim=sim_cd_spec_corrected,
             ac_nameplate=6_000_000,
@@ -248,7 +248,7 @@ def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
 
 @pytest.fixture
 def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected):
-    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_meas preset.
+    """CapTest for the bifi_e2848_etotal_rear_shade_meas_spec_corrected preset.
 
     The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
     setup; that auto-propagation behavior is covered separately by the
@@ -257,7 +257,7 @@ def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Propagating meas.site")
         return CapTest.from_params(
-            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            test_setup="bifi_e2848_etotal_rear_shade_meas_spec_corrected",
             meas=meas_cd_spec_corrected,
             sim=sim_cd_spec_corrected,
             ac_nameplate=6_000_000,
@@ -294,7 +294,7 @@ Add to `class TestDownstreamPropagation` in `tests/test_captest.py`:
         """rear_shade discounts the measured rear but is absent on sim."""
         with pytest.warns(UserWarning, match="Propagating meas.site"):
             capt = CapTest.from_params(
-                test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+                test_setup="bifi_e2848_etotal_rear_shade_meas_spec_corrected",
                 meas=meas_cd_spec_corrected,
                 sim=sim_cd_spec_corrected,
                 bifaciality=0.5,

--- a/docs/superpowers/plans/2026-06-09-spec-corrected-etotal-test-coverage.md
+++ b/docs/superpowers/plans/2026-06-09-spec-corrected-etotal-test-coverage.md
@@ -1,0 +1,419 @@
+# Spectral-corrected e_total preset test coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the two new `TEST_SETUPS` presets (`bifi_e2848_spec_corrected_etotal_rear_shade_sim` / `_meas`) to full test-coverage parity with the existing presets, and fix the test breakage their addition caused.
+
+**Architecture:** Four sequential tasks, each TDD red→green→commit. Task 1 fixes the existing parametrized-test breakage. Tasks 2–4 add the four coverage layers (structural calc-tree, downstream propagation, column existence, end-to-end integration), reusing the existing `*_spec_corrected` data fixtures.
+
+**Tech Stack:** Python, pytest, `uv run pytest`, ruff (`just lint` / `just fmt`).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-spec-corrected-etotal-test-coverage-design.md`
+
+---
+
+### Task 1: Fix the `_DEFAULT_FIXTURE_PRESETS` breakage
+
+The two new presets need humidity/pressure/site (meas) and `PrecWat` (sim), which
+`meas_cd_default` / `sim_cd_default` lack. They are currently included in
+`_DEFAULT_FIXTURE_PRESETS`, so two parametrized tests fail. Exclude them (like
+`e2848_spec_corrected_poa`).
+
+**Files:**
+- Modify: `tests/test_captest.py:32-36`
+
+- [ ] **Step 1: Confirm the tests are currently red**
+
+Run: `uv run pytest "tests/test_captest.py::TestSetup::test_setup_wires_regression_formula" "tests/test_captest.py::TestPresetRepConditionsRoundTrip" -q`
+
+(The second node id may differ; the failing test is `test_each_preset_rep_conditions_round_trips_through_rep_cond`.) Run instead:
+
+Run: `uv run pytest tests/test_captest.py -k "wires_regression_formula or round_trips_through_rep_cond" -q`
+Expected: FAIL — 2 failures for the `bifi_e2848_spec_corrected_etotal_*` params with `KeyError: "Group 'humidity' was not found..."`
+
+- [ ] **Step 2: Add the new presets to the exclusion set**
+
+In `tests/test_captest.py`, change:
+
+```python
+_DEFAULT_FIXTURE_PRESETS = [
+    p
+    for p in ct.TEST_SETUPS.keys()
+    if p not in {"e2848_spec_corrected_poa", "bifi_power_tc_meas_tbom"}
+]
+```
+
+to:
+
+```python
+_DEFAULT_FIXTURE_PRESETS = [
+    p
+    for p in ct.TEST_SETUPS.keys()
+    if p
+    not in {
+        "e2848_spec_corrected_poa",
+        "bifi_power_tc_meas_tbom",
+        "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+        "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+    }
+]
+```
+
+- [ ] **Step 3: Run to verify green**
+
+Run: `uv run pytest tests/test_captest.py -k "wires_regression_formula or round_trips_through_rep_cond" -q`
+Expected: PASS (no `bifi_e2848_spec_corrected_etotal_*` params remain; all pass)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_captest.py
+git commit -m "test: exclude spec-corrected etotal presets from default-fixture tests"
+```
+
+---
+
+### Task 2: Layer 1 — structural calc-tree tests + scatter_etotal switch
+
+Add per-preset structural assertions mirroring the existing
+`test_bifi_e2848_etotal_rear_shade_sim_uses_e_total` /
+`test_e2848_spec_corrected_poa_*` tests. The `scatter_etotal` assertion drives the
+source switch from `scatter_default`.
+
+**Files:**
+- Modify: `tests/test_captest.py` (imports near line 19; new tests in `class TestTestSetupsRegistry`, after the existing `test_e2848_spec_corrected_poa_sim_uses_apparent_zenith_pvsyst` at ~line 108)
+- Modify: `src/captest/captest.py:582` and `:676` (the `"scatter_plots": scatter_default,` lines inside the two new presets)
+
+- [ ] **Step 1: Extend the calcparams import in the test module**
+
+In `tests/test_captest.py`, change the import block (currently lines 19–26):
+
+```python
+from captest.calcparams import (
+    apparent_zenith_pvsyst,
+    cell_temp,
+    e_total,
+    poa_spec_corrected,
+    power_temp_correct,
+    spectral_factor_firstsolar,
+)
+```
+
+to add `rpoa_pvsyst` and `scale`:
+
+```python
+from captest.calcparams import (
+    apparent_zenith_pvsyst,
+    cell_temp,
+    e_total,
+    poa_spec_corrected,
+    power_temp_correct,
+    rpoa_pvsyst,
+    scale,
+    spectral_factor_firstsolar,
+)
+```
+
+- [ ] **Step 2: Write the failing structural tests**
+
+Add these methods to `class TestTestSetupsRegistry` (after
+`test_e2848_spec_corrected_poa_sim_uses_apparent_zenith_pvsyst`):
+
+```python
+    def test_spec_corrected_etotal_sim_front_spec_corrected_rear_raw(self):
+        """_sim meas poa = e_total(front=poa_spec_corrected, rear=raw irr_rpoa)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        meas_poa = entry["reg_cols_meas"]["poa"]
+        assert isinstance(meas_poa, tuple)
+        assert meas_poa[0] is e_total
+        assert meas_poa[1]["poa"][0] is poa_spec_corrected
+        assert meas_poa[1]["rpoa"] == ("irr_rpoa", "mean")
+
+    def test_spec_corrected_etotal_sim_rear_uses_rpoa_pvsyst(self):
+        """_sim sim-side rear routes through rpoa_pvsyst (shading in model)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        sim_rear = entry["reg_cols_sim"]["poa"][1]["rpoa"]
+        assert isinstance(sim_rear, tuple)
+        assert sim_rear[0] is rpoa_pvsyst
+
+    def test_spec_corrected_etotal_meas_rear_maps_to_globbak(self):
+        """_meas sim-side rear maps directly to GlobBak; meas side matches _sim."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_meas"]
+        assert entry["reg_cols_sim"]["poa"][1]["rpoa"] == "GlobBak"
+        meas_poa = entry["reg_cols_meas"]["poa"]
+        assert meas_poa[0] is e_total
+        assert meas_poa[1]["poa"][0] is poa_spec_corrected
+        assert meas_poa[1]["rpoa"] == ("irr_rpoa", "mean")
+
+    def test_spec_corrected_etotal_sim_routes_through_pvsyst_zenith_and_scale(self):
+        """_sim sim-side spectral tree uses apparent_zenith_pvsyst + scale(PrecWat)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        front = entry["reg_cols_sim"]["poa"][1]["poa"]  # poa_spec_corrected tuple
+        assert front[0] is poa_spec_corrected
+        spec_node = front[1]["spectral_correction"]
+        assert spec_node[0] is spectral_factor_firstsolar
+        zenith = spec_node[1]["absolute_airmass"][1]["apparent_zenith"]
+        assert zenith[0] is apparent_zenith_pvsyst
+        assert spec_node[1]["precipitable_water"][0] is scale
+
+    def test_spec_corrected_etotal_presets_use_scatter_etotal(self):
+        """Both presets use scatter_etotal, matching the other e_total presets."""
+        for name in (
+            "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+        ):
+            assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
+```
+
+- [ ] **Step 3: Run to verify the scatter test fails, the rest pass**
+
+Run: `uv run pytest tests/test_captest.py::TestTestSetupsRegistry -k "spec_corrected_etotal" -q`
+Expected: FAIL — only `test_spec_corrected_etotal_presets_use_scatter_etotal` fails (asserts `scatter_etotal`, source still `scatter_default`); the other four pass.
+
+- [ ] **Step 4: Switch the source scatter callable on both new presets**
+
+In `src/captest/captest.py`, inside `bifi_e2848_spec_corrected_etotal_rear_shade_sim` and `bifi_e2848_spec_corrected_etotal_rear_shade_meas`, change each `"scatter_plots": scatter_default,` to:
+
+```python
+            "scatter_plots": scatter_etotal,
+```
+
+(Note the indentation differs between the two entries until `just fmt` runs in Step 6 — match the surrounding lines of each entry.)
+
+- [ ] **Step 5: Run to verify green**
+
+Run: `uv run pytest tests/test_captest.py::TestTestSetupsRegistry -k "spec_corrected_etotal" -q`
+Expected: PASS (all 5)
+
+- [ ] **Step 6: Normalize formatting and lint**
+
+Run: `just fmt && just lint`
+Expected: the `_sim` entry indentation is normalized; no lint errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "test: structural coverage for spec-corrected etotal presets; use scatter_etotal"
+```
+
+---
+
+### Task 3: Fixtures + Layer 2 downstream-propagation tests
+
+Add two `CapTest` fixtures and the propagation test that asserts the *novel*
+behavior: the front term inside `e_total` is the spectrally-corrected column, and
+`rear_shade` is meas-only.
+
+**Files:**
+- Modify: `tests/conftest.py` (add `import warnings` near line 1; add two fixtures after `sim_cd_spec_corrected` at ~line 372)
+- Modify: `tests/test_captest.py` (new test in `class TestDownstreamPropagation`, after `test_meas_shade_setup_applies_shade_to_meas_only` at ~line 1027)
+
+- [ ] **Step 1: Add `import warnings` to conftest**
+
+In `tests/conftest.py`, add at the top with the other stdlib import (after line 1 `import pytest` is fine; keep stdlib first):
+
+```python
+import warnings
+
+import pytest
+import numpy as np
+import pandas as pd
+```
+
+- [ ] **Step 2: Add the two CapTest fixtures**
+
+After the `sim_cd_spec_corrected` fixture in `tests/conftest.py`, add:
+
+```python
+@pytest.fixture
+def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
+    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_sim preset.
+
+    The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
+    setup; that auto-propagation behavior is covered separately by the
+    e2848_spec_corrected_poa tests.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Propagating meas.site")
+        return CapTest.from_params(
+            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            meas=meas_cd_spec_corrected,
+            sim=sim_cd_spec_corrected,
+            ac_nameplate=6_000_000,
+            bifaciality=0.15,
+            test_tolerance="- 4",
+        )
+
+
+@pytest.fixture
+def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected):
+    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_meas preset.
+
+    The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
+    setup; that auto-propagation behavior is covered separately by the
+    e2848_spec_corrected_poa tests.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Propagating meas.site")
+        return CapTest.from_params(
+            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            meas=meas_cd_spec_corrected,
+            sim=sim_cd_spec_corrected,
+            ac_nameplate=6_000_000,
+            bifaciality=0.15,
+            test_tolerance="- 4",
+        )
+```
+
+- [ ] **Step 3: Write the failing propagation test**
+
+Add to `class TestDownstreamPropagation` in `tests/test_captest.py`:
+
+```python
+    def test_spec_correction_applied_to_front_inside_e_total(
+        self, ct_spec_corrected_etotal_sim
+    ):
+        """Meas e_total front term is poa_spec_corrected (not raw irr_poa),
+        and rear is discounted by bifaciality (rear_shade=0 by default)."""
+        capt = ct_spec_corrected_etotal_sim
+        meas_df = capt.meas.data
+        assert "poa_spec_corrected" in meas_df.columns
+        mask = meas_df["irr_poa_mean_agg"] > 0
+        first = meas_df.loc[mask].iloc[0]
+        expected = (
+            first["poa_spec_corrected"] + first["irr_rpoa_mean_agg"] * 0.15
+        )
+        assert first["e_total"] == pytest.approx(expected)
+        # The corrected front differs from the raw front (spectral factor != 1).
+        assert first["poa_spec_corrected"] != pytest.approx(first["irr_poa_mean_agg"])
+
+    def test_rear_shade_meas_only_for_spec_corrected_etotal(
+        self, meas_cd_spec_corrected, sim_cd_spec_corrected
+    ):
+        """rear_shade discounts the measured rear but is absent on sim."""
+        with pytest.warns(UserWarning, match="Propagating meas.site"):
+            capt = CapTest.from_params(
+                test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+                bifaciality=0.5,
+                rear_shade=0.12,
+            )
+        assert capt.meas.rear_shade == 0.12
+        assert not hasattr(capt.sim, "rear_shade")
+        meas_df = capt.meas.data
+        m = meas_df.loc[meas_df["irr_poa_mean_agg"] > 0].iloc[0]
+        expected = m["poa_spec_corrected"] + m["irr_rpoa_mean_agg"] * 0.5 * (1 - 0.12)
+        assert m["e_total"] == pytest.approx(expected)
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `uv run pytest tests/test_captest.py::TestDownstreamPropagation -k "spec_correction_applied or rear_shade_meas_only_for_spec" -q`
+Expected: PASS (2)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+just fmt && just lint
+git add tests/conftest.py tests/test_captest.py
+git commit -m "test: fixtures + propagation coverage for spec-corrected etotal presets"
+```
+
+---
+
+### Task 4: Layer 3 column-existence + Layer 4 integration tests
+
+**Files:**
+- Modify: `tests/test_captest.py` (new test class after `TestCapTestSpectralCorrection` at ~line 1259; new integration tests in `class TestIntegration` after `test_end_to_end_bifi_power_tc_meas_tbom` at ~line 2043)
+
+- [ ] **Step 1: Write the failing column-existence tests**
+
+Add a new class after `TestCapTestSpectralCorrection`:
+
+```python
+class TestSpecCorrectedEtotalColumns:
+    """Both poa_spec_corrected and e_total materialize on meas and sim."""
+
+    def test_sim_variant_materializes_both_columns(
+        self, ct_spec_corrected_etotal_sim
+    ):
+        capt = ct_spec_corrected_etotal_sim
+        for cd in (capt.meas, capt.sim):
+            assert "poa_spec_corrected" in cd.data.columns
+            assert "e_total" in cd.data.columns
+
+    def test_meas_variant_materializes_both_columns(
+        self, ct_spec_corrected_etotal_meas
+    ):
+        capt = ct_spec_corrected_etotal_meas
+        for cd in (capt.meas, capt.sim):
+            assert "poa_spec_corrected" in cd.data.columns
+            assert "e_total" in cd.data.columns
+```
+
+- [ ] **Step 2: Run to verify green**
+
+Run: `uv run pytest tests/test_captest.py::TestSpecCorrectedEtotalColumns -q`
+Expected: PASS (2)
+
+- [ ] **Step 3: Write the failing integration tests**
+
+Add to `class TestIntegration` (after `test_end_to_end_bifi_power_tc_meas_tbom`):
+
+```python
+    def test_end_to_end_spec_corrected_etotal_sim(
+        self, ct_spec_corrected_etotal_sim
+    ):
+        """Spectral-corrected e_total (_sim) runs end-to-end to a plausible ratio."""
+        capt = ct_spec_corrected_etotal_sim
+        assert "e_total" in capt.meas.data.columns
+        assert "poa_spec_corrected" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"
+
+    def test_end_to_end_spec_corrected_etotal_meas(
+        self, ct_spec_corrected_etotal_meas
+    ):
+        """Spectral-corrected e_total (_meas) runs end-to-end to a plausible ratio."""
+        capt = ct_spec_corrected_etotal_meas
+        assert "e_total" in capt.meas.data.columns
+        assert "poa_spec_corrected" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `uv run pytest tests/test_captest.py::TestIntegration -k "spec_corrected_etotal" -q`
+Expected: PASS (2)
+
+- [ ] **Step 5: Run the full test module + lint**
+
+Run: `uv run pytest tests/test_captest.py -q`
+Expected: PASS (all)
+
+Run: `just lint && just fmt`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_captest.py
+git commit -m "test: column-existence + integration coverage for spec-corrected etotal presets"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Task 1 = exclusion fix; Task 2 = Layer 1 + scatter switch + fmt; Task 3 = fixtures + Layer 2; Task 4 = Layer 3 + Layer 4. All spec sections mapped.
+- **Fixture-warning approach:** the spec said "pre-assign sim.site"; this plan instead suppresses the `Propagating meas.site` warning in the fixture (simpler, and exercises the real auto-propagation path to a fixed-offset tz). Same intent — integration tests stay quiet and the warning is not re-tested here.
+- **Imports:** `rpoa_pvsyst`, `scale` added to the test module; `warnings` added to conftest.

--- a/docs/superpowers/plans/2026-06-10-reuse-agg-column-message.md
+++ b/docs/superpowers/plans/2026-06-10-reuse-agg-column-message.md
@@ -1,0 +1,226 @@
+# Reuse-Existing-Agg-Column Verbose Message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Print a "Reusing existing column ..." message when `_get_or_create_aggregation` finds a pre-existing `<group>_<func>_agg` column and skips aggregation, so verbose `setup()` / `process_regression_columns()` output is self-explanatory.
+
+**Architecture:** One-branch change in `src/captest/util.py::_get_or_create_aggregation`. The function already receives a `verbose` flag (threaded from `CapData.process_regression_columns` → `util.process_reg_cols` → `transform_calc_params`); the reuse branch (`expected_agg_name in cd.data.columns`) currently returns silently while the fresh-aggregation branch prints via `CapData.agg_group`. Add a `verbose`-gated `print` to the reuse branch and update the docstring. Tested through the public `util.process_reg_cols` entry point using the existing `nested_calc_dict` DummyCapData fixture and pytest's `capsys`.
+
+**Tech Stack:** Python, pandas, pytest (`capsys`), `uv` + `just` task runner, ruff.
+
+**Background (why):** When measured data is loaded from a previously exported test-data CSV that already contains aggregated columns (e.g. `irr_poa_mean_agg`), `setup()` silently reuses those columns. The only visible aggregation report is for groups whose agg column is missing, which looks like a bug (observed in the kimmel_road integration notebook where only `real_pwr_mtr_sum_agg` was reported). The skip-if-exists behavior is intentional; the silence is the gap.
+
+---
+
+### Task 1: Create a working branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create and switch to a new branch off the current branch**
+
+```bash
+cd /home/ben/python/pvcaptest_bt-
+git checkout -b reuse-agg-column-message
+```
+
+Expected: `Switched to a new branch 'reuse-agg-column-message'` (branched from `filters-with-etotal`, which contains `_get_or_create_aggregation`).
+
+---
+
+### Task 2: Verbose reuse message in `_get_or_create_aggregation`
+
+**Files:**
+- Modify: `src/captest/util.py:332-365` (`_get_or_create_aggregation`)
+- Test: `tests/test_util.py` (new class after `TestProcessRegCols`, which ends at line 303)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this class to `tests/test_util.py` immediately after `TestProcessRegCols` (after line 303). It reuses the module-level `nested_calc_dict` fixture (defined at `tests/test_util.py:111`), whose `DummyCapData` starts with an empty `data` DataFrame and an `agg_group` method that records `agg_group_kwargs` when called — so `not hasattr(dummy_cd, "agg_group_kwargs")` proves aggregation was skipped. The `irr_poa` group has two columns in the fixture, so without a pre-existing column it would be aggregated.
+
+```python
+class TestGetOrCreateAggregationReuse:
+    """A pre-existing <group>_<func>_agg column is reused, not re-aggregated.
+
+    This happens e.g. when measured data is loaded from a previously
+    exported test-data csv that already contains aggregated columns. The
+    reuse should be reported when verbose so the absence of an
+    'Aggregating ...' block is explained.
+    """
+
+    def test_reuses_existing_column_and_prints_message(
+        self, nested_calc_dict, capsys
+    ):
+        dummy_cd, _ = nested_calc_dict
+        dummy_cd.data["irr_poa_mean_agg"] = np.full(10, 7)
+        reg_cols = {"poa": ("irr_poa", "mean")}
+        util.process_reg_cols(reg_cols, cd=dummy_cd)
+        captured = capsys.readouterr()
+        assert (
+            "Reusing existing column 'irr_poa_mean_agg'; skipping "
+            "aggregation of the irr_poa group." in captured.out
+        )
+        assert reg_cols["poa"] == "irr_poa_mean_agg"
+        assert not hasattr(dummy_cd, "agg_group_kwargs")
+
+    def test_reuse_is_silent_when_verbose_false(self, nested_calc_dict, capsys):
+        dummy_cd, _ = nested_calc_dict
+        dummy_cd.data["irr_poa_mean_agg"] = np.full(10, 7)
+        reg_cols = {"poa": ("irr_poa", "mean")}
+        util.process_reg_cols(reg_cols, cd=dummy_cd, verbose=False)
+        assert capsys.readouterr().out == ""
+        assert reg_cols["poa"] == "irr_poa_mean_agg"
+        assert not hasattr(dummy_cd, "agg_group_kwargs")
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `uv run pytest tests/test_util.py::TestGetOrCreateAggregationReuse -v`
+
+Expected: `test_reuses_existing_column_and_prints_message` FAILS on the message assertion (`assert "Reusing existing column ..." in ''`). `test_reuse_is_silent_when_verbose_false` PASSES already (the reuse branch is currently silent regardless of `verbose`) — that is fine; it pins the `verbose=False` contract so the fix doesn't print unconditionally.
+
+- [ ] **Step 3: Implement the message**
+
+In `src/captest/util.py`, `_get_or_create_aggregation` (currently lines 332-365). Replace the body's resolution block:
+
+```python
+    cache_key = (group_id, agg_func)
+    if cache_key in agg_cache:
+        return agg_cache[cache_key]
+
+    expected_agg_name = get_agg_column_name(group_id, agg_func)
+    if expected_agg_name in cd.data.columns:
+        agg_name = expected_agg_name
+    else:
+        agg_name = cd.agg_group(group_id=group_id, agg_func=agg_func, verbose=verbose)
+
+    agg_cache[cache_key] = agg_name
+    return agg_name
+```
+
+with:
+
+```python
+    cache_key = (group_id, agg_func)
+    if cache_key in agg_cache:
+        return agg_cache[cache_key]
+
+    expected_agg_name = get_agg_column_name(group_id, agg_func)
+    if expected_agg_name in cd.data.columns:
+        agg_name = expected_agg_name
+        if verbose:
+            print(
+                f"Reusing existing column '{expected_agg_name}'; skipping "
+                f"aggregation of the {group_id} group.\n"
+            )
+    else:
+        agg_name = cd.agg_group(group_id=group_id, agg_func=agg_func, verbose=verbose)
+
+    agg_cache[cache_key] = agg_name
+    return agg_name
+```
+
+The trailing `\n` inside the message gives one blank line after it, matching the spacing of the `Aggregating the below ...` blocks printed by `CapData.agg_group` (`src/captest/capdata.py:1472-1487`).
+
+Also update the function's docstring summary and the `Returns` section note. Replace the current docstring opening:
+
+```python
+    """
+    Get an aggregated column name, creating it if necessary.
+```
+
+with:
+
+```python
+    """
+    Get an aggregated column name, creating it if necessary.
+
+    If a column named ``<group_id>_<agg_func>_agg`` already exists in
+    ``cd.data`` (e.g. measured data was loaded from a previously exported
+    test-data file), that column is reused instead of re-aggregating the
+    group, and a "Reusing existing column ..." message is printed when
+    ``verbose`` is True.
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/test_util.py::TestGetOrCreateAggregationReuse -v`
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Run the full test_util module to check for regressions**
+
+Run: `just test-module test_util.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Lint and format**
+
+Run: `just lint src/captest/util.py tests/test_util.py && just fmt`
+
+Expected: no errors; no reformatting diffs beyond the edited files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/captest/util.py tests/test_util.py
+git commit -m "feat: report reuse of existing agg column in process_reg_cols
+
+When a <group>_<func>_agg column already exists in the data (e.g. measured
+data loaded from a previously exported test-data csv), the aggregation is
+skipped silently, which makes verbose setup() output look like groups were
+never aggregated. Print a 'Reusing existing column ...' message in the
+reuse branch of _get_or_create_aggregation when verbose.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Changelog entry
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased → Changed section, currently starting at line 16)
+
+- [ ] **Step 1: Add the entry**
+
+Add this bullet at the end of the `### Changed` list under `## [Unreleased]` in `CHANGELOG.md`:
+
+```markdown
+- `CapData.process_regression_columns` (and `CapTest.setup`) now print a "Reusing existing column '<group>_<func>_agg'; skipping aggregation of the <group> group." message when a pre-aggregated column already exists in the data and aggregation is skipped. Previously the reuse was silent, so verbose output only showed "Aggregating ..." blocks for groups whose agg column was missing.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for agg-column reuse message
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:** none
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `just test`
+
+Expected: all tests pass. The new print is gated on `verbose`, but a handful of capdata/captest tests assert on captured stdout — if any fail, they will be tests that pre-seed `_agg` columns and run `process_regression_columns` with `verbose=True`; update only their expected-output strings to include the new message, never the implementation.
+
+- [ ] **Step 2: Run lint over the repo**
+
+Run: `just lint && just fmt`
+
+Expected: clean.
+
+- [ ] **Step 3: Commit any test-expectation fixes (only if Step 1 required them)**
+
+```bash
+git add tests/
+git commit -m "test: update expected verbose output for agg reuse message
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-06-09-spec-corrected-etotal-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-09-spec-corrected-etotal-test-coverage-design.md
@@ -1,0 +1,149 @@
+# Test coverage for the spectral-corrected e_total presets
+
+**Date:** 2026-06-09
+**Branch:** etotal-fixes
+
+## Summary
+
+Two new entries were added to `TEST_SETUPS` in `src/captest/captest.py`:
+
+- `bifi_e2848_spec_corrected_etotal_rear_shade_sim`
+- `bifi_e2848_spec_corrected_etotal_rear_shade_meas`
+
+They combine the First Solar spectral correction (front POA) with the bifacial
+total-effective-irradiance (`e_total`) regression, splitting rear-shade handling
+between the modeled (`_sim`) and measured (`_meas`) sides. This spec defines the
+test coverage to bring them to parity with the existing presets, plus the source
+touch-ups and breakage fix the additions require.
+
+## Review findings (pre-existing state)
+
+- **No syntax errors or functional bugs.** Both entries import, pass
+  `validate_test_setup`, resolve via `resolve_test_setup`, and run end-to-end
+  through `CapTest.setup()` -> filter -> `rep_cond` -> fit. Verified with a probe
+  script. The novel interaction is correct: the spectral correction is applied to
+  the **front** POA *inside* the `e_total` calc-tree, rear POA left uncorrected:
+
+  ```
+  e_total = poa_spec_corrected(front) + rpoa * bifaciality * bifacial_frac * (1 - rear_shade)
+  ```
+
+  The `_sim`/`_meas` split matches the existing non-spectral pair: sim rear =
+  `rpoa_pvsyst(GlobBak, BackShd)` (`_sim`) vs direct `"GlobBak"` (`_meas`);
+  `rear_shade` is meas-only.
+
+- **Style only:** the `_sim` entry (captest.py:493-592) is indented one level
+  deeper than every other entry. Not a syntax error (ignored inside a dict
+  literal); `ruff format` / `just fmt` normalizes it. The `_meas` entry is already
+  correct.
+
+- **Existing tests broken by the additions:** `_DEFAULT_FIXTURE_PRESETS`
+  (tests/test_captest.py:32) excludes only `e2848_spec_corrected_poa` and
+  `bifi_power_tc_meas_tbom`. The two new presets need humidity/pressure/site
+  (meas) and `PrecWat` (sim), which the default fixtures lack, so they currently
+  fail two parametrized tests (`test_setup_wires_regression_formula`,
+  `test_each_preset_rep_conditions_round_trips_through_rep_cond`). They must be
+  added to that exclusion set.
+
+- **Decision (resolved):** switch `scatter_plots` from `scatter_default` to
+  `scatter_etotal` on both new presets, for consistency with the non-spectral
+  e_total presets. (The callables are functionally identical today.)
+
+- **Decision (resolved):** full 4-layer coverage parity.
+
+## Source changes (`src/captest/captest.py`)
+
+- Switch `scatter_plots` -> `scatter_etotal` on both new presets.
+- Normalize the `_sim` entry indentation via `just fmt`.
+
+## Fixtures (`tests/conftest.py`)
+
+No new *data* fixtures. `meas_cd_spec_corrected` and `sim_cd_spec_corrected`
+already carry everything required (they extend the default fixtures, which have
+`irr_rpoa` and `GlobBak`/`BackShd`). Add two `CapTest` fixtures:
+
+- `ct_spec_corrected_etotal_sim` (test_setup `..._rear_shade_sim`)
+- `ct_spec_corrected_etotal_meas` (test_setup `..._rear_shade_meas`)
+
+Both: `meas=meas_cd_spec_corrected`, `sim=sim_cd_spec_corrected`,
+`ac_nameplate=6_000_000`, `bifaciality=0.15`, `test_tolerance="- 4"`. Each
+pre-assigns `sim.site` so the "Propagating meas.site" `UserWarning` does not fire
+at fixture setup (that warning's behavior is already covered by the existing
+`e2848_spec_corrected_poa` tests).
+
+## Test changes (`tests/test_captest.py`)
+
+1. **Exclusion fix** — add both new presets to the `_DEFAULT_FIXTURE_PRESETS`
+   exclusion set. Turns the two currently-failing parametrized tests green.
+
+2. **Layer 1 — structural** (`TestTestSetupsRegistry`): per preset, assert meas
+   `poa` is an `e_total` tuple whose front sub-node is `poa_spec_corrected` and
+   rear is `("irr_rpoa", "mean")`; sim rear is `rpoa_pvsyst` (`_sim`) vs literal
+   `"GlobBak"` (`_meas`); sim front routes through `apparent_zenith_pvsyst` +
+   `scale(PrecWat)`; `scatter_plots is scatter_etotal`.
+
+3. **Layer 2 — downstream propagation** (`TestDownstreamPropagation`): the novel
+   behavior — meas `e_total` equals `poa_spec_corrected + irr_rpoa * bifaciality *
+   (1 - rear_shade)` (front term is the spectrally-corrected column, not raw
+   `irr_poa`); `rear_shade` is meas-only.
+
+4. **Layer 3 — column existence** (new class mirroring
+   `TestCapTestSpectralCorrection`): both `poa_spec_corrected` and `e_total`
+   columns exist on meas & sim for both presets.
+
+5. **Layer 4 — integration** (`TestIntegration`): `test_end_to_end_*_sim` /
+   `_meas` run the canonical sequence to `0.8 < cap_ratio < 1.2` and assert
+   `regression_cols["poa"] == "e_total"`.
+
+## TDD flow
+
+The dict already exists; the code-under-test being driven red->green is the
+scatter switch, the new fixtures, and the exclusion. For each test: write it,
+watch it fail for the right reason, make the minimal source/fixture/exclusion
+change, confirm green, then run the full suite + `just lint` / `just fmt`.
+
+## Plan chunking (for writing-plans)
+
+Per the user's preference for fine-grained, sequentially-reviewed plans:
+
+1. Source touch-ups (`scatter_etotal`, `just fmt`) + `_DEFAULT_FIXTURE_PRESETS`
+   exclusion fix.
+2. Layer 1 structural tests.
+3. Fixtures + Layer 2 propagation tests.
+4. Layer 3 column-existence + Layer 4 integration tests.
+
+## Skill notes — repeatable checklist for "adding a test setup"
+
+Captured while doing this work, for the future skill. Two more presets remain to
+be added after these.
+
+1. Add the dict entry to `TEST_SETUPS`.
+2. Validate it: `validate_test_setup(entry)` and `resolve_test_setup(name)`; run a
+   quick end-to-end probe (`CapTest.from_params(...)`) to confirm columns
+   materialize and regression cols resolve.
+3. Run `just fmt` — dict-literal indentation drift is silent and easy to
+   introduce.
+4. Choose the scatter callable (`scatter_default` / `scatter_etotal` /
+   `scatter_bifi_power_tc`) to match the regression form, consistent with sibling
+   presets.
+5. Map the preset's required `column_groups`, `cd.site`, and sim columns. Reuse an
+   existing fixture if one already supplies them; only add a fixture when none
+   does.
+6. If the default fixtures don't satisfy the preset, add the preset to the
+   `_DEFAULT_FIXTURE_PRESETS` exclusion set (otherwise the parametrized setup /
+   rep_cond round-trip tests break).
+7. Add the 4 test layers: structural calc-tree, downstream-scalar propagation,
+   end-to-end column existence, end-to-end integration to a cap ratio.
+8. Add a `ct_*` CapTest fixture; for spectral presets, pre-set `sim.site` to avoid
+   the site-propagation `UserWarning` at fixture setup.
+9. Run the full suite + `just lint` / `just fmt`.
+
+### Known gotchas
+- Dict-literal over-indentation passes Python and tests but fails formatting.
+- The parametrized registry tests (`test_each_shipped_preset_validates`, etc.)
+  auto-cover new presets — no work — but the `_DEFAULT_FIXTURE_PRESETS`-driven
+  tests will break unless the preset is excluded.
+- `scatter_etotal` and `scatter_default` are currently identical bodies; the
+  choice is about intent/consistency, not runtime behavior.
+- Spectral presets emit a "Propagating meas.site" `UserWarning` when `sim` has no
+  `site`; pre-set `sim.site` in fixtures to keep integration tests quiet.

--- a/docs/superpowers/specs/2026-06-09-spec-corrected-etotal-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-09-spec-corrected-etotal-test-coverage-design.md
@@ -7,8 +7,8 @@
 
 Two new entries were added to `TEST_SETUPS` in `src/captest/captest.py`:
 
-- `bifi_e2848_spec_corrected_etotal_rear_shade_sim`
-- `bifi_e2848_spec_corrected_etotal_rear_shade_meas`
+- `bifi_e2848_etotal_rear_shade_sim_spec_corrected`
+- `bifi_e2848_etotal_rear_shade_meas_spec_corrected`
 
 They combine the First Solar spectral correction (front POA) with the bifacial
 total-effective-irradiance (`e_total`) regression, splitting rear-shade handling

--- a/docs/user_guide/bifacial.rst
+++ b/docs/user_guide/bifacial.rst
@@ -6,7 +6,7 @@ Bifacial Tests
 
 
 .. note::
-   The manual approach described in this section can still be implemented, but the preferred approach to bifacial capacity testing as of v0.15.0 is to use one of the default test setups (`bifi_e2848_etotal` or `bifi_power_tc`) or write a `regression_columns` dictionary that will provide the calculated regressors when processed by `process_regression_columns`.
+   The manual approach described in this section can still be implemented, but the preferred approach to bifacial capacity testing as of v0.15.0 is to use one of the default test setups (`bifi_e2848_etotal_rear_shade_sim`, `bifi_e2848_etotal_rear_shade_meas`, or `bifi_power_tc_calc_tbom`) or write a `regression_columns` dictionary that will provide the calculated regressors when processed by `process_regression_columns`.
 
 This section discusses how pvcaptest can be used to conduct a capacity test for a project with bifacial modules.
 

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -65,7 +65,8 @@ A test setup is a named preset that bundles everything needed to configure
 the regression for a capacity test. Each setup defines:
 
 - **Regression formula** — the model equation, such as the standard ASTM E2848
-  four-term formula or the bifacial temperature-corrected power formula.
+  four-term formula or the bifacial temperature-corrected power formula (see
+  :ref:`identifying-regression-data`).
 - **Measured column mappings** (``reg_cols_meas``) — which measured data columns
   map to each regression variable, how multiple sensors are aggregated (sum or
   mean), and any calculated columns required by the setup (e.g. ``e_total``,
@@ -81,8 +82,25 @@ the regression for a capacity test. Each setup defines:
 See :ref:`custom_test_setups` for additional details and example.
 
 The complete list of built-in presets, with a description of each, is in
-:ref:`test-setups` in the API reference. The most commonly used options are
-described below:
+:ref:`test-setups` in the API reference. You can also print the available
+setup names at any time by calling ``captest.captest.test_setups()`` (pass
+``descriptions=True`` to also print each setup's summary):
+
+.. code-block:: Python
+
+    >>> from captest import captest
+    >>> captest.captest.test_setups()
+    All options
+    ============================================================
+    e2848_default
+    bifi_e2848_etotal_rear_shade_sim
+    bifi_e2848_etotal_rear_shade_meas
+    bifi_power_tc_meas_tbom
+    bifi_power_tc_calc_tbom
+    ...
+    bifi_e2848_etotal_rear_shade_meas_spec_corrected
+
+The most commonly used options are described below:
 
 ``e2848_default``
     Standard ASTM E2848 regression:
@@ -105,8 +123,7 @@ described below:
     .. math::
         E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi
 
-    where :math:`\varphi` is the bifaciality factor. This is useful for the
-    NREL modified bifacial approach described in :ref:`bifacial`.
+    where :math:`\varphi` is the bifaciality factor.
 
 ``bifi_e2848_etotal_rear_shade_meas``
     Same regression form as ``bifi_e2848_etotal_rear_shade_sim``, but rear
@@ -115,14 +132,14 @@ described below:
     unshaded global rear (``GlobBak``).
 
     .. math::
-        E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi\left(1 - s\right)
-
-    .. math::
         E_{Total}^{model} = E_{POA} + GlobBak \cdot \varphi
 
+    .. math::
+        E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi\left(1 - s\right)
+
+
     where :math:`\varphi` is the bifaciality factor and :math:`s` is the
-    ``rear_shade`` fraction. Use this when rear-shading losses are better
-    characterized from the measured array than from the PVsyst model.
+    ``rear_shade`` fraction. 
 
 ``bifi_power_tc_meas_tbom``
     Uses temperature-corrected power as the dependent variable and regresses it

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -83,13 +83,13 @@ See :ref:`custom_test_setups` for additional details and example.
 
 The complete list of built-in presets, with a description of each, is in
 :ref:`test-setups` in the API reference. You can also print the available
-setup names at any time by calling ``captest.captest.test_setups()`` (pass
-``descriptions=True`` to also print each setup's summary):
+setup names at any time by calling :py:func:`~captest.captest.test_setups`
+(pass ``descriptions=True`` to also print each setup's summary):
 
 .. code-block:: Python
 
-    >>> from captest import captest
-    >>> captest.captest.test_setups()
+    >>> import captest as ct
+    >>> ct.test_setups()
     All options
     ============================================================
     e2848_default
@@ -118,7 +118,7 @@ The most commonly used options are described below:
     (``irr_rpoa``) is used as-measured (``rear_shade = 0``).
 
     .. math::
-        E_{Total}^{model} = E_{POA} + \left(E_{Rear} + E_{BackShd}\right)\varphi
+        E_{Total}^{model} = E_{POA} + \left(GlobBak + BackShd\right)\varphi
 
     .. math::
         E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -53,6 +53,8 @@ directly. That workflow is mostly unchanged and may be helpful while learning pv
   :py:meth:`~captest.captest.CapTest.residual_plot` to use the same measured
   and modeled data automatically.
 
+.. _choosing-test-setup:
+
 Choosing a test setup
 ---------------------
 The ``test_setup`` value tells pvcaptest which regression equation and default
@@ -78,7 +80,9 @@ the regression for a capacity test. Each setup defines:
 
 See :ref:`custom_test_setups` for additional details and example.
 
-The built-in options are:
+The complete list of built-in presets, with a description of each, is in
+:ref:`test-setups` in the API reference. The most commonly used options are
+described below:
 
 ``e2848_default``
     Standard ASTM E2848 regression:
@@ -140,6 +144,15 @@ The built-in options are:
     precipitable water from the PVsyst output. See :ref:`spec_corrected_poa`
     for the additional inputs.
 
+The remaining built-in presets combine the pieces above — total-irradiance
+variants of the temperature-corrected power setups
+(``bifi_power_tc_etotal_rear_shade_sim``,
+``bifi_power_tc_etotal_rear_shade_meas``) and spectrally corrected
+total-irradiance setups
+(``bifi_e2848_etotal_rear_shade_sim_spec_corrected``,
+``bifi_e2848_etotal_rear_shade_meas_spec_corrected``). See :ref:`test-setups`
+in the API reference for their descriptions.
+
 .. note::
 
     The built-in setup names are strings. For example,
@@ -154,17 +167,16 @@ The built-in options are:
     The IDs hardcoded into the built-in setups are:
 
     - ``irr_poa`` — front-side plane-of-array irradiance (all setups)
-    - ``irr_rpoa`` — rear-side plane-of-array irradiance
-      (``bifi_e2848_etotal_rear_shade_sim``,
-      ``bifi_e2848_etotal_rear_shade_meas``, ``bifi_power_tc_meas_tbom``,
-      ``bifi_power_tc_calc_tbom``)
-    - ``temp_bom`` — back-of-module temperature
-      (``bifi_power_tc_meas_tbom`` only)
+    - ``irr_rpoa`` — rear-side plane-of-array irradiance (all bifacial setups)
+    - ``temp_bom`` — back-of-module temperature (temperature-corrected setups
+      using measured BOM temperature: ``bifi_power_tc_meas_tbom``,
+      ``bifi_power_tc_etotal_rear_shade_sim``,
+      ``bifi_power_tc_etotal_rear_shade_meas``)
     - ``real_pwr_mtr`` — AC power meter (all setups)
     - ``temp_amb`` — ambient temperature (all setups)
     - ``wind_speed`` — wind speed (all setups)
-    - ``humidity`` — relative humidity (``e2848_spec_corrected_poa`` only)
-    - ``pressure`` — station pressure (``e2848_spec_corrected_poa`` only)
+    - ``humidity`` — relative humidity (spectrally corrected setups)
+    - ``pressure`` — station pressure (spectrally corrected setups)
 
     .. warning::
 
@@ -292,6 +304,7 @@ setup and the temperature-corrected power setup.
     ct_power_tc = CapTest.from_yaml('./project.yaml', key='captest_bifi_power_tc')
 
 .. _what-setup-does:
+
 What setup does
 ---------------
 When ``CapTest`` has both measured and modeled data, it prepares each

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -88,15 +88,37 @@ The built-in options are:
 
     This is the default setup for monofacial capacity tests.
 
-``bifi_e2848_etotal``
+``bifi_e2848_etotal_rear_shade_sim``
     Uses the standard ASTM E2848 regression form, but replaces front-side POA
-    with total irradiance:
+    with total irradiance. Rear shading and IAM losses are handled in the
+    modeled (PVsyst) data: the modeled rear irradiance is
+    ``rpoa_pvsyst = GlobBak + BackShd``, while the measured rear sensor
+    (``irr_rpoa``) is used as-measured (``rear_shade = 0``).
 
     .. math::
-        E_{Total} = E_{POA} + E_{Rear} \varphi
+        E_{Total}^{model} = E_{POA} + \left(E_{Rear} + E_{BackShd}\right)\varphi
+
+    .. math::
+        E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi
 
     where :math:`\varphi` is the bifaciality factor. This is useful for the
     NREL modified bifacial approach described in :ref:`bifacial`.
+
+``bifi_e2848_etotal_rear_shade_meas``
+    Same regression form as ``bifi_e2848_etotal_rear_shade_sim``, but rear
+    shading is applied on the measured side as a flat fraction :math:`s` (the
+    ``rear_shade`` factor), while the modeled rear maps directly to PVsyst's
+    unshaded global rear (``GlobBak``).
+
+    .. math::
+        E_{Total}^{meas} = E_{POA} + E_{Rear}\,\varphi\left(1 - s\right)
+
+    .. math::
+        E_{Total}^{model} = E_{POA} + GlobBak \cdot \varphi
+
+    where :math:`\varphi` is the bifaciality factor and :math:`s` is the
+    ``rear_shade`` fraction. Use this when rear-shading losses are better
+    characterized from the measured array than from the PVsyst model.
 
 ``bifi_power_tc_meas_tbom``
     Uses temperature-corrected power as the dependent variable and regresses it
@@ -122,7 +144,8 @@ The built-in options are:
 
     The built-in setup names are strings. For example,
     ``test_setup='e2848_default'`` uses the standard ASTM E2848 setup, and
-    ``test_setup='bifi_e2848_etotal'`` uses the total-irradiance bifacial setup.
+    ``test_setup='bifi_e2848_etotal_rear_shade_sim'`` uses the total-irradiance
+    bifacial setup.
 
 .. note:: 
 
@@ -132,7 +155,8 @@ The built-in options are:
 
     - ``irr_poa`` — front-side plane-of-array irradiance (all setups)
     - ``irr_rpoa`` — rear-side plane-of-array irradiance
-      (``bifi_e2848_etotal``, ``bifi_power_tc_meas_tbom``,
+      (``bifi_e2848_etotal_rear_shade_sim``,
+      ``bifi_e2848_etotal_rear_shade_meas``, ``bifi_power_tc_meas_tbom``,
       ``bifi_power_tc_calc_tbom``)
     - ``temp_bom`` — back-of-module temperature
       (``bifi_power_tc_meas_tbom`` only)
@@ -166,7 +190,7 @@ If you provide paths to your data, ``CapTest`` will load the data for you.
 .. code-block:: Python
 
     ct = CapTest.from_params(
-        test_setup='bifi_e2848_etotal',
+        test_setup='bifi_e2848_etotal_rear_shade_sim',
         meas_path='./data/measured/',
         sim_path='./data/pvsyst_results.csv',
         bifaciality=0.15,
@@ -225,7 +249,7 @@ file and loaded with :py:meth:`~captest.captest.CapTest.from_yaml`.
 .. code-block:: yaml
 
     captest:
-      test_setup: bifi_e2848_etotal
+      test_setup: bifi_e2848_etotal_rear_shade_sim
       meas_path: ./data/measured/
       sim_path: ./data/pvsyst.csv
       ac_nameplate: 6_000_000
@@ -249,7 +273,7 @@ setup and the temperature-corrected power setup.
 .. code-block:: yaml
 
     captest_bifi_etotal:
-      test_setup: bifi_e2848_etotal
+      test_setup: bifi_e2848_etotal_rear_shade_sim
       meas_path: ./data/measured/
       sim_path: ./data/pvsyst.csv
       ac_nameplate: 6_000_000

--- a/docs/user_guide/custom_test_setups.rst
+++ b/docs/user_guide/custom_test_setups.rst
@@ -2,7 +2,8 @@
 
 Custom Test Setups
 ==================
-The built-in ``test_setup`` presets (``e2848_default``, ``bifi_e2848_etotal``,
+The built-in ``test_setup`` presets (``e2848_default``,
+``bifi_e2848_etotal_rear_shade_sim``, ``bifi_e2848_etotal_rear_shade_meas``,
 ``bifi_power_tc_meas_tbom``, ``bifi_power_tc_calc_tbom``, ``e2848_spec_corrected_poa``)
 cover the most common capacity-test configurations. When a project calls for a
 different regression equation or a non-standard column calculation, pvcaptest lets

--- a/docs/user_guide/dataload.rst
+++ b/docs/user_guide/dataload.rst
@@ -167,6 +167,8 @@ simulated :py:class:`~captest.capdata.CapData` instances bound to a
 the two models differ across the range of each predictor variable. See
 :ref:`captest` for the full workflow.
 
+.. _identifying-regression-data:
+
 Identifying Regression Data
 ---------------------------
 To perform the regression pvcaptest uses `statsmodels <https://www.statsmodels.org/stable/index.html>`_, which in turn `relies on patsy <https://www.statsmodels.org/stable/examples/notebooks/generated/formulas.html>`_ to simplify specifying regression equations.

--- a/src/captest/__init__.py
+++ b/src/captest/__init__.py
@@ -19,6 +19,7 @@ from captest.captest import (
     CapTest as CapTest,
     TEST_SETUPS as TEST_SETUPS,
     load_config as load_config,
+    test_setups as test_setups,
 )
 
 try:

--- a/src/captest/calcparams.py
+++ b/src/captest/calcparams.py
@@ -262,8 +262,8 @@ def e_total(
         print(
             f'Calculating and adding "{e_total.__name__}" column as '
             f"{poa} + {rpoa} * "
-            f"{bifaciality} * {bifacial_frac} * "
-            f"(1 - {rear_shade})"
+            f"{bifaciality} (bifaciality) * {bifacial_frac} (bifacial fraction) * "
+            f"(1 - {rear_shade} (rear shade))"
         )
     return data[poa] + data[rpoa] * bifaciality * bifacial_frac * (1 - rear_shade)
 

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1993,7 +1993,15 @@ class CapData(object):
             columns_to_aggregate = self._get_group(group_id)
         else:
             columns_to_aggregate = columns
-        agg_result = columns_to_aggregate.agg(agg_func, axis=1)
+        # pandas sum() defaults to min_count=0, so a row where every column is
+        # NaN sums to 0.0 instead of NaN. Pass min_count=1 for sum aggregations
+        # so all-NaN rows remain NaN (missing) rather than being treated as real
+        # zeros. This matters for single-column power groups where summing is a
+        # no-op but would otherwise convert NaN to 0.0.
+        if isinstance(agg_func, str) and agg_func == "sum":
+            agg_result = columns_to_aggregate.agg(agg_func, axis=1, min_count=1)
+        else:
+            agg_result = columns_to_aggregate.agg(agg_func, axis=1)
         col_name = util.get_agg_column_name(group_id, agg_func)
         self.column_groups.setdefault("agg", []).append(col_name)
         agg_result = agg_result.rename(col_name).to_frame()

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -1988,6 +1988,13 @@ class CapData(object):
             Pre-fetched DataFrame of columns to aggregate. When provided the
             lookup via ``self._get_group`` is skipped. Intended for internal use
             by ``agg_sensors`` to avoid a redundant lookup.
+
+        Notes
+        -----
+        When ``agg_func`` is ``"sum"`` the aggregation is performed with
+        ``min_count=1`` so that a row in which every column is ``NaN`` returns
+        ``NaN`` rather than ``0.0`` (the pandas default). Rows with at least one
+        value still skip ``NaN`` and sum the remaining values.
         """
         if columns is None:
             columns_to_aggregate = self._get_group(group_id)

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -490,6 +490,206 @@ TEST_SETUPS = {
             },
         },
     },
+    "bifi_e2848_spec_corrected_etotal_rear_shade_sim": {
+        "description": (
+            "Standard ASTM E2848 regression with total effective irradiance replacing "
+            "front POA and a First Solar spectral correction applied to "
+            "front-side POA irradiance used to calculate the total POA irradiance. "
+            "Requires relative humidity and atmospheric "
+            "pressure on the measured side and precipitable water from the PVsyst output. "
+            "Rear shading and IAM losses are handled in the modeled (PVsyst) "
+            "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
+            "BackShd, while the measured rear sensor (irr_rpoa) is used "
+            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
+            "variant that instead applies rear shading on the measured side, "
+            "see 'bifi_e2848_spec_corrected_etotal_rear_shade_meas'. Total irradiance is "
+            "E_Total = E_POA + E_Rear * bifaciality with the spectral correction "
+            "applied to E_POA. "
+        ),
+        "reg_cols_meas": {
+            "power": ("real_pwr_mtr", "sum"),
+            "poa": (
+                e_total,
+                {
+                    "poa": (  # front POA: spectrally corrected
+                        poa_spec_corrected,
+                        {
+                            "poa": ("irr_poa", "mean"),
+                            "spectral_correction": (
+                                spectral_factor_firstsolar,
+                                {
+                                    "precipitable_water": (
+                                        precipitable_water_gueymard,
+                                        {
+                                            "temp_amb": ("temp_amb", "mean"),
+                                            "rel_humidity": ("humidity", "mean"),
+                                        },
+                                    ),
+                                    "absolute_airmass": (
+                                        absolute_airmass,
+                                        {
+                                            "apparent_zenith": (apparent_zenith, {}),
+                                            "pressure": ("pressure", "mean"),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    "rpoa": ("irr_rpoa", "mean"),  # rear POA: unchanged
+                },
+            ),
+            "t_amb": ("temp_amb", "mean"),
+            "w_vel": ("wind_speed", "mean"),
+        },
+        "reg_cols_sim": {
+            "power": "E_Grid",
+            "poa": (
+                e_total,
+                {
+                    "poa": (  # front POA: spectrally corrected
+                        poa_spec_corrected,
+                        {
+                            "poa": "GlobInc",
+                            "spectral_correction": (
+                                spectral_factor_firstsolar,
+                                {
+                                    "precipitable_water": (
+                                        scale,
+                                        {"col": "PrecWat", "factor": 100},
+                                    ),
+                                    "absolute_airmass": (
+                                        absolute_airmass,
+                                        {
+                                            "apparent_zenith": (
+                                                apparent_zenith_pvsyst,
+                                                {},
+                                            ),
+                                            # no pressure col: PVsyst uses sea-level default
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    "rpoa": (  # rear POA: unchanged
+                        rpoa_pvsyst,
+                        {"globbak": "GlobBak", "backshd": "BackShd"},
+                    ),
+                },
+            ),
+            "t_amb": "T_Amb",
+            "w_vel": "WindVel",
+        },
+        "reg_fml": "power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1",
+        "scatter_plots": scatter_etotal,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "func": {
+                "poa": perc_wrap(60),
+                "t_amb": "mean",
+                "w_vel": "mean",
+            },
+        },
+    },
+    "bifi_e2848_spec_corrected_etotal_rear_shade_meas": {
+        "description": (
+            "Standard ASTM E2848 regression with total effective irradiance replacing "
+            "front POA and a First Solar spectral correction applied to "
+            "front-side POA irradiance used to calculate the total POA irradiance. "
+            "Requires relative humidity and atmospheric "
+            "pressure on the measured side and precipitable water from the PVsyst output. "
+            "The modeled rear irradiance maps directly to PVsyst's unshaded global rear "
+            "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
+            "to the measured side through the e_total 'rear_shade' factor "
+            "(propagated by CapTest to the measured CapData only). Total "
+            "irradiance is E_Total = E_POA + E_Rear * bifaciality * (1 - rear_shade)."
+        ),
+        "reg_cols_meas": {
+            "power": ("real_pwr_mtr", "sum"),
+            "poa": (
+                e_total,
+                {
+                    "poa": (
+                        poa_spec_corrected,
+                        {
+                            "poa": ("irr_poa", "mean"),
+                            "spectral_correction": (
+                                spectral_factor_firstsolar,
+                                {
+                                    "precipitable_water": (
+                                        precipitable_water_gueymard,
+                                        {
+                                            "temp_amb": ("temp_amb", "mean"),
+                                            "rel_humidity": ("humidity", "mean"),
+                                        },
+                                    ),
+                                    "absolute_airmass": (
+                                        absolute_airmass,
+                                        {
+                                            "apparent_zenith": (apparent_zenith, {}),
+                                            "pressure": ("pressure", "mean"),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    "rpoa": ("irr_rpoa", "mean"),
+                },
+            ),
+            "t_amb": ("temp_amb", "mean"),
+            "w_vel": ("wind_speed", "mean"),
+        },
+        "reg_cols_sim": {
+            "power": "E_Grid",
+            "poa": (
+                e_total,
+                {
+                    "poa": (  # front POA: spectrally corrected
+                        poa_spec_corrected,
+                        {
+                            "poa": "GlobInc",
+                            "spectral_correction": (
+                                spectral_factor_firstsolar,
+                                {
+                                    "precipitable_water": (
+                                        scale,
+                                        {"col": "PrecWat", "factor": 100},
+                                    ),
+                                    "absolute_airmass": (
+                                        absolute_airmass,
+                                        {
+                                            "apparent_zenith": (
+                                                apparent_zenith_pvsyst,
+                                                {},
+                                            ),
+                                            # no pressure col: PVsyst uses sea-level default
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    "rpoa": "GlobBak",
+                },
+            ),
+            "t_amb": "T_Amb",
+            "w_vel": "WindVel",
+        },
+        "reg_fml": "power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1",
+        "scatter_plots": scatter_etotal,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "func": {
+                "poa": perc_wrap(60),
+                "t_amb": "mean",
+                "w_vel": "mean",
+            },
+        },
+    },
 }
 
 _TEST_SETUP_REQUIRED_KEYS = frozenset(

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -838,6 +838,14 @@ _CAPTEST_OVERRIDE_KEYS = frozenset(
     {"reg_cols_meas", "reg_cols_sim", "reg_fml", "rep_conditions"}
 )
 
+# Keys whose ``None`` (yaml ``null``) value is a distinct, meaningful value
+# rather than a request to fall back to the param default. These are NOT
+# stripped by ``from_mapping`` so the value round-trips through ``to_yaml`` /
+# ``from_yaml``. ``altitude_override`` is the only such key: it has a non-None
+# default (0, the sea-level convention) but allows ``None`` to mean "respect
+# the site's own altitude".
+_CAPTEST_NONE_MEANINGFUL_KEYS = frozenset({"altitude_override"})
+
 
 def _default_meas_loader():
     """Return the default measured-data loader (``captest.io.load_data``).
@@ -1194,7 +1202,9 @@ class CapTest(param.Parameterized):
     # Class-level tuple of param names to copy onto the CapData instances
     # during setup(). Names also listed in _downstream_attrs_meas_only are
     # copied onto meas only; all others are copied onto both meas and sim.
-    # Extending is a one-line edit.
+    # Extending is a one-line edit. Invariant: every name in
+    # _downstream_attrs_meas_only MUST also appear in _downstream_attrs, since
+    # setup() iterates _downstream_attrs (guarded by a subset test).
     _downstream_attrs = (
         "bifaciality",
         "bifacial_frac",
@@ -1440,8 +1450,14 @@ class CapTest(param.Parameterized):
                 )
             kwargs[path_key] = _join_base_and_relative(base_dir, val_str)
 
-        # ``null`` (None) in yaml is equivalent to omitting the key.
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        # ``null`` (None) in yaml is equivalent to omitting the key, except
+        # for keys where None is a distinct, meaningful value (see
+        # _CAPTEST_NONE_MEANINGFUL_KEYS) and must survive the round trip.
+        kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if v is not None or k in _CAPTEST_NONE_MEANINGFUL_KEYS
+        }
 
         # Inject programmatic-only loader callables. Explicit kwargs win
         # over any value that happened to slip through the sub-mapping

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -490,7 +490,7 @@ TEST_SETUPS = {
             },
         },
     },
-    "bifi_e2848_spec_corrected_etotal_rear_shade_sim": {
+    "bifi_e2848_etotal_rear_shade_sim_spec_corrected": {
         "description": (
             "Standard ASTM E2848 regression with total effective irradiance replacing "
             "front POA and a First Solar spectral correction applied to "
@@ -502,7 +502,7 @@ TEST_SETUPS = {
             "BackShd, while the measured rear sensor (irr_rpoa) is used "
             "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
             "variant that instead applies rear shading on the measured side, "
-            "see 'bifi_e2848_spec_corrected_etotal_rear_shade_meas'. Total irradiance is "
+            "see 'bifi_e2848_etotal_rear_shade_meas_spec_corrected'. Total irradiance is "
             "E_Total = E_POA + E_Rear * bifaciality with the spectral correction "
             "applied to E_POA. "
         ),
@@ -593,7 +593,7 @@ TEST_SETUPS = {
             },
         },
     },
-    "bifi_e2848_spec_corrected_etotal_rear_shade_meas": {
+    "bifi_e2848_etotal_rear_shade_meas_spec_corrected": {
         "description": (
             "Standard ASTM E2848 regression with total effective irradiance replacing "
             "front POA and a First Solar spectral correction applied to "

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -21,6 +21,7 @@ import difflib
 import importlib.util
 import warnings
 from pathlib import Path
+import textwrap
 
 import numpy as np
 import pandas as pd
@@ -834,6 +835,26 @@ _TEST_SETUP_REQUIRED_KEYS = frozenset(
     }
 )
 
+def test_setups(options=True, descriptions=False):
+    """
+    Display test setups available.
+    """
+    if options:
+        print('All options')
+        print('=' * 60)
+        for name in TEST_SETUPS.keys():
+            print(name)
+
+    if descriptions:
+        if options:
+            print('\n\n')
+        print('Descriptions')
+        print('=' * 60)
+        for name, setup in TEST_SETUPS.items():
+            print('\n')
+            print(f'{name}')
+            print('-' * 60)
+            print(textwrap.fill(setup['description'], 60))
 
 def validate_test_setup(entry):
     """Validate a single ``TEST_SETUPS`` entry dict.

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -835,6 +835,7 @@ _TEST_SETUP_REQUIRED_KEYS = frozenset(
     }
 )
 
+
 def test_setups(options=True, descriptions=False):
     """
     Display test setups available.
@@ -851,21 +852,22 @@ def test_setups(options=True, descriptions=False):
     None
     """
     if options:
-        print('All options')
-        print('=' * 60)
+        print("All options")
+        print("=" * 60)
         for name in TEST_SETUPS.keys():
             print(name)
 
     if descriptions:
         if options:
-            print('\n\n')
-        print('Descriptions')
-        print('=' * 60)
+            print("\n\n")
+        print("Descriptions")
+        print("=" * 60)
         for name, setup in TEST_SETUPS.items():
-            print('\n')
-            print(f'{name}')
-            print('-' * 60)
-            print(textwrap.fill(setup['description'], 60))
+            print("\n")
+            print(f"{name}")
+            print("-" * 60)
+            print(textwrap.fill(setup["description"], 60))
+
 
 def validate_test_setup(entry):
     """Validate a single ``TEST_SETUPS`` entry dict.

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -838,6 +838,17 @@ _TEST_SETUP_REQUIRED_KEYS = frozenset(
 def test_setups(options=True, descriptions=False):
     """
     Display test setups available.
+
+    Parameters
+    ----------
+    options: bool, default True
+        List the names of the test setups.
+    descriptions: bool, default False
+        List the descriptions of the test setups.
+
+    Returns
+    -------
+    None
     """
     if options:
         print('All options')
@@ -2524,5 +2535,6 @@ __all__ = [
     "scatter_bifi_power_tc",
     "scatter_default",
     "scatter_etotal",
+    "test_setups",
     "validate_test_setup",
 ]

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -410,6 +410,137 @@ TEST_SETUPS = {
             },
         },
     },
+    "bifi_power_tc_etotal_rear_shade_sim": {
+        "description": (
+            "The regression equation is temperature corrected power regressed against "
+            "total POA irradiance. The back of module temperature is from field "
+            "measurements and the cell temperature is calculated using the Sandia PV Array "
+            "Performance Model from the POA irradiance and measured BOM temperature. "
+            "Note that the PVsyst temperature correction uses the 'TArray' output variable. "
+            "Rear shading and IAM losses are handled in the modeled (PVsyst) "
+            "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
+            "BackShd, while the measured rear sensor (irr_rpoa) is used "
+            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
+            "variant that instead applies rear shading on the measured side, "
+            "see 'bifi_power_tc_etotal_rear_shade_meas'. Total irradiance is "
+            "E_Total = E_POA + E_Rear * bifaciality, following the NREL "
+            "modified bifacial approach."
+        ),
+        "reg_cols_meas": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": ("real_pwr_mtr", "sum"),
+                    "cell_temp": (
+                        cell_temp,
+                        {
+                            "poa": ("irr_poa", "mean"),
+                            "bom": ("temp_bom", "mean"),
+                        },
+                    ),
+                },
+            ),
+            "poa": (
+                e_total,
+                {
+                    "poa": ("irr_poa", "mean"),
+                    "rpoa": ("irr_rpoa", "mean"),
+                },
+            ),
+        },
+        "reg_cols_sim": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": "E_Grid",
+                    "cell_temp": "TArray",
+                },
+            ),
+            "poa": (
+                e_total,
+                {
+                    "poa": "GlobInc",
+                    "rpoa": (
+                        rpoa_pvsyst,
+                        {"globbak": "GlobBak", "backshd": "BackShd"},
+                    ),
+                },
+            ),
+        },
+        "reg_fml": "power ~ poa",
+        "scatter_plots": scatter_etotal,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "func": {
+                "poa": perc_wrap(60),
+            },
+        },
+    },
+    "bifi_power_tc_etotal_rear_shade_meas": {
+        "description": (
+            "The regression equation is temperature corrected power regressed against "
+            "total POA irradiance. The back of module temperature is from field "
+            "measurements and the cell temperature is calculated using the Sandia PV Array "
+            "Performance Model from the POA irradiance and measured BOM temperature. "
+            "Note that the PVsyst temperature correction uses the 'TArray' output variable. "
+            "Variant of 'bifi_power_tc_etotal_rear_shade_sim' for applying "
+            "rear-shading losses on the measured side. The modeled rear "
+            "irradiance maps directly to PVsyst's unshaded global rear "
+            "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
+            "to the measured side through the e_total 'rear_shade' factor "
+            "(propagated by CapTest to the measured CapData only). Total "
+            "irradiance is E_Total = E_POA + E_Rear * bifaciality * "
+            "(1 - rear_shade)."
+        ),
+        "reg_cols_meas": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": ("real_pwr_mtr", "sum"),
+                    "cell_temp": (
+                        cell_temp,
+                        {
+                            "poa": ("irr_poa", "mean"),
+                            "bom": ("temp_bom", "mean"),
+                        },
+                    ),
+                },
+            ),
+            "poa": (
+                e_total,
+                {
+                    "poa": ("irr_poa", "mean"),
+                    "rpoa": ("irr_rpoa", "mean"),
+                },
+            ),
+        },
+        "reg_cols_sim": {
+            "power": (
+                power_temp_correct,
+                {
+                    "power": "E_Grid",
+                    "cell_temp": "TArray",
+                },
+            ),
+            "poa": (
+                e_total,
+                {
+                    "poa": "GlobInc",
+                    "rpoa": "GlobBak",
+                },
+            ),
+        },
+        "reg_fml": "power ~ poa",
+        "scatter_plots": scatter_etotal,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "func": {
+                "poa": perc_wrap(60),
+            },
+        },
+    },
     "e2848_spec_corrected_poa": {
         "description": (
             "Standard ASTM E2848 regression with a First Solar spectral correction applied to "

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -312,9 +312,9 @@ TEST_SETUPS = {
     "bifi_power_tc_meas_tbom": {
         "description": (
             "The regression equation is temperature corrected power regressed against "
-            "front POA and rear POA. The back of module temperature is from field"
+            "front POA and rear POA. The back of module temperature is from field "
             "measurements and the cell temperature is calculated using the Sandia PV Array "
-            "Performance Model from the POA irradiance and measured BOM temperature."
+            "Performance Model from the POA irradiance and measured BOM temperature. "
             "Note that the PVsyst temperature correction uses the 'TArray' output variable."
         ),
         "reg_cols_meas": {

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -254,6 +254,51 @@ TEST_SETUPS = {
             },
         },
     },
+    "bifi_e2848_etotal_meas_shade": {
+        "description": (
+            "Variant of 'bifi_e2848_etotal' for applying rear-shading losses on the "
+            "measured side. The modeled rear irradiance maps directly to PVsyst's "
+            "unshaded global rear ('GlobBak') instead of rpoa_pvsyst, and rear shading "
+            "is applied to the measured side through the e_total 'rear_shade' factor "
+            "(propagated by CapTest to the measured CapData only). Total irradiance is "
+            "E_Total = E_POA + E_Rear * bifaciality * (1 - rear_shade)."
+        ),
+        "reg_cols_meas": {
+            "power": ("real_pwr_mtr", "sum"),
+            "poa": (
+                e_total,
+                {
+                    "poa": ("irr_poa", "mean"),
+                    "rpoa": ("irr_rpoa", "mean"),
+                },
+            ),
+            "t_amb": ("temp_amb", "mean"),
+            "w_vel": ("wind_speed", "mean"),
+        },
+        "reg_cols_sim": {
+            "power": "E_Grid",
+            "poa": (
+                e_total,
+                {
+                    "poa": "GlobInc",
+                    "rpoa": "GlobBak",
+                },
+            ),
+            "t_amb": "T_Amb",
+            "w_vel": "WindVel",
+        },
+        "reg_fml": "power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1",
+        "scatter_plots": scatter_etotal,
+        "rep_conditions": {
+            "irr_bal": False,
+            "percent_filter": 20,
+            "func": {
+                "poa": perc_wrap(60),
+                "t_amb": "mean",
+                "w_vel": "mean",
+            },
+        },
+    },
     "bifi_power_tc_meas_tbom": {
         "description": (
             "The regression equation is temperature corrected power regressed against "
@@ -771,9 +816,15 @@ _CAPTEST_YAML_KEYS = frozenset(
         "irrad_stability_threshold",
         "hrs_req",
         "bifaciality",
+        "bifacial_frac",
+        "rear_shade",
         "power_temp_coeff",
         "base_temp",
+        "module_type",
+        "racking",
         "spectral_module_type",
+        "airmass_model",
+        "altitude_override",
         "meas_load_kwargs",
         "sim_load_kwargs",
         "meas_path",
@@ -889,9 +940,21 @@ class CapTest(param.Parameterized):
         Threshold value for ``irrad_stability``.
     hrs_req : float
         Hours of data required for a complete test. Default 12.5.
-    bifaciality, power_temp_coeff, base_temp : float
-        Calc-params scalars propagated onto both ``CapData`` instances at
-        ``setup()``. See ``_downstream_attrs``.
+    bifaciality, bifacial_frac, power_temp_coeff, base_temp, altitude_override : float
+        Numeric calc-params scalars propagated to both CapData instances at
+        setup(). See ``_downstream_attrs``.
+    module_type, racking, airmass_model, spectral_module_type : str
+        String calc-params options propagated to both CapData instances at
+        setup(). ``module_type``/``racking`` feed the Sandia temperature
+        model (``calcparams.bom_temp`` / ``calcparams.cell_temp``);
+        ``airmass_model`` feeds ``calcparams.absolute_airmass``;
+        ``spectral_module_type`` feeds
+        ``calcparams.spectral_factor_firstsolar``.
+    rear_shade : float
+        Fraction of rear irradiance lost to shading, propagated to the
+        measured CapData instance only (see ``_downstream_attrs_meas_only``).
+        Applied by ``calcparams.e_total`` on the measured side; the modeled
+        side handles rear shading through its own ``reg_cols_sim`` definition.
     meas_loader, sim_loader : callable or None
         Programmatic-only data-loader callables. Default resolution when
         ``None``: ``captest.io.load_data`` and ``captest.io.load_pvsyst``
@@ -1022,11 +1085,30 @@ class CapTest(param.Parameterized):
         doc="Hours of data required for a complete test.",
     )
 
-    # Calc-params scalars propagated to both CapData instances at setup().
+    # Calc-params scalars propagated to the CapData instances at setup().
+    # All are propagated onto both meas and sim except rear_shade, which is
+    # meas-only (see _downstream_attrs_meas_only).
     bifaciality = param.Number(
         default=0.0,
         bounds=(0.0, 1.0),
         doc="Bifaciality factor propagated onto both CapData instances.",
+    )
+    bifacial_frac = param.Number(
+        default=1.0,
+        bounds=(0.0, 1.0),
+        doc=(
+            "Fraction of array nameplate power that is bifacial, passed to "
+            "calcparams.e_total. Propagated onto both CapData instances."
+        ),
+    )
+    rear_shade = param.Number(
+        default=0.0,
+        bounds=(0.0, 1.0),
+        doc=(
+            "Fraction of rear irradiance lost due to shading, passed to "
+            "calcparams.e_total. Propagated onto the measured CapData "
+            "instance only (see _downstream_attrs_meas_only)."
+        ),
     )
     power_temp_coeff = param.Number(
         default=-0.32,
@@ -1035,6 +1117,26 @@ class CapTest(param.Parameterized):
     base_temp = param.Number(
         default=25,
         doc="Base temperature for temperature correction (deg C).",
+    )
+    module_type = param.String(
+        default="glass_cell_poly",
+        doc=(
+            "Module construction passed to the Sandia temperature model via "
+            "calcparams.bom_temp and calcparams.cell_temp. One of "
+            "'glass_cell_poly', 'glass_cell_glass', or 'poly_tf_steel'. "
+            "Propagated onto both CapData instances at setup(). Distinct from "
+            "spectral_module_type, which feeds "
+            "calcparams.spectral_factor_firstsolar."
+        ),
+    )
+    racking = param.String(
+        default="open_rack",
+        doc=(
+            "Racking configuration passed to the Sandia temperature model via "
+            "calcparams.bom_temp and calcparams.cell_temp. One of 'open_rack', "
+            "'close_roof_mount', or 'insulated_back'. Propagated onto both "
+            "CapData instances at setup()."
+        ),
     )
     spectral_module_type = param.String(
         default="cdte",
@@ -1045,6 +1147,25 @@ class CapTest(param.Parameterized):
             "CapData.custom_param. Named to avoid collision with the "
             "'module_type' kwarg of calcparams.bom_temp and "
             "calcparams.cell_temp."
+        ),
+    )
+    airmass_model = param.String(
+        default="kastenyoung1989",
+        doc=(
+            "Relative airmass model passed to calcparams.absolute_airmass "
+            "(pvlib.atmosphere.get_relative_airmass). Propagated onto both "
+            "CapData instances at setup()."
+        ),
+    )
+    altitude_override = param.Number(
+        default=0,
+        allow_None=True,
+        doc=(
+            "Altitude (m) used when building the pvlib.Location in "
+            "calcparams.apparent_zenith / apparent_zenith_pvsyst. Defaults to "
+            "0 (sea level) per the First Solar spectral-correction reference; "
+            "set to None to respect the site's own altitude. Propagated onto "
+            "both CapData instances at setup()."
         ),
     )
 
@@ -1070,14 +1191,23 @@ class CapTest(param.Parameterized):
         doc="Extra kwargs splatted into sim_loader.",
     )
 
-    # Class-level tuple of param names to copy onto both CapData instances
-    # during setup(). Extending is a one-line edit.
+    # Class-level tuple of param names to copy onto the CapData instances
+    # during setup(). Names also listed in _downstream_attrs_meas_only are
+    # copied onto meas only; all others are copied onto both meas and sim.
+    # Extending is a one-line edit.
     _downstream_attrs = (
         "bifaciality",
+        "bifacial_frac",
+        "rear_shade",
         "power_temp_coeff",
         "base_temp",
+        "module_type",
+        "racking",
         "spectral_module_type",
+        "airmass_model",
+        "altitude_override",
     )
+    _downstream_attrs_meas_only = ("rear_shade",)
 
     def __init__(self, **kwargs):  # noqa: D107
         super().__init__(**kwargs)
@@ -1465,9 +1595,15 @@ class CapTest(param.Parameterized):
             "irrad_stability_threshold",
             "hrs_req",
             "bifaciality",
+            "bifacial_frac",
+            "rear_shade",
             "power_temp_coeff",
             "base_temp",
+            "module_type",
+            "racking",
             "spectral_module_type",
+            "airmass_model",
+            "altitude_override",
         )
         for name in scalar_names:
             sub[name] = getattr(self, name)
@@ -1563,10 +1699,13 @@ class CapTest(param.Parameterized):
         resolved = resolve_test_setup(self.test_setup, overrides=overrides)
         self._resolved_setup = resolved
 
-        # Propagate scalar calc-params onto both CapData instances.
+        # Propagate scalar calc-params onto the CapData instances. Names in
+        # _downstream_attrs_meas_only are copied onto meas only; all others
+        # are copied onto both meas and sim.
         for name in self._downstream_attrs:
             setattr(self.meas, name, getattr(self, name))
-            setattr(self.sim, name, getattr(self, name))
+            if name not in self._downstream_attrs_meas_only:
+                setattr(self.sim, name, getattr(self, name))
 
         # Propagate site from meas -> sim with Etc/GMT±N tz for PVsyst.
         self._propagate_sim_site()

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -158,7 +158,8 @@ def scatter_default(cd, **kwargs):
 def scatter_etotal(cd, **kwargs):
     """Single scatter of regression lhs vs. the ``e_total`` column.
 
-    Intended for the ``bifi_e2848_etotal`` preset. Thin wrapper around
+    Intended for the ``bifi_e2848_etotal_rear_shade_sim`` /
+    ``bifi_e2848_etotal_rear_shade_meas`` presets. Thin wrapper around
     :class:`captest.plotting.ScatterPlot`; resolves the x column from
     ``cd.regression_cols['poa']`` after ``process_regression_columns``
     has materialized the calculated e_total column.
@@ -209,11 +210,18 @@ TEST_SETUPS = {
             },
         },
     },
-    "bifi_e2848_etotal": {
+    "bifi_e2848_etotal_rear_shade_sim": {
         "description": (
-            "Standard ASTM E2848 regression form with total effective irradiance replacing "
-            "front-side POA as the independent variable. Total irradiance is calculated as "
-            "E_Total = E_POA + E_Rear * bifaciality, following the NREL modified bifacial approach."
+            "Standard ASTM E2848 regression form with total effective "
+            "irradiance replacing front-side POA as the independent variable. "
+            "Rear shading and IAM losses are handled in the modeled (PVsyst) "
+            "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
+            "BackShd, while the measured rear sensor (irr_rpoa) is used "
+            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
+            "variant that instead applies rear shading on the measured side, "
+            "see 'bifi_e2848_etotal_rear_shade_meas'. Total irradiance is "
+            "E_Total = E_POA + E_Rear * bifaciality, following the NREL "
+            "modified bifacial approach."
         ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
@@ -254,14 +262,16 @@ TEST_SETUPS = {
             },
         },
     },
-    "bifi_e2848_etotal_meas_shade": {
+    "bifi_e2848_etotal_rear_shade_meas": {
         "description": (
-            "Variant of 'bifi_e2848_etotal' for applying rear-shading losses on the "
-            "measured side. The modeled rear irradiance maps directly to PVsyst's "
-            "unshaded global rear ('GlobBak') instead of rpoa_pvsyst, and rear shading "
-            "is applied to the measured side through the e_total 'rear_shade' factor "
-            "(propagated by CapTest to the measured CapData only). Total irradiance is "
-            "E_Total = E_POA + E_Rear * bifaciality * (1 - rear_shade)."
+            "Variant of 'bifi_e2848_etotal_rear_shade_sim' for applying "
+            "rear-shading losses on the measured side. The modeled rear "
+            "irradiance maps directly to PVsyst's unshaded global rear "
+            "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
+            "to the measured side through the e_total 'rear_shade' factor "
+            "(propagated by CapTest to the measured CapData only). Total "
+            "irradiance is E_Total = E_POA + E_Rear * bifaciality * "
+            "(1 - rear_shade)."
         ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
@@ -899,7 +909,7 @@ class CapTest(param.Parameterized):
 
     3. Bare + manual::
 
-        ct = CapTest(test_setup="bifi_e2848_etotal", bifaciality=0.15)
+        ct = CapTest(test_setup="bifi_e2848_etotal_rear_shade_sim", bifaciality=0.15)
         ct.meas = my_meas_cd
         ct.sim = my_sim_cd
         ct.setup()
@@ -1767,7 +1777,8 @@ class CapTest(param.Parameterized):
 
         Built-in setup behavior:
 
-        - ``e2848_default``, ``bifi_e2848_etotal``, and
+        - ``e2848_default``, ``bifi_e2848_etotal_rear_shade_sim``,
+          ``bifi_e2848_etotal_rear_shade_meas``, and
           ``e2848_spec_corrected_poa`` use ``ScatterPlot`` through the
           ``scatter_default`` / ``scatter_etotal`` wrappers. These create a
           formula-driven scatter of the regression left-hand-side variable

--- a/src/captest/io.py
+++ b/src/captest/io.py
@@ -281,13 +281,16 @@ class DataLoader:
                 )
             )
 
-    def reindex_loaded_files(self, verbose=False):
+    def reindex_loaded_files(self, verbose=False, report=False):
         """Reindex files to ensure no missing indices and find frequency for each file.
 
         Parameters
         ----------
         verbose : bool, default False
             Set to True for more detailed output.
+        report : bool, default False
+            Set to True AND set verbose to TRUE to show frequency used when reindexing
+            and quantity of intervals added to the index.
 
         Returns
         -------
@@ -298,6 +301,8 @@ class DataLoader:
         file_frequencies : list
             The index frequencies for each file.
         """
+        if not verbose:
+            report = False
         reindexed_dfs = {}
         file_frequencies = []
         for name, file in self.loaded_files.items():
@@ -307,7 +312,7 @@ class DataLoader:
             current_file, missing_intervals, freq_str = util.reindex_datetime(
                 file,
                 file_name=name,
-                report=False,
+                report=report,
             )
             reindexed_dfs[name] = current_file
             file_frequencies.append(freq_str)
@@ -422,6 +427,7 @@ class DataLoader:
         None
             Resulting DataFrame of data is stored to the `data` attribute.
         """
+        report = kwargs.pop("report", False)
         if verbose:
             summary = True
         if self.path.is_file():
@@ -470,7 +476,7 @@ class DataLoader:
                     self.loaded_files,
                     self.common_freq,
                     self.file_frequencies,
-                ) = self.reindex_loaded_files(verbose=verbose)
+                ) = self.reindex_loaded_files(verbose=verbose, report=report)
                 data = self.join_files()
             elif len(self.loaded_files) == 1:
                 data = list(self.loaded_files.values())[0]
@@ -489,10 +495,10 @@ class DataLoader:
     def drop_duplicate_rows(self):
         self.data.drop_duplicates(inplace=True)
 
-    def reindex(self):
+    def reindex(self, report=False):
         self.data, self.missing_intervals, self.freq_str = util.reindex_datetime(
             self.data,
-            report=False,
+            report=report,
         )
 
 
@@ -569,9 +575,9 @@ def load_data(
     **kwargs
         Passed to `DataLoader.load`. Any kwargs not used by `DataLoader.load` are
         passed to the `file_reader` function, which by default passes
-        them to pandas.read_csv. `DataLoader.load` accepts a summary kwarg to show files
+        them to pandas.read_csv. `DataLoader.load` accepts a `summary` kwarg to show files
         loaded from a directory without reindexing status shown when verbose is set to
-        True.
+        True. Reindexing accepts a `report` kwarg.
     """
     dl = DataLoader(
         path=path,

--- a/src/captest/util.py
+++ b/src/captest/util.py
@@ -332,6 +332,12 @@ def _get_or_create_aggregation(group_id, agg_func, cd, agg_cache, verbose):
     """
     Get an aggregated column name, creating it if necessary.
 
+    If a column named ``<group_id>_<agg_func>_agg`` already exists in
+    ``cd.data`` (e.g. measured data was loaded from a previously exported
+    test-data file), that column is reused instead of re-aggregating the
+    group, and a "Reusing existing column ..." message is printed when
+    ``verbose`` is True.
+
     Parameters
     ----------
     group_id : str
@@ -357,6 +363,11 @@ def _get_or_create_aggregation(group_id, agg_func, cd, agg_cache, verbose):
     expected_agg_name = get_agg_column_name(group_id, agg_func)
     if expected_agg_name in cd.data.columns:
         agg_name = expected_agg_name
+        if verbose:
+            print(
+                f"Reusing existing column '{expected_agg_name}'; skipping "
+                f"aggregation of the {group_id} group.\n"
+            )
     else:
         agg_name = cd.agg_group(group_id=group_id, agg_func=agg_func, verbose=verbose)
 

--- a/src/captest/util.py
+++ b/src/captest/util.py
@@ -79,9 +79,7 @@ def reindex_datetime(data, file_name=None, report=False):
     data_index_length = data.shape[0]
     df = data.copy()
     df.sort_index(inplace=True)
-    print("before calling get common timestep")
     freq_str = get_common_timestep(data, string_output=True)
-    print(freq_str)
     full_ix = pd.date_range(start=df.index[0], end=df.index[-1], freq=freq_str)
     try:
         df = df.reindex(index=full_ix)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -369,6 +371,46 @@ def sim_cd_spec_corrected(sim_cd_default):
     cd.data["PrecWat"] = rng.uniform(0.005, 0.03, n)  # meters
     cd.data_filtered = cd.data.copy(deep=True)
     return cd
+
+
+@pytest.fixture
+def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
+    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_sim preset.
+
+    The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
+    setup; that auto-propagation behavior is covered separately by the
+    e2848_spec_corrected_poa tests.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Propagating meas.site")
+        return CapTest.from_params(
+            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            meas=meas_cd_spec_corrected,
+            sim=sim_cd_spec_corrected,
+            ac_nameplate=6_000_000,
+            bifaciality=0.15,
+            test_tolerance="- 4",
+        )
+
+
+@pytest.fixture
+def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected):
+    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_meas preset.
+
+    The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
+    setup; that auto-propagation behavior is covered separately by the
+    e2848_spec_corrected_poa tests.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Propagating meas.site")
+        return CapTest.from_params(
+            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            meas=meas_cd_spec_corrected,
+            sim=sim_cd_spec_corrected,
+            ac_nameplate=6_000_000,
+            bifaciality=0.15,
+            test_tolerance="- 4",
+        )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,36 @@ def ct_bifi_power_tc_meas_tbom(meas_cd_bom_temp, sim_cd_default):
 
 
 @pytest.fixture
+def ct_power_tc_etotal_sim(meas_cd_bom_temp, sim_cd_default):
+    """CapTest for the bifi_power_tc_etotal_rear_shade_sim preset with setup() run."""
+    return CapTest.from_params(
+        test_setup="bifi_power_tc_etotal_rear_shade_sim",
+        meas=meas_cd_bom_temp,
+        sim=sim_cd_default,
+        ac_nameplate=6_000_000,
+        bifaciality=0.15,
+        power_temp_coeff=-0.32,
+        base_temp=25,
+        test_tolerance="- 4",
+    )
+
+
+@pytest.fixture
+def ct_power_tc_etotal_meas(meas_cd_bom_temp, sim_cd_default):
+    """CapTest for the bifi_power_tc_etotal_rear_shade_meas preset with setup() run."""
+    return CapTest.from_params(
+        test_setup="bifi_power_tc_etotal_rear_shade_meas",
+        meas=meas_cd_bom_temp,
+        sim=sim_cd_default,
+        ac_nameplate=6_000_000,
+        bifaciality=0.15,
+        power_temp_coeff=-0.32,
+        base_temp=25,
+        test_tolerance="- 4",
+    )
+
+
+@pytest.fixture
 def meas_cd_spec_corrected(meas_cd_default):
     """Measured CapData extended with humidity, pressure, and a site dict.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -375,7 +375,7 @@ def sim_cd_spec_corrected(sim_cd_default):
 
 @pytest.fixture
 def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
-    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_sim preset.
+    """CapTest for the bifi_e2848_etotal_rear_shade_sim_spec_corrected preset.
 
     The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
     setup; that auto-propagation behavior is covered separately by the
@@ -384,7 +384,7 @@ def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Propagating meas.site")
         return CapTest.from_params(
-            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            test_setup="bifi_e2848_etotal_rear_shade_sim_spec_corrected",
             meas=meas_cd_spec_corrected,
             sim=sim_cd_spec_corrected,
             ac_nameplate=6_000_000,
@@ -395,7 +395,7 @@ def ct_spec_corrected_etotal_sim(meas_cd_spec_corrected, sim_cd_spec_corrected):
 
 @pytest.fixture
 def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected):
-    """CapTest for the bifi_e2848_spec_corrected_etotal_rear_shade_meas preset.
+    """CapTest for the bifi_e2848_etotal_rear_shade_meas_spec_corrected preset.
 
     The "Propagating meas.site" UserWarning (sim has no site) is suppressed at
     setup; that auto-propagation behavior is covered separately by the
@@ -404,7 +404,7 @@ def ct_spec_corrected_etotal_meas(meas_cd_spec_corrected, sim_cd_spec_corrected)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Propagating meas.site")
         return CapTest.from_params(
-            test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            test_setup="bifi_e2848_etotal_rear_shade_meas_spec_corrected",
             meas=meas_cd_spec_corrected,
             sim=sim_cd_spec_corrected,
             ac_nameplate=6_000_000,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def meas_cd_default():
     Column groups are renamed so the shipped ``e2848_default`` preset matches
     without extra overrides: ``real_pwr_mtr``, ``irr_poa``, ``temp_amb``,
     ``wind_speed``. A synthetic ``irr_rpoa`` group is added (scaled fraction
-    of the POA sensors) so the ``bifi_e2848_etotal`` and
+    of the POA sensors) so the ``bifi_e2848_etotal_rear_shade_sim`` and
     ``bifi_power_tc_calc_tbom`` presets also resolve against this fixture
     without additional wiring.
     """
@@ -230,7 +230,7 @@ def sim_cd_default():
     """Minimal modeled CapData loaded from the shipped PVsyst example.
 
     Synthetic ``GlobBak`` and ``BackShd`` columns are added so presets that
-    rely on ``rpoa_pvsyst(globbak=..., backshd=...)`` (``bifi_e2848_etotal``,
+    rely on ``rpoa_pvsyst(globbak=..., backshd=...)`` (``bifi_e2848_etotal_rear_shade_sim``,
     ``bifi_power_tc_meas_tbom``, ``bifi_power_tc_calc_tbom``) resolve without
     needing a new PVsyst export.
     """
@@ -255,9 +255,9 @@ def ct_default(meas_cd_default, sim_cd_default):
 
 @pytest.fixture
 def ct_etotal(meas_cd_default, sim_cd_default):
-    """CapTest for the bifi_e2848_etotal preset with setup() run."""
+    """CapTest for the bifi_e2848_etotal_rear_shade_sim preset with setup() run."""
     return CapTest.from_params(
-        test_setup="bifi_e2848_etotal",
+        test_setup="bifi_e2848_etotal_rear_shade_sim",
         meas=meas_cd_default,
         sim=sim_cd_default,
         ac_nameplate=6_000_000,

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -1965,6 +1965,59 @@ class TestAggGroupCutoff:
             assert f"    {col}" in captured.out
 
 
+class TestAggGroupSumNaN:
+    """Verify sum aggregation preserves NaN for all-NaN rows (min_count=1)."""
+
+    def _build_cd(self, data, column_groups):
+        """Build a minimal CapData from a DataFrame and column_groups dict."""
+        cd = pvc.CapData("cd")
+        cd.data = data
+        cd.data_filtered = data.copy()
+        cd.column_groups = column_groups
+        return cd
+
+    def test_agg_group_sum_single_column_all_nan_row_stays_nan(self):
+        """Summing a one-column group yields NaN, not 0.0, for an all-NaN row."""
+        idx = pd.date_range("2023-11-18 09:55", periods=3, freq="1min")
+        data = pd.DataFrame({"mtr_power": [np.nan, 1.5, 2.5]}, index=idx)
+        cd = self._build_cd(data, {"real_pwr_mtr": ["mtr_power"]})
+
+        agg_result, col_name = cd.agg_group(
+            "real_pwr_mtr", "sum", inplace=False, verbose=False
+        )
+
+        assert col_name == "real_pwr_mtr_sum_agg"
+        # All-NaN row stays NaN instead of collapsing to 0.0.
+        assert np.isnan(agg_result.iloc[0, 0])
+        # Rows with a value pass through unchanged.
+        assert agg_result.iloc[1, 0] == pytest.approx(1.5)
+        assert agg_result.iloc[2, 0] == pytest.approx(2.5)
+
+    def test_agg_group_sum_multi_column_all_nan_row_stays_nan(self):
+        """Summing a multi-column group yields NaN for a fully-NaN row while
+        still skipping NaN in a partially-populated row."""
+        idx = pd.date_range("2023-11-18 09:55", periods=3, freq="1min")
+        data = pd.DataFrame(
+            {
+                "mtr_a": [np.nan, np.nan, 3.0],
+                "mtr_b": [np.nan, 5.0, 4.0],
+            },
+            index=idx,
+        )
+        cd = self._build_cd(data, {"real_pwr_mtr": ["mtr_a", "mtr_b"]})
+
+        agg_result, col_name = cd.agg_group(
+            "real_pwr_mtr", "sum", inplace=False, verbose=False
+        )
+
+        # All-NaN row stays NaN instead of collapsing to 0.0.
+        assert np.isnan(agg_result.iloc[0, 0])
+        # Partially-populated row skips the NaN and sums the present value.
+        assert agg_result.iloc[1, 0] == pytest.approx(5.0)
+        # Fully-populated row sums normally.
+        assert agg_result.iloc[2, 0] == pytest.approx(7.0)
+
+
 class TestFilterSensors:
     def test_perc_diff_none(self, meas):
         rows_before_flt = meas.data_filtered.shape[0]

--- a/tests/test_calc_params.py
+++ b/tests/test_calc_params.py
@@ -301,7 +301,8 @@ class TestEtotal:
         _ = calcparams.e_total(df, "poa", "rear")
         captured = capsys.readouterr()
         assert captured.out.rstrip("\n") == (
-            'Calculating and adding "e_total" column as poa + rear * 0.7 * 1 * (1 - 0)'
+            'Calculating and adding "e_total" column as poa + rear * '
+            "0.7 (bifaciality) * 1 (bifacial fraction) * (1 - 0 (rear shade))"
         )
 
 

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -386,6 +386,14 @@ class TestConstruction:
         )
         assert CapTest._downstream_attrs_meas_only == ("rear_shade",)
 
+    def test_downstream_attrs_meas_only_is_subset(self):
+        """meas-only attrs must be a subset of _downstream_attrs; setup()
+        iterates _downstream_attrs, so an orphaned meas-only name would never
+        propagate to either CapData instance."""
+        assert set(CapTest._downstream_attrs_meas_only).issubset(
+            CapTest._downstream_attrs
+        )
+
     def test_from_params_with_capdata_instances_triggers_setup(
         self, meas_cd_default, sim_cd_default
     ):
@@ -1057,6 +1065,55 @@ class TestDownstreamPropagation:
             cell_temp_open.to_numpy(), ct_ins.meas.data["cell_temp"].to_numpy()
         )
 
+    def test_airmass_model_flows_into_absolute_airmass(
+        self, meas_cd_spec_corrected, sim_cd_spec_corrected
+    ):
+        """A non-default airmass_model changes the absolute_airmass column."""
+        with pytest.warns(UserWarning, match="Propagating meas.site"):
+            ct_default_model = CapTest.from_params(
+                test_setup="e2848_spec_corrected_poa",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+            )
+            am_default = ct_default_model.meas.data["absolute_airmass"].copy()
+            ct_alt = CapTest.from_params(
+                test_setup="e2848_spec_corrected_poa",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+                airmass_model="simple",
+            )
+        assert ct_alt.meas.airmass_model == "simple"
+        assert ct_alt.sim.airmass_model == "simple"
+        assert not np.allclose(
+            am_default.to_numpy(),
+            ct_alt.meas.data["absolute_airmass"].to_numpy(),
+            equal_nan=True,
+        )
+
+    def test_altitude_override_flows_into_apparent_zenith(
+        self, meas_cd_spec_corrected, sim_cd_spec_corrected
+    ):
+        """A non-zero altitude_override changes the apparent_zenith column."""
+        with pytest.warns(UserWarning, match="Propagating meas.site"):
+            ct_sea = CapTest.from_params(
+                test_setup="e2848_spec_corrected_poa",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+            )
+            zen_sea = ct_sea.meas.data["apparent_zenith"].copy()
+            ct_alt = CapTest.from_params(
+                test_setup="e2848_spec_corrected_poa",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+                altitude_override=5000,
+            )
+        assert ct_alt.meas.altitude_override == 5000
+        assert not np.allclose(
+            zen_sea.to_numpy(),
+            ct_alt.meas.data["apparent_zenith"].to_numpy(),
+            equal_nan=True,
+        )
+
     def test_power_temp_coeff_flows_into_power_temp_correct(
         self, meas_cd_default, sim_cd_default
     ):
@@ -1709,6 +1766,15 @@ class TestToYamlAndRoundTrip:
         assert loaded.racking == "close_roof_mount"
         assert loaded.airmass_model == "kasten1966"
         assert loaded.altitude_override == 500
+
+    def test_to_yaml_round_trips_altitude_override_none(self, tmp_path):
+        """altitude_override=None (respect site altitude) survives the round
+        trip as None rather than being coerced to the default of 0."""
+        p = tmp_path / "cfg.yaml"
+        capt = CapTest(test_setup="e2848_default", altitude_override=None)
+        capt.to_yaml(p, merge_into_existing=False)
+        loaded = CapTest.from_yaml(p)
+        assert loaded.altitude_override is None
 
     def test_to_yaml_warns_when_scatter_plots_is_user_mutated(
         self, tmp_path, ct_default

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -22,6 +22,8 @@ from captest.calcparams import (
     e_total,
     poa_spec_corrected,
     power_temp_correct,
+    rpoa_pvsyst,
+    scale,
     spectral_factor_firstsolar,
 )
 
@@ -112,6 +114,50 @@ class TestTestSetupsRegistry:
         zenith_node = abs_airmass_node[1]["apparent_zenith"]
         assert isinstance(zenith_node, tuple)
         assert zenith_node[0] is apparent_zenith_pvsyst
+
+    def test_spec_corrected_etotal_sim_front_spec_corrected_rear_raw(self):
+        """_sim meas poa = e_total(front=poa_spec_corrected, rear=raw irr_rpoa)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        meas_poa = entry["reg_cols_meas"]["poa"]
+        assert isinstance(meas_poa, tuple)
+        assert meas_poa[0] is e_total
+        assert meas_poa[1]["poa"][0] is poa_spec_corrected
+        assert meas_poa[1]["rpoa"] == ("irr_rpoa", "mean")
+
+    def test_spec_corrected_etotal_sim_rear_uses_rpoa_pvsyst(self):
+        """_sim sim-side rear routes through rpoa_pvsyst (shading in model)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        sim_rear = entry["reg_cols_sim"]["poa"][1]["rpoa"]
+        assert isinstance(sim_rear, tuple)
+        assert sim_rear[0] is rpoa_pvsyst
+
+    def test_spec_corrected_etotal_meas_rear_maps_to_globbak(self):
+        """_meas sim-side rear maps directly to GlobBak; meas side matches _sim."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_meas"]
+        assert entry["reg_cols_sim"]["poa"][1]["rpoa"] == "GlobBak"
+        meas_poa = entry["reg_cols_meas"]["poa"]
+        assert meas_poa[0] is e_total
+        assert meas_poa[1]["poa"][0] is poa_spec_corrected
+        assert meas_poa[1]["rpoa"] == ("irr_rpoa", "mean")
+
+    def test_spec_corrected_etotal_sim_routes_through_pvsyst_zenith_and_scale(self):
+        """_sim sim-side spectral tree uses apparent_zenith_pvsyst + scale(PrecWat)."""
+        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        front = entry["reg_cols_sim"]["poa"][1]["poa"]  # poa_spec_corrected tuple
+        assert front[0] is poa_spec_corrected
+        spec_node = front[1]["spectral_correction"]
+        assert spec_node[0] is spectral_factor_firstsolar
+        zenith = spec_node[1]["absolute_airmass"][1]["apparent_zenith"]
+        assert zenith[0] is apparent_zenith_pvsyst
+        assert spec_node[1]["precipitable_water"][0] is scale
+
+    def test_spec_corrected_etotal_presets_use_scatter_etotal(self):
+        """Both presets use scatter_etotal, matching the other e_total presets."""
+        for name in (
+            "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+            "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+        ):
+            assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
 
     def test_validate_rejects_unknown_keys(self):
         bad = dict(ct.TEST_SETUPS["e2848_default"])

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -40,6 +40,8 @@ _DEFAULT_FIXTURE_PRESETS = [
         "bifi_power_tc_meas_tbom",
         "bifi_e2848_etotal_rear_shade_sim_spec_corrected",
         "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
+        "bifi_power_tc_etotal_rear_shade_sim",
+        "bifi_power_tc_etotal_rear_shade_meas",
     }
 ]
 
@@ -158,6 +160,43 @@ class TestTestSetupsRegistry:
             "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
         ):
             assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
+
+    def test_power_tc_etotal_power_is_temp_corrected_with_measured_bom(self):
+        """power_tc_etotal meas power is power_temp_correct over measured BOM."""
+        entry = ct.TEST_SETUPS["bifi_power_tc_etotal_rear_shade_sim"]
+        meas_power = entry["reg_cols_meas"]["power"]
+        assert meas_power[0] is power_temp_correct
+        bom_spec = meas_power[1]["cell_temp"][1]["bom"]
+        assert bom_spec == ("temp_bom", "mean")
+
+    def test_power_tc_etotal_poa_is_e_total_over_front_and_rear(self):
+        """power_tc_etotal meas poa is an e_total calc-tuple over front + rear."""
+        entry = ct.TEST_SETUPS["bifi_power_tc_etotal_rear_shade_sim"]
+        meas_poa = entry["reg_cols_meas"]["poa"]
+        assert meas_poa[0] is e_total
+        assert meas_poa[1]["poa"] == ("irr_poa", "mean")
+        assert meas_poa[1]["rpoa"] == ("irr_rpoa", "mean")
+
+    def test_power_tc_etotal_sim_rear_uses_rpoa_pvsyst(self):
+        """_sim sim-side e_total rear routes through rpoa_pvsyst (shading in model)."""
+        entry = ct.TEST_SETUPS["bifi_power_tc_etotal_rear_shade_sim"]
+        sim_rear = entry["reg_cols_sim"]["poa"][1]["rpoa"]
+        assert isinstance(sim_rear, tuple)
+        assert sim_rear[0] is rpoa_pvsyst
+
+    def test_power_tc_etotal_meas_rear_maps_to_globbak(self):
+        """_meas sim-side e_total rear maps directly to GlobBak (no rpoa_pvsyst)."""
+        entry = ct.TEST_SETUPS["bifi_power_tc_etotal_rear_shade_meas"]
+        assert entry["reg_cols_sim"]["poa"][1]["rpoa"] == "GlobBak"
+
+    def test_power_tc_etotal_presets_use_scatter_etotal_and_single_term_formula(self):
+        """Both presets use scatter_etotal and the single-term 'power ~ poa' formula."""
+        for name in (
+            "bifi_power_tc_etotal_rear_shade_sim",
+            "bifi_power_tc_etotal_rear_shade_meas",
+        ):
+            assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
+            assert ct.TEST_SETUPS[name]["reg_fml"] == "power ~ poa"
 
     def test_validate_rejects_unknown_keys(self):
         bad = dict(ct.TEST_SETUPS["e2848_default"])
@@ -1118,6 +1157,30 @@ class TestDownstreamPropagation:
         expected = m["poa_spec_corrected"] + m["irr_rpoa_mean_agg"] * 0.5 * (1 - 0.12)
         assert m["e_total"] == pytest.approx(expected)
 
+    def test_power_tc_etotal_meas_composition_and_temp_corrected_power(
+        self, meas_cd_bom_temp, sim_cd_default
+    ):
+        """power_tc_etotal _meas: e_total = poa + rpoa*bifaciality*(1-rear_shade),
+        temp-corrected power materializes, and rear_shade is meas-only."""
+        capt = CapTest.from_params(
+            test_setup="bifi_power_tc_etotal_rear_shade_meas",
+            meas=meas_cd_bom_temp,
+            sim=sim_cd_default,
+            bifaciality=0.5,
+            rear_shade=0.12,
+            power_temp_coeff=-0.32,
+            base_temp=25,
+        )
+        assert capt.meas.rear_shade == 0.12
+        assert not hasattr(capt.sim, "rear_shade")
+        meas_df = capt.meas.data
+        assert "power_temp_correct" in meas_df.columns
+        first = meas_df.loc[meas_df["irr_poa_mean_agg"] > 0].iloc[0]
+        expected = first["irr_poa_mean_agg"] + first["irr_rpoa_mean_agg"] * 0.5 * (
+            1 - 0.12
+        )
+        assert first["e_total"] == pytest.approx(expected)
+
     def test_bifacial_frac_flows_into_e_total(self, meas_cd_default, sim_cd_default):
         capt = CapTest.from_params(
             test_setup="bifi_e2848_etotal_rear_shade_sim",
@@ -1367,6 +1430,22 @@ class TestSpecCorrectedEtotalColumns:
         capt = ct_spec_corrected_etotal_meas
         for cd in (capt.meas, capt.sim):
             assert "poa_spec_corrected" in cd.data.columns
+            assert "e_total" in cd.data.columns
+
+
+class TestPowerTcEtotalColumns:
+    """power_temp_correct and e_total materialize on meas and sim."""
+
+    def test_sim_variant_materializes_both_columns(self, ct_power_tc_etotal_sim):
+        capt = ct_power_tc_etotal_sim
+        for cd in (capt.meas, capt.sim):
+            assert "power_temp_correct" in cd.data.columns
+            assert "e_total" in cd.data.columns
+
+    def test_meas_variant_materializes_both_columns(self, ct_power_tc_etotal_meas):
+        capt = ct_power_tc_etotal_meas
+        for cd in (capt.meas, capt.sim):
+            assert "power_temp_correct" in cd.data.columns
             assert "e_total" in cd.data.columns
 
 
@@ -2169,6 +2248,28 @@ class TestIntegration:
         capt = ct_spec_corrected_etotal_meas
         assert "e_total" in capt.meas.data.columns
         assert "poa_spec_corrected" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"
+
+    def test_end_to_end_power_tc_etotal_sim(self, ct_power_tc_etotal_sim):
+        """power_tc e_total (_sim) runs end-to-end to a plausible cap ratio."""
+        capt = ct_power_tc_etotal_sim
+        assert "power_temp_correct" in capt.meas.data.columns
+        assert "e_total" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"
+
+    def test_end_to_end_power_tc_etotal_meas(self, ct_power_tc_etotal_meas):
+        """power_tc e_total (_meas) runs end-to-end to a plausible cap ratio."""
+        capt = ct_power_tc_etotal_meas
+        assert "power_temp_correct" in capt.meas.data.columns
+        assert "e_total" in capt.meas.data.columns
         self._run_canonical_sequence(capt)
         cap_ratio = capt.captest_results(print_res=False)
         assert 0.8 < cap_ratio < 1.2

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1352,6 +1352,24 @@ class TestCapTestSpectralCorrection:
         assert capt.sim.spectral_module_type == "monosi"
 
 
+class TestSpecCorrectedEtotalColumns:
+    """Both poa_spec_corrected and e_total materialize on meas and sim."""
+
+    def test_sim_variant_materializes_both_columns(self, ct_spec_corrected_etotal_sim):
+        capt = ct_spec_corrected_etotal_sim
+        for cd in (capt.meas, capt.sim):
+            assert "poa_spec_corrected" in cd.data.columns
+            assert "e_total" in cd.data.columns
+
+    def test_meas_variant_materializes_both_columns(
+        self, ct_spec_corrected_etotal_meas
+    ):
+        capt = ct_spec_corrected_etotal_meas
+        for cd in (capt.meas, capt.sim):
+            assert "poa_spec_corrected" in cd.data.columns
+            assert "e_total" in cd.data.columns
+
+
 class TestLoaderInjection:
     """Loader callable defaults, overrides, and kwarg splatting."""
 
@@ -2134,3 +2152,25 @@ class TestIntegration:
         self._run_canonical_sequence(ct_bifi_power_tc_meas_tbom)
         cap_ratio = ct_bifi_power_tc_meas_tbom.captest_results(print_res=False)
         assert 0.8 < cap_ratio < 1.2
+
+    def test_end_to_end_spec_corrected_etotal_sim(self, ct_spec_corrected_etotal_sim):
+        """Spectral-corrected e_total (_sim) runs end-to-end to a plausible ratio."""
+        capt = ct_spec_corrected_etotal_sim
+        assert "e_total" in capt.meas.data.columns
+        assert "poa_spec_corrected" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"
+
+    def test_end_to_end_spec_corrected_etotal_meas(self, ct_spec_corrected_etotal_meas):
+        """Spectral-corrected e_total (_meas) runs end-to-end to a plausible ratio."""
+        capt = ct_spec_corrected_etotal_meas
+        assert "e_total" in capt.meas.data.columns
+        assert "poa_spec_corrected" in capt.meas.data.columns
+        self._run_canonical_sequence(capt)
+        cap_ratio = capt.captest_results(print_res=False)
+        assert 0.8 < cap_ratio < 1.2
+        assert capt.meas.regression_cols["poa"] == "e_total"
+        assert capt.sim.regression_cols["poa"] == "e_total"

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1077,6 +1077,47 @@ class TestDownstreamPropagation:
         s = sim_df.loc[sim_df["GlobInc"] > 0].iloc[0]
         assert s["e_total"] == pytest.approx(s["GlobInc"] + s["GlobBak"] * 0.5)
 
+    def test_spec_correction_applied_to_front_inside_e_total(
+        self, ct_spec_corrected_etotal_sim
+    ):
+        """Meas e_total front term is poa_spec_corrected (not raw irr_poa),
+        and rear is discounted by bifaciality (rear_shade=0 by default)."""
+        capt = ct_spec_corrected_etotal_sim
+        meas_df = capt.meas.data
+        assert "poa_spec_corrected" in meas_df.columns
+        # Pick a daytime row with a valid spectral factor; the First Solar model
+        # returns NaN near sunrise/sunset (outside its valid airmass/pw range).
+        mask = meas_df["poa_spec_corrected"].notna() & (
+            meas_df["poa_spec_corrected"] > 0
+        )
+        first = meas_df.loc[mask].iloc[0]
+        expected = first["poa_spec_corrected"] + first["irr_rpoa_mean_agg"] * 0.15
+        assert first["e_total"] == pytest.approx(expected)
+        # The corrected front differs from the raw front (spectral factor != 1).
+        assert first["poa_spec_corrected"] != pytest.approx(first["irr_poa_mean_agg"])
+
+    def test_rear_shade_meas_only_for_spec_corrected_etotal(
+        self, meas_cd_spec_corrected, sim_cd_spec_corrected
+    ):
+        """rear_shade discounts the measured rear but is absent on sim."""
+        with pytest.warns(UserWarning, match="Propagating meas.site"):
+            capt = CapTest.from_params(
+                test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+                meas=meas_cd_spec_corrected,
+                sim=sim_cd_spec_corrected,
+                bifaciality=0.5,
+                rear_shade=0.12,
+            )
+        assert capt.meas.rear_shade == 0.12
+        assert not hasattr(capt.sim, "rear_shade")
+        meas_df = capt.meas.data
+        mask = meas_df["poa_spec_corrected"].notna() & (
+            meas_df["poa_spec_corrected"] > 0
+        )
+        m = meas_df.loc[mask].iloc[0]
+        expected = m["poa_spec_corrected"] + m["irr_rpoa_mean_agg"] * 0.5 * (1 - 0.12)
+        assert m["e_total"] == pytest.approx(expected)
+
     def test_bifacial_frac_flows_into_e_total(self, meas_cd_default, sim_cd_default):
         capt = CapTest.from_params(
             test_setup="bifi_e2848_etotal_rear_shade_sim",

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -347,8 +347,14 @@ class TestConstruction:
         assert capt.sim is None
         assert capt.test_tolerance == "- 4"
         assert capt.bifaciality == 0.0
+        assert capt.rear_shade == 0.0
         assert capt.power_temp_coeff == -0.32
         assert capt.base_temp == 25
+        assert capt.bifacial_frac == 1.0
+        assert capt.module_type == "glass_cell_poly"
+        assert capt.racking == "open_rack"
+        assert capt.airmass_model == "kastenyoung1989"
+        assert capt.altitude_override == 0
         assert capt._resolved_setup is None
 
     def test_bare_init_accepts_kwargs(self):
@@ -368,10 +374,17 @@ class TestConstruction:
     def test_class_level_downstream_attrs(self):
         assert CapTest._downstream_attrs == (
             "bifaciality",
+            "bifacial_frac",
+            "rear_shade",
             "power_temp_coeff",
             "base_temp",
+            "module_type",
+            "racking",
             "spectral_module_type",
+            "airmass_model",
+            "altitude_override",
         )
+        assert CapTest._downstream_attrs_meas_only == ("rear_shade",)
 
     def test_from_params_with_capdata_instances_triggers_setup(
         self, meas_cd_default, sim_cd_default
@@ -840,7 +853,11 @@ class TestSetup:
         )
         for attr in CapTest._downstream_attrs:
             assert getattr(capt.meas, attr) == getattr(capt, attr)
-            assert getattr(capt.sim, attr) == getattr(capt, attr)
+            if attr in CapTest._downstream_attrs_meas_only:
+                # meas-only attrs must NOT be propagated to sim.
+                assert not hasattr(capt.sim, attr)
+            else:
+                assert getattr(capt.sim, attr) == getattr(capt, attr)
 
     @pytest.mark.parametrize("preset", _DEFAULT_FIXTURE_PRESETS)
     def test_setup_wires_regression_formula(
@@ -939,6 +956,106 @@ class TestDownstreamPropagation:
         first = meas_df.loc[mask].iloc[0]
         expected = first["irr_poa_mean_agg"] + first["irr_rpoa_mean_agg"] * 0.5
         assert first["e_total"] == pytest.approx(expected)
+
+    def test_rear_shade_flows_into_e_total(self, meas_cd_default, sim_cd_default):
+        capt = CapTest.from_params(
+            test_setup="bifi_e2848_etotal",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.5,
+            rear_shade=0.12,
+        )
+        # Sanity: e_total = poa + rpoa * bifaciality * (1 - rear_shade)
+        meas_df = capt.meas.data
+        mask = meas_df["irr_poa_mean_agg"] > 0
+        first = meas_df.loc[mask].iloc[0]
+        expected = first["irr_poa_mean_agg"] + first["irr_rpoa_mean_agg"] * 0.5 * (
+            1 - 0.12
+        )
+        assert first["e_total"] == pytest.approx(expected)
+
+    def test_rear_shade_not_propagated_to_sim(self, meas_cd_default, sim_cd_default):
+        """rear_shade is meas-only: set on meas, absent on sim, no sim discount."""
+        capt = CapTest.from_params(
+            test_setup="bifi_e2848_etotal",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.5,
+            rear_shade=0.12,
+        )
+        assert capt.meas.rear_shade == 0.12
+        assert not hasattr(capt.sim, "rear_shade")
+        # Sim e_total uses the e_total default rear_shade=0 (no shade discount).
+        # sim rpoa = rpoa_pvsyst(GlobBak, BackShd) = GlobBak (BackShd is 0).
+        sim_df = capt.sim.data
+        first = sim_df.loc[sim_df["GlobInc"] > 0].iloc[0]
+        expected_sim = first["GlobInc"] + first["GlobBak"] * 0.5
+        assert first["e_total"] == pytest.approx(expected_sim)
+
+    def test_meas_shade_setup_applies_shade_to_meas_only(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """bifi_e2848_etotal_meas_shade discounts the measured rear by
+        rear_shade while mapping sim rpoa directly to GlobBak (no discount).
+        """
+        capt = CapTest.from_params(
+            test_setup="bifi_e2848_etotal_meas_shade",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.5,
+            rear_shade=0.12,
+        )
+        # Meas: e_total = poa + rpoa * bifaciality * (1 - rear_shade).
+        meas_df = capt.meas.data
+        m = meas_df.loc[meas_df["irr_poa_mean_agg"] > 0].iloc[0]
+        assert m["e_total"] == pytest.approx(
+            m["irr_poa_mean_agg"] + m["irr_rpoa_mean_agg"] * 0.5 * (1 - 0.12)
+        )
+        # Sim: rpoa maps directly to GlobBak with no rear_shade discount.
+        assert not hasattr(capt.sim, "rear_shade")
+        sim_df = capt.sim.data
+        s = sim_df.loc[sim_df["GlobInc"] > 0].iloc[0]
+        assert s["e_total"] == pytest.approx(s["GlobInc"] + s["GlobBak"] * 0.5)
+
+    def test_bifacial_frac_flows_into_e_total(self, meas_cd_default, sim_cd_default):
+        capt = CapTest.from_params(
+            test_setup="bifi_e2848_etotal",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.5,
+            bifacial_frac=0.8,
+        )
+        # e_total = poa + rpoa * bifaciality * bifacial_frac (rear_shade=0).
+        meas_df = capt.meas.data
+        first = meas_df.loc[meas_df["irr_poa_mean_agg"] > 0].iloc[0]
+        expected = first["irr_poa_mean_agg"] + first["irr_rpoa_mean_agg"] * 0.5 * 0.8
+        assert first["e_total"] == pytest.approx(expected)
+
+    def test_module_type_and_racking_flow_into_temp_model(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """module_type/racking propagate into the Sandia temp model so a
+        non-default racking changes the calculated cell_temp column."""
+        ct_open = CapTest.from_params(
+            test_setup="bifi_power_tc_calc_tbom",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.15,
+        )
+        cell_temp_open = ct_open.meas.data["cell_temp"].copy()
+        ct_ins = CapTest.from_params(
+            test_setup="bifi_power_tc_calc_tbom",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            bifaciality=0.15,
+            racking="insulated_back",
+        )
+        assert ct_ins.meas.racking == "insulated_back"
+        assert ct_ins.sim.racking == "insulated_back"
+        # open_rack del_tcnd=3 vs insulated_back del_tcnd=0 -> cell_temp differs.
+        assert not np.allclose(
+            cell_temp_open.to_numpy(), ct_ins.meas.data["cell_temp"].to_numpy()
+        )
 
     def test_power_temp_coeff_flows_into_power_temp_correct(
         self, meas_cd_default, sim_cd_default
@@ -1569,6 +1686,29 @@ class TestToYamlAndRoundTrip:
         # A second from_yaml on the written file succeeds.
         capt2 = CapTest.from_yaml(p2)
         assert capt2.ac_nameplate == 6_000_000
+
+    def test_to_yaml_round_trips_calc_param_scalars(self, tmp_path):
+        """New calc-param scalars + rear_shade survive a to_yaml/from_yaml trip."""
+        p = tmp_path / "cfg.yaml"
+        capt = CapTest(
+            test_setup="bifi_e2848_etotal",
+            bifaciality=0.3,
+            bifacial_frac=0.8,
+            rear_shade=0.12,
+            module_type="glass_cell_glass",
+            racking="close_roof_mount",
+            airmass_model="kasten1966",
+            altitude_override=500,
+        )
+        capt.to_yaml(p, merge_into_existing=False)
+        loaded = CapTest.from_yaml(p)
+        assert loaded.bifaciality == 0.3
+        assert loaded.bifacial_frac == 0.8
+        assert loaded.rear_shade == 0.12
+        assert loaded.module_type == "glass_cell_glass"
+        assert loaded.racking == "close_roof_mount"
+        assert loaded.airmass_model == "kasten1966"
+        assert loaded.altitude_override == 500
 
     def test_to_yaml_warns_when_scatter_plots_is_user_mutated(
         self, tmp_path, ct_default

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1038,6 +1038,13 @@ class TestDownstreamPropagation:
         first = meas_df.loc[meas_df["irr_poa_mean_agg"] > 0].iloc[0]
         expected = first["irr_poa_mean_agg"] + first["irr_rpoa_mean_agg"] * 0.5 * 0.8
         assert first["e_total"] == pytest.approx(expected)
+        # bifacial_frac propagates to both sides; sim e_total reflects it too.
+        # sim rpoa = rpoa_pvsyst(GlobBak, BackShd) = GlobBak (BackShd is 0).
+        assert capt.sim.bifacial_frac == 0.8
+        sim_df = capt.sim.data
+        sim_first = sim_df.loc[sim_df["GlobInc"] > 0].iloc[0]
+        expected_sim = sim_first["GlobInc"] + sim_first["GlobBak"] * 0.5 * 0.8
+        assert sim_first["e_total"] == pytest.approx(expected_sim)
 
     def test_module_type_and_racking_flow_into_temp_model(
         self, meas_cd_default, sim_cd_default

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -38,8 +38,8 @@ _DEFAULT_FIXTURE_PRESETS = [
     not in {
         "e2848_spec_corrected_poa",
         "bifi_power_tc_meas_tbom",
-        "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
-        "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+        "bifi_e2848_etotal_rear_shade_sim_spec_corrected",
+        "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
     }
 ]
 
@@ -117,7 +117,7 @@ class TestTestSetupsRegistry:
 
     def test_spec_corrected_etotal_sim_front_spec_corrected_rear_raw(self):
         """_sim meas poa = e_total(front=poa_spec_corrected, rear=raw irr_rpoa)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         meas_poa = entry["reg_cols_meas"]["poa"]
         assert isinstance(meas_poa, tuple)
         assert meas_poa[0] is e_total
@@ -126,14 +126,14 @@ class TestTestSetupsRegistry:
 
     def test_spec_corrected_etotal_sim_rear_uses_rpoa_pvsyst(self):
         """_sim sim-side rear routes through rpoa_pvsyst (shading in model)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         sim_rear = entry["reg_cols_sim"]["poa"][1]["rpoa"]
         assert isinstance(sim_rear, tuple)
         assert sim_rear[0] is rpoa_pvsyst
 
     def test_spec_corrected_etotal_meas_rear_maps_to_globbak(self):
         """_meas sim-side rear maps directly to GlobBak; meas side matches _sim."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_meas"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_meas_spec_corrected"]
         assert entry["reg_cols_sim"]["poa"][1]["rpoa"] == "GlobBak"
         meas_poa = entry["reg_cols_meas"]["poa"]
         assert meas_poa[0] is e_total
@@ -142,7 +142,7 @@ class TestTestSetupsRegistry:
 
     def test_spec_corrected_etotal_sim_routes_through_pvsyst_zenith_and_scale(self):
         """_sim sim-side spectral tree uses apparent_zenith_pvsyst + scale(PrecWat)."""
-        entry = ct.TEST_SETUPS["bifi_e2848_spec_corrected_etotal_rear_shade_sim"]
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim_spec_corrected"]
         front = entry["reg_cols_sim"]["poa"][1]["poa"]  # poa_spec_corrected tuple
         assert front[0] is poa_spec_corrected
         spec_node = front[1]["spectral_correction"]
@@ -154,8 +154,8 @@ class TestTestSetupsRegistry:
     def test_spec_corrected_etotal_presets_use_scatter_etotal(self):
         """Both presets use scatter_etotal, matching the other e_total presets."""
         for name in (
-            "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
-            "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+            "bifi_e2848_etotal_rear_shade_sim_spec_corrected",
+            "bifi_e2848_etotal_rear_shade_meas_spec_corrected",
         ):
             assert ct.TEST_SETUPS[name]["scatter_plots"] is ct.scatter_etotal
 
@@ -1102,7 +1102,7 @@ class TestDownstreamPropagation:
         """rear_shade discounts the measured rear but is absent on sim."""
         with pytest.warns(UserWarning, match="Propagating meas.site"):
             capt = CapTest.from_params(
-                test_setup="bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+                test_setup="bifi_e2848_etotal_rear_shade_meas_spec_corrected",
                 meas=meas_cd_spec_corrected,
                 sim=sim_cd_spec_corrected,
                 bifaciality=0.5,

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -62,9 +62,9 @@ class TestTestSetupsRegistry:
         assert set(entry["reg_cols_meas"].keys()) == {"power", "poa", "t_amb", "w_vel"}
         assert set(entry["reg_cols_sim"].keys()) == {"power", "poa", "t_amb", "w_vel"}
 
-    def test_bifi_e2848_etotal_uses_e_total(self):
-        """bifi_e2848_etotal preset wraps poa in an e_total calc-tuple."""
-        entry = ct.TEST_SETUPS["bifi_e2848_etotal"]
+    def test_bifi_e2848_etotal_rear_shade_sim_uses_e_total(self):
+        """bifi_e2848_etotal_rear_shade_sim preset wraps poa in an e_total calc-tuple."""
+        entry = ct.TEST_SETUPS["bifi_e2848_etotal_rear_shade_sim"]
         meas_poa = entry["reg_cols_meas"]["poa"]
         assert isinstance(meas_poa, tuple)
         assert meas_poa[0] is e_total
@@ -232,11 +232,11 @@ class TestLoadConfig:
             ct.load_config(p)
 
     def test_custom_key(self, tmp_path):
-        yaml_text = "captest_bifi:\n  test_setup: bifi_e2848_etotal\n"
+        yaml_text = "captest_bifi:\n  test_setup: bifi_e2848_etotal_rear_shade_sim\n"
         p = tmp_path / "cfg.yaml"
         p.write_text(yaml_text)
         sub = ct.load_config(p, key="captest_bifi")
-        assert sub["test_setup"] == "bifi_e2848_etotal"
+        assert sub["test_setup"] == "bifi_e2848_etotal_rear_shade_sim"
 
     def test_top_level_not_a_mapping_raises(self, tmp_path):
         p = tmp_path / "cfg.yaml"
@@ -359,11 +359,11 @@ class TestConstruction:
 
     def test_bare_init_accepts_kwargs(self):
         capt = CapTest(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             ac_nameplate=125_000,
             bifaciality=0.15,
         )
-        assert capt.test_setup == "bifi_e2848_etotal"
+        assert capt.test_setup == "bifi_e2848_etotal_rear_shade_sim"
         assert capt.ac_nameplate == 125_000
         assert capt.bifaciality == 0.15
 
@@ -789,12 +789,12 @@ class TestLoadConfigPublicExport:
     def test_returns_sub_mapping(self, tmp_path):
         p = tmp_path / "cfg.yaml"
         p.write_text(
-            "captest:\n  test_setup: bifi_e2848_etotal\n  ac_nameplate: 1234\n"
+            "captest:\n  test_setup: bifi_e2848_etotal_rear_shade_sim\n  ac_nameplate: 1234\n"
         )
         import captest
 
         sub = captest.load_config(p)
-        assert sub["test_setup"] == "bifi_e2848_etotal"
+        assert sub["test_setup"] == "bifi_e2848_etotal_rear_shade_sim"
         assert sub["ac_nameplate"] == 1234
 
     def test_missing_key_raises_keyerror_listing_available_keys(self, tmp_path):
@@ -852,7 +852,7 @@ class TestSetup:
         self, meas_cd_default, sim_cd_default
     ):
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.22,
@@ -952,7 +952,7 @@ class TestDownstreamPropagation:
 
     def test_bifaciality_flows_into_e_total(self, meas_cd_default, sim_cd_default):
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.5,
@@ -967,7 +967,7 @@ class TestDownstreamPropagation:
 
     def test_rear_shade_flows_into_e_total(self, meas_cd_default, sim_cd_default):
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.5,
@@ -985,7 +985,7 @@ class TestDownstreamPropagation:
     def test_rear_shade_not_propagated_to_sim(self, meas_cd_default, sim_cd_default):
         """rear_shade is meas-only: set on meas, absent on sim, no sim discount."""
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.5,
@@ -1003,11 +1003,11 @@ class TestDownstreamPropagation:
     def test_meas_shade_setup_applies_shade_to_meas_only(
         self, meas_cd_default, sim_cd_default
     ):
-        """bifi_e2848_etotal_meas_shade discounts the measured rear by
+        """bifi_e2848_etotal_rear_shade_meas discounts the measured rear by
         rear_shade while mapping sim rpoa directly to GlobBak (no discount).
         """
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal_meas_shade",
+            test_setup="bifi_e2848_etotal_rear_shade_meas",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.5,
@@ -1027,7 +1027,7 @@ class TestDownstreamPropagation:
 
     def test_bifacial_frac_flows_into_e_total(self, meas_cd_default, sim_cd_default):
         capt = CapTest.from_params(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             meas=meas_cd_default,
             sim=sim_cd_default,
             bifaciality=0.5,
@@ -1748,7 +1748,7 @@ class TestToYamlAndRoundTrip:
         """New calc-param scalars + rear_shade survive a to_yaml/from_yaml trip."""
         p = tmp_path / "cfg.yaml"
         capt = CapTest(
-            test_setup="bifi_e2848_etotal",
+            test_setup="bifi_e2848_etotal_rear_shade_sim",
             bifaciality=0.3,
             bifacial_frac=0.8,
             rear_shade=0.12,
@@ -1866,18 +1866,20 @@ class TestYamlKeyParametrization:
 
     def test_from_yaml_reads_under_captest_key_by_default(self, tmp_path):
         p = tmp_path / "cfg.yaml"
-        p.write_text("captest:\n  test_setup: bifi_e2848_etotal\n  ac_nameplate: 1\n")
+        p.write_text(
+            "captest:\n  test_setup: bifi_e2848_etotal_rear_shade_sim\n  ac_nameplate: 1\n"
+        )
         capt = CapTest.from_yaml(p)
-        assert capt.test_setup == "bifi_e2848_etotal"
+        assert capt.test_setup == "bifi_e2848_etotal_rear_shade_sim"
         assert capt.ac_nameplate == 1
 
     def test_from_yaml_reads_under_custom_key(self, tmp_path):
         p = tmp_path / "cfg.yaml"
         p.write_text(
-            "captest_bifi:\n  test_setup: bifi_e2848_etotal\n  ac_nameplate: 2\n"
+            "captest_bifi:\n  test_setup: bifi_e2848_etotal_rear_shade_sim\n  ac_nameplate: 2\n"
         )
         capt = CapTest.from_yaml(p, key="captest_bifi")
-        assert capt.test_setup == "bifi_e2848_etotal"
+        assert capt.test_setup == "bifi_e2848_etotal_rear_shade_sim"
         assert capt.ac_nameplate == 2
 
     def test_from_yaml_missing_key_lists_available_keys(self, tmp_path):
@@ -1908,7 +1910,7 @@ class TestYamlKeyParametrization:
             "  test_setup: e2848_default\n"
             "  ac_nameplate: 10\n"
         )
-        capt = CapTest(test_setup="bifi_e2848_etotal", ac_nameplate=20)
+        capt = CapTest(test_setup="bifi_e2848_etotal_rear_shade_sim", ac_nameplate=20)
         capt.to_yaml(p, key="captest_bifi", merge_into_existing=True)
         doc = yaml.safe_load(p.read_text())
         # Other top-level keys preserved.
@@ -1918,7 +1920,7 @@ class TestYamlKeyParametrization:
         assert doc["captest"]["test_setup"] == "e2848_default"
         assert doc["captest"]["ac_nameplate"] == 10
         # New captest_bifi sub-map written.
-        assert doc["captest_bifi"]["test_setup"] == "bifi_e2848_etotal"
+        assert doc["captest_bifi"]["test_setup"] == "bifi_e2848_etotal_rear_shade_sim"
         assert doc["captest_bifi"]["ac_nameplate"] == 20
 
     def test_to_yaml_merge_false_overwrites_existing_file(self, tmp_path):
@@ -1975,7 +1977,7 @@ class TestIntegration:
         assert ct_default.meas.regression_cols["poa"] == "irr_poa_mean_agg"
         assert ct_default.sim.regression_cols["poa"] == "GlobInc"
 
-    def test_end_to_end_bifi_e2848_etotal(self, ct_etotal):
+    def test_end_to_end_bifi_e2848_etotal_rear_shade_sim(self, ct_etotal):
         """Bifacial e_total preset runs end-to-end; e_total column materialized."""
         # setup() (called by from_params) already ran process_regression_columns
         # which adds the e_total column to both CapData instances.

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -32,7 +32,13 @@ from captest.calcparams import (
 _DEFAULT_FIXTURE_PRESETS = [
     p
     for p in ct.TEST_SETUPS.keys()
-    if p not in {"e2848_spec_corrected_poa", "bifi_power_tc_meas_tbom"}
+    if p
+    not in {
+        "e2848_spec_corrected_poa",
+        "bifi_power_tc_meas_tbom",
+        "bifi_e2848_spec_corrected_etotal_rear_shade_sim",
+        "bifi_e2848_spec_corrected_etotal_rear_shade_meas",
+    }
 ]
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -302,6 +302,38 @@ class TestProcessRegCols:
             assert v == test_dict[k]
 
 
+class TestGetOrCreateAggregationReuse:
+    """A pre-existing <group>_<func>_agg column is reused, not re-aggregated.
+
+    This happens e.g. when measured data is loaded from a previously
+    exported test-data csv that already contains aggregated columns. The
+    reuse should be reported when verbose so the absence of an
+    'Aggregating ...' block is explained.
+    """
+
+    def test_reuses_existing_column_and_prints_message(self, nested_calc_dict, capsys):
+        dummy_cd, _ = nested_calc_dict
+        dummy_cd.data["irr_poa_mean_agg"] = np.full(10, 7)
+        reg_cols = {"poa": ("irr_poa", "mean")}
+        util.process_reg_cols(reg_cols, cd=dummy_cd)
+        captured = capsys.readouterr()
+        assert (
+            "Reusing existing column 'irr_poa_mean_agg'; skipping "
+            "aggregation of the irr_poa group." in captured.out
+        )
+        assert reg_cols["poa"] == "irr_poa_mean_agg"
+        assert not hasattr(dummy_cd, "agg_group_kwargs")
+
+    def test_reuse_is_silent_when_verbose_false(self, nested_calc_dict, capsys):
+        dummy_cd, _ = nested_calc_dict
+        dummy_cd.data["irr_poa_mean_agg"] = np.full(10, 7)
+        reg_cols = {"poa": ("irr_poa", "mean")}
+        util.process_reg_cols(reg_cols, cd=dummy_cd, verbose=False)
+        assert capsys.readouterr().out == ""
+        assert reg_cols["poa"] == "irr_poa_mean_agg"
+        assert not hasattr(dummy_cd, "agg_group_kwargs")
+
+
 class TestParseRegressionFormula:
     def test_astm(self):
         lhs, rhs = util.parse_regression_formula(


### PR DESCRIPTION
## Summary

Extends `CapTest` with the remaining ASTM E2848 / bifacial calc-params as first-class parameters, adds a measured-side rear-shading preset, and renames the bifacial `e_total` presets so their names state *where* rear-shade loss is handled. Includes accompanying docs and tests.

## Changes

- Add calc-params as `CapTest` parameters, propagated onto the bound `CapData` instances during `setup()`:
  - `bifacial_frac`, `module_type`, `racking`, `airmass_model`, `altitude_override` — propagated to **both** meas and sim.
  - `rear_shade` — propagated to the **measured** `CapData` only (via `_downstream_attrs_meas_only`).
- Add the `bifi_e2848_etotal_rear_shade_meas` preset: rear shading applied on the measured side via the `e_total` `rear_shade` factor, while the modeled rear maps directly to PVsyst's unshaded `GlobBak`.
- **Breaking:** rename `bifi_e2848_etotal` → `bifi_e2848_etotal_rear_shade_sim` (and the in-development `bifi_e2848_etotal_meas_shade` → `bifi_e2848_etotal_rear_shade_meas`) so the rear-shade-handling side is explicit. Both preset `description` strings were rewritten to state the handling side.
- Fix `altitude_override=None` so it round-trips through `to_yaml` / `from_yaml` instead of being coerced to the default of `0` (narrow `_CAPTEST_NONE_MEANINGFUL_KEYS` exception to the `null`-stripping in `from_mapping`).
- Docs: user guide "Choosing a test setup" with per-side `E_Total` LaTeX formulas, API reference (new preset entries + a note documenting the `TEST_SETUPS` `description` key), `bifacial.rst`, `custom_test_setups.rst`, the bifacial example notebook, and the CHANGELOG.

## Testing

- `just lint`, `just fmt`, and `just test` all pass (597 tests).
- New/updated tests in `tests/test_captest.py` and `tests/test_calc_params.py` cover: parameter defaults, propagation to both sides vs. meas-only, the `_downstream_attrs_meas_only` subset invariant, flow-through into `e_total` / the Sandia temperature model / `absolute_airmass` / `apparent_zenith`, the `rear_shade_meas` preset behavior, and yaml round-tripping of the new scalars (including `altitude_override=None`).

## Notes

- Breaking change: code or yaml configs referencing `bifi_e2848_etotal` must switch to `bifi_e2848_etotal_rear_shade_sim`. That preset shipped in 0.15.0, so the rename is recorded under `[Unreleased] → Changed` in the CHANGELOG.
