### PR TITLE
feat: make CapTest.rc the single owner of test reporting conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ automatically wraps the simulated data into a contiguous year so it aligns with
 the year-end-spanning measured data — no manual step required. The auto-wrap is
 idempotent and reversible (set `auto_wrap_sim=False` and re-run `setup()` to
 restore the un-wrapped sim data).
+- Added `CapTest.rc` as the single owner of a test's reporting conditions. It is
+settable for manual override (`ct.rc = df`, a one-row DataFrame / Series / dict),
+which validates that every right-hand-side regression variable of the shared
+meas/sim formula is covered and records the source as `"manual"`. Reporting
+conditions computed via `rep_cond` (on `ct.meas` / `ct.sim`, or
+`ct.rep_cond(which=...)`) now populate `CapTest.rc` automatically —
+last-writer-wins, with a warning only when the source changes — and the single
+test RC round-trips through `to_yaml` / `from_yaml`.
 
 ### Changed
 - **Breaking:** `CapData.data_filtered` is now a derived, read-only property — the
@@ -55,6 +63,12 @@ any YAML pipeline configs written with the old `type` strings must be regenerate
 - Converted `CapData.rep_cond` to a `RepCond` zero-removal step so the
 reporting-conditions calculation appears in the summary at its position in the
 filter chain.
+- Reporting conditions are now owned at the test level by `CapTest.rc` rather than
+read per-`CapData`. `captest_results` predicts both regressions at `CapTest.rc` and
+raises `ValueError` when it is unset; `CapTest.rep_cond(which=None)` defaults to the
+current `rc_source`; and `filter_irr(ref_val="rep_irr")` within a `CapTest` resolves
+against the single test RC, so a `sim` filter can anchor on the test's reporting
+irradiance without passing the value manually.
 - Removed the internal `summary` / `summary_ix` / `removed` / `kept` mirror lists,
 the `filter_counts` dict, and the `update_summary` decorator. `get_summary()`,
 `describe_filters()`, and the visualization methods (`scatter_filters`,

--- a/docs/examples/captest_class.ipynb
+++ b/docs/examples/captest_class.ipynb
@@ -48,7 +48,9 @@
    "metadata": {},
    "source": [
     "## Load and Plot Measured Data\n",
-    "Load the measured data with the `load_data` method, which returns a CapData object. This example uses a column grouping defined in an excel file. "
+    "Load the measured data with the `load_data` method, which returns a CapData object. This example uses a column grouping defined in an excel file. \n",
+    "\n",
+    "The `test_setups` function provides a convenient way to review the available test setups. Passing `descriptions=True` will show a written description of the test setups."
    ]
   },
   {
@@ -57,8 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## uncomment line below to review options for pre-defined capacity tests\n",
-    "# ct.captest.TEST_SETUPS.keys()"
+    "ct.test_setups()"
    ]
   },
   {
@@ -322,9 +323,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pvcaptest_bt-",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pvcaptest_bt-"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/captest_class.ipynb
+++ b/docs/examples/captest_class.ipynb
@@ -196,16 +196,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load and Filter PVsyst Data\n",
-    "\n",
-    "To load and filter the modeled data, often from PVsyst, we simply create a new CapData object, load the PVsyst data, and apply the filtering methods as appropriate."
+    "## Load and Filter PVsyst Data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To load pvsyst data we use the `load_data` method with the `load_pvsyst` option set to True.  By default the `load_data` method will search for a csv file that includes `pvsyst` in the filename in a `data` directory in the same directory as this file.  If you have saved the pvsyst file in a different location, you can use the `path` and `fname` arguments to load it."
+    "Running `CapTest.from_params` at the beginning of the notebook loaded the PVsyst data into `CapTest.sim.data`. So, we can begin with the PVsyst data filtering."
    ]
   },
   {
@@ -216,15 +214,6 @@
    "source": [
     "# Write over cptest.flt_sim dataframe with a copy of the original unfiltered dataframe\n",
     "ts.sim.reset_filter()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ts.min_irr"
    ]
   },
   {
@@ -293,7 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts.meas.rc"
+    "ts.rc"
    ]
   },
   {
@@ -333,9 +322,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pvcaptest_bt-",
    "language": "python",
-   "name": "python3"
+   "name": "pvcaptest_bt-"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/captest_class_bifi.ipynb
+++ b/docs/examples/captest_class_bifi.ipynb
@@ -389,9 +389,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pvcaptest_bt-",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pvcaptest_bt-"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/captest_class_bifi.ipynb
+++ b/docs/examples/captest_class_bifi.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "## uncomment line below to review options for pre-defined capacity tests\n",
-    "# ct.captest.TEST_SETUPS.keys()"
+    "# ct.test_setups()"
    ]
   },
   {

--- a/docs/examples/captest_from_config.ipynb
+++ b/docs/examples/captest_from_config.ipynb
@@ -309,9 +309,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pvcaptest_bt-",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pvcaptest_bt-"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/complete_capacity_test.ipynb
+++ b/docs/examples/complete_capacity_test.ipynb
@@ -684,7 +684,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts = ct.CapTest(meas=das, sim=sim, ac_nameplate=6_000, test_tolerance='+/- 7')"
+    "ts = ct.CapTest(meas=das, sim=sim, ac_nameplate=6_000, test_tolerance='+/- 7')\n",
+    "ts.rc = das.rc"
    ]
   },
   {

--- a/docs/examples/concise_capacity_test.ipynb
+++ b/docs/examples/concise_capacity_test.ipynb
@@ -298,7 +298,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts = ct.CapTest(meas=das, sim=sim, ac_nameplate=6_000, test_tolerance='+/- 7')"
+    "ts = ct.CapTest(meas=das, sim=sim, ac_nameplate=6_000, test_tolerance='+/- 7')\n",
+    "ts.rc = das.rc"
    ]
   },
   {

--- a/docs/examples/reporting_conditions.ipynb
+++ b/docs/examples/reporting_conditions.ipynb
@@ -16,7 +16,6 @@
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "import pandas as pd\n",
-    "import matplotlib as plt\n",
     "import captest as ct"
    ]
   },
@@ -67,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is an exmaple of calculating reporting conditions using all defaults, which are set based on the ASTM E2939 standard.  The reporting condition method always performs calculations using the filtered dataframe stored in the df_flt attribute.\n",
+    "Below is an exmaple of calculating reporting conditions using all defaults, which are set based on the ASTM E2939 standard.  The reporting condition method always performs calculations using the filtered data accessible through `data_filtered`.\n",
     "\n",
     "- RC_irr 60% percentile\n",
     "- RC_temp mean\n",
@@ -83,6 +82,45 @@
    "outputs": [],
    "source": [
     "meas.rep_cond()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the func argument is passed straight through to pandas' DataFrame.agg, each reporting condition can be computed with any aggregation pandas\n",
+    "supports — a built-in aggregation named as a string (e.g. 'mean', 'median', 'sum', 'min', 'max'), a NumPy or user-defined callable, or a per-variable dict\n",
+    "that mixes them (e.g. {'poa': perc_wrap(60), 't_amb': 'mean', 'w_vel': 'mean'}). This means you are not limited to the default values: any regression variable can use a different statistic without changing captest itself. For the full list of aggregations that can be passed as\n",
+    "strings, see the [pandas built-in aggregation methods](https://pandas.pydata.org/docs/user_guide/groupby.html#built-in-aggregation-methods).\n",
+    "\n",
+    "A few examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meas.rep_cond(func='median')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meas.rep_cond(func='mean')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meas.rep_cond(func={'poa': ct.util.perc_wrap(70), 't_amb':'mean', 'w_vel':'mean'}, w_vel=1)"
    ]
   },
   {
@@ -124,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The instance of `ReportingIrradiance` created is stored in the `rc_tool` attribute and additional, so it can be used to access additional documentation of the reporting irradiance calculation. For example, there is a plot method, which marks the reporting irradiance selected on a linked plots showing the count of points above and below the reporting irradiance, the percent of points below the reporting irradiance, and the total points within the specifiec +/- percent band centered on the reporting irradiance."
+    "The instance of `ReportingIrradiance` created is stored in the `rc_tool` attribute, so it can be used to access additional documentation of the reporting irradiance calculation. For example, there is a plot method, which marks the reporting irradiance selected on a linked plots showing the count of points above and below the reporting irradiance, the percent of points below the reporting irradiance, and the total points within the specifiec +/- percent band centered on the reporting irradiance."
    ]
   },
   {
@@ -174,7 +212,9 @@
    "source": [
     "## Reporting Conditions spanning New Year Using TMY Data\n",
     "\n",
-    "The cntg_eoy year function can be used to wrap tmy data around the beginning/end of the year to prepare for calculating reporting conditions using time periods that span the new year."
+    "The `wrap_year_end` function can be used to wrap tmy data around the beginning/end of the year to prepare for calculating reporting conditions using time periods that span the new year.\n",
+    "\n",
+    "**NOTE: As of v0.17.0 the when using the `CapTest` class TMY data for a test close to the end / beginning of the year is wrapped automatically when loaded.**"
    ]
   },
   {
@@ -210,9 +250,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pvsyst.df_flt = ct.capdata.wrap_year_end(pvsyst.data_filtered, \n",
-    "                                  pd.Timestamp(year=1989, month=12, day=15),\n",
-    "                                  pd.Timestamp(year=1990, month=1, day=15))"
+    "pvsyst.df_flt = ct.capdata.wrap_year_end(\n",
+    "    pvsyst.data_filtered, \n",
+    "    pd.Timestamp(year=1989, month=12, day=15),\n",
+    "    pd.Timestamp(year=1990, month=1, day=15)\n",
+    ")"
    ]
   },
   {
@@ -386,7 +428,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/api_reference/capdata.rst
+++ b/docs/source/api_reference/capdata.rst
@@ -93,13 +93,17 @@ chain. See :doc:`filters` for the underlying step classes.
 Reporting Conditions
 --------------------
 
-Methods for computing ASTM E2848 reporting conditions.
+Methods for computing ASTM E2848 reporting conditions. ``rep_irr`` is the
+reporting POA irradiance used to anchor ``filter_irr(ref_val='rep_irr')``; within
+a :py:class:`~captest.captest.CapTest` it resolves from the single test RC. See
+:ref:`reporting_conditions` in the user guide.
 
 .. autosummary::
    :toctree: generated/
 
    capdata.CapData.rep_cond
    capdata.CapData.rep_cond_freq
+   capdata.CapData.rep_irr
 
 Regression
 ----------

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -41,9 +41,17 @@ Methods for configuring the test and serializing configuration.
 Reporting Conditions
 --------------------
 
+A capacity test has a single set of reporting conditions, owned by the test as
+:py:attr:`~captest.captest.CapTest.rc` and tracked by
+:py:attr:`~captest.captest.CapTest.rc_source` (``'meas'`` / ``'sim'`` /
+``'manual'``). Compute them with :py:meth:`~captest.captest.CapTest.rep_cond`
+or assign them directly via the ``rc`` setter. See :ref:`reporting_conditions`
+in the user guide for the full model.
+
 .. autosummary::
    :toctree: generated/
 
+   captest.CapTest.rc
    captest.CapTest.rep_cond
    captest.CapTest.rep_irr_filter_low
    captest.CapTest.rep_irr_filter_high

--- a/docs/source/api_reference/generated/captest.CapTest.rc.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rc.rst
@@ -1,0 +1,6 @@
+﻿captest.CapTest.rc
+==================
+
+.. currentmodule:: captest
+
+.. autoproperty:: CapTest.rc

--- a/docs/source/api_reference/generated/captest.CapTest.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rst
@@ -58,6 +58,7 @@
       ~CapTest.param
       ~CapTest.power_temp_coeff
       ~CapTest.racking
+      ~CapTest.rc
       ~CapTest.rc_source
       ~CapTest.rear_shade
       ~CapTest.reg_cols_meas

--- a/docs/source/api_reference/generated/captest.capdata.CapData.rep_irr.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.rep_irr.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.rep\_irr
+================================
+
+.. currentmodule:: captest.capdata
+
+.. autoproperty:: CapData.rep_irr

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-1-data-model.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-1-data-model.md
@@ -1,0 +1,429 @@
+# CapTest RC Ownership — Plan 1: Data Model + Resolution Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `CapTest.rc` as the single stored test reporting-conditions value (with `rc_source` provenance incl. `"manual"`), replace the `CapData.rc_source_resolved` CapData→CapData reference with a `CapData._captest` back-reference, and make `CapData.rep_irr` resolve from `ct.rc` inside a test (else `self.rc`).
+
+**Architecture:** `CapTest` stores `_rc` (a one-row DataFrame or None) behind a read-only `rc` property and a private `_set_rc(df, source, warn)` write point that also sets the `rc_source` Selector. `CapTest.setup()` wires `cd._captest = self` on both CapData instances. `CapData.rep_irr` reads `self._captest.rc` when in a test, otherwise `self.rc`. This plan does **not** yet auto-populate `ct.rc` from `rep_cond` (Plan 3) or add the manual setter (Plan 2); tests here populate `ct.rc` directly via `_set_rc`.
+
+**Tech Stack:** Python, `param` (Parameterized/Selector), pandas, pytest, `uv`, `just`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md`.
+- Standalone `CapData` behavior must not change: `cd.rep_cond()` still sets `cd.rc`; `cd.filter_irr(ref_val="rep_irr")` outside a test still resolves from `cd.rc`.
+- `capdata.py` must NOT import `captest` — `_captest` is an opaque runtime reference only.
+- Line length 88 (ruff). NumPy-style docstrings on public API.
+- Execution is deferred until after the `filters-refactor` branch merges and releases.
+- Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` and `uv run ruff format`.
+
+---
+
+### Task 1: `CapTest` RC storage (`_rc`, `_loading`, `rc` getter, `_set_rc`, `rc_source` += `"manual"`)
+
+**Files:**
+- Modify: `src/captest/captest.py` — `__init__` (around line 1546-1555), `rc_source` Selector (line 1347), add `rc` property + `_set_rc` after `__init__`.
+- Test: `tests/test_captest.py` — new class `TestTestRc`.
+
+**Interfaces:**
+- Produces:
+  - `CapTest.rc` → property returning the stored one-row `pandas.DataFrame` or `None`.
+  - `CapTest._set_rc(rc: pandas.DataFrame, source: str, warn: bool = True) -> None` — sets `self._rc = rc` and `self.rc_source = source`; emits a `UserWarning` when `warn and self._rc is not None and source != self.rc_source`.
+  - `CapTest.rc_source` Selector objects become `["meas", "sim", "manual"]`.
+  - `CapTest._rc` (private, default `None`), `CapTest._loading` (private bool, default `False`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_captest.py` (top of file already has `import pytest`, `import pandas as pd`, `from captest import CapTest`):
+
+```python
+class TestTestRc:
+    """CapTest.rc storage, _set_rc write point, and source-change warning."""
+
+    def _rc_df(self, poa=800.0):
+        return pd.DataFrame({"poa": [poa], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_rc_defaults_none_and_source_meas(self):
+        ct = CapTest()
+        assert ct.rc is None
+        assert ct.rc_source == "meas"
+        assert ct._loading is False
+
+    def test_set_rc_first_set_is_silent_and_records_source(self, recwarn):
+        ct = CapTest()
+        df = self._rc_df()
+        ct._set_rc(df, "sim")
+        assert ct.rc is df
+        assert ct.rc_source == "sim"
+        assert len(recwarn) == 0
+
+    def test_set_rc_same_source_is_silent(self, recwarn):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        ct._set_rc(self._rc_df(810.0), "meas")
+        assert ct.rc_source == "meas"
+        assert len(recwarn) == 0
+
+    def test_set_rc_source_change_warns(self):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        with pytest.warns(UserWarning, match="rc_source changed from 'meas' to 'sim'"):
+            ct._set_rc(self._rc_df(), "sim")
+        assert ct.rc_source == "sim"
+
+    def test_set_rc_warn_false_suppresses(self, recwarn):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        ct._set_rc(self._rc_df(), "manual", warn=False)
+        assert ct.rc_source == "manual"
+        assert len(recwarn) == 0
+
+    def test_rc_source_accepts_manual(self):
+        ct = CapTest()
+        ct.rc_source = "manual"  # must not raise (Selector now allows it)
+        assert ct.rc_source == "manual"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `TestTestRc` errors (`AttributeError: 'CapTest' object has no attribute '_set_rc'` / `_loading`; `test_rc_source_accepts_manual` raises `ValueError` from the Selector).
+
+- [ ] **Step 3: Extend the `rc_source` Selector**
+
+In `src/captest/captest.py`, change the Selector at line ~1347 from:
+
+```python
+    rc_source = param.Selector(
+        objects=["meas", "sim"],
+        default="meas",
+        doc="Which CapData provides reporting conditions: used by "
+        "captest_results and as the source that filter_irr(ref_val='rep_irr') "
+        "resolves against on both meas and sim.",
+    )
+```
+
+to:
+
+```python
+    rc_source = param.Selector(
+        objects=["meas", "sim", "manual"],
+        default="meas",
+        doc="Provenance of the single test RC (CapTest.rc): 'meas'/'sim' when "
+        "computed from that dataset's rep_cond, or 'manual' when set directly. "
+        "Seeds the default 'which' for rep_cond.",
+    )
+```
+
+- [ ] **Step 4: Initialize `_rc` and `_loading` in `__init__`**
+
+In `src/captest/captest.py`, in `__init__` (after `self._sim_path = None`, line ~1555), add:
+
+```python
+        # The single test reporting-conditions DataFrame (or None). Plain attr,
+        # not a param.*, so the `rc` property setter can validate and the
+        # `_set_rc` write point can manage provenance. `_loading` is True only
+        # during from_yaml replay (see Plan 5) to seed RC from config.
+        self._rc = None
+        self._loading = False
+```
+
+- [ ] **Step 5: Add the `rc` getter and `_set_rc` write point**
+
+In `src/captest/captest.py`, immediately after `__init__` (before the `# --- constructors ---` comment at line ~1557), add:
+
+```python
+    @property
+    def rc(self):
+        """The single test reporting-conditions DataFrame, or ``None``.
+
+        Sourced from ``meas``/``sim`` via :meth:`rep_cond` or set manually via
+        the property setter; provenance is tracked by :attr:`rc_source`. See the
+        RC-ownership design spec for the full lifecycle.
+        """
+        return self._rc
+
+    def _set_rc(self, rc, source, warn=True):
+        """Single internal write point for ``_rc`` and ``rc_source``.
+
+        Emits a source-change ``UserWarning`` when ``warn`` is True, an RC is
+        already set, and ``source`` differs from the current ``rc_source``
+        (silent on first establishment and same-source recompute).
+
+        Parameters
+        ----------
+        rc : pandas.DataFrame
+            One-row reporting-conditions DataFrame.
+        source : {'meas', 'sim', 'manual'}
+            Provenance to record in ``rc_source``.
+        warn : bool, default True
+            Suppress the source-change warning when False (used during load).
+        """
+        if warn and self._rc is not None and source != self.rc_source:
+            warnings.warn(
+                f"Test reporting conditions rc_source changed from "
+                f"'{self.rc_source}' to '{source}'."
+            )
+        self._rc = rc
+        self.rc_source = source
+```
+
+(`warnings` is already imported in `captest.py`.)
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for `TestTestRc`; rest of module still passes.
+
+- [ ] **Step 7: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass; files formatted.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: add CapTest.rc storage and _set_rc write point
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `CapData._captest` back-reference, `rep_irr` rewrite, `setup()` wiring
+
+**Files:**
+- Modify: `src/captest/capdata.py` — `__init__` (line 842), `rep_irr` property (lines 943-980).
+- Modify: `src/captest/captest.py` — `setup()` wiring (lines 2185-2193).
+- Test: `tests/test_CapData.py` (standalone `rep_irr`), `tests/test_captest.py` (`setup()` wiring + in-test `rep_irr`).
+
+**Interfaces:**
+- Consumes: `CapTest.rc` / `CapTest._set_rc` (Task 1).
+- Produces:
+  - `CapData._captest` (private, default `None`; a `CapTest` reference or `None`).
+  - `CapData.rep_irr` → `float`; reads `self._captest.rc` when `_captest is not None`, else `self.rc`; raises `ValueError` (distinct in-test vs standalone messages) when the resolved RC is `None`, and when it lacks a `"poa"` column.
+  - `CapTest.setup()` sets `self.meas._captest = self` and `self.sim._captest = self`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_CapData.py` — replace the existing `TestRepIrr` class (lines ~2320-2353, the one using `rc_source_resolved`) with:
+
+```python
+class TestRepIrr:
+    """The standalone CapData.rep_irr property (no CapTest attached)."""
+
+    def test_rep_irr_reads_self_rc_when_standalone(self, nrel):
+        """rep_irr reads self.rc when this CapData has no _captest."""
+        assert nrel._captest is None
+        nrel.rc = pd.DataFrame({"poa": [222.0], "t_amb": [20], "w_vel": [2]})
+        assert nrel.rep_irr == pytest.approx(222.0)
+
+    def test_rep_irr_standalone_none_rc_raises(self, nrel):
+        """Standalone with no rc raises directing to rep_cond()."""
+        assert nrel.rc is None
+        with pytest.raises(ValueError, match="requires reporting conditions"):
+            nrel.rep_irr
+
+    def test_rep_irr_missing_poa_column_raises(self, nrel):
+        """rep_irr raises when the resolved rc lacks a 'poa' column."""
+        nrel.rc = pd.DataFrame({"irr": [500.0], "t_amb": [20], "w_vel": [2]})
+        with pytest.raises(ValueError, match="requires a 'poa' column"):
+            nrel.rep_irr
+```
+
+Add to `tests/test_captest.py` — replace the two `test_setup_wires_rc_source_resolved_*` methods in `TestSetup` (lines ~979-996) with:
+
+```python
+    def test_setup_wires_captest_backref_on_both(self, ct_default):
+        """setup() wires _captest back to the CapTest on both CapData."""
+        assert ct_default.meas._captest is ct_default
+        assert ct_default.sim._captest is ct_default
+```
+
+And in `TestRepIrrCrossInstance` (class at line ~1061), replace
+`test_sim_rep_irr_filter_uses_meas_reporting_irradiance` and
+`test_sim_rep_irr_filter_roundtrips_through_yaml` with these (they set `ct.rc`
+via `_set_rc` because `rep_cond` auto-sync lands in Plan 3):
+
+```python
+    def test_sim_rep_irr_resolves_from_ct_rc(self, ct_default):
+        """sim.rep_irr reads the test-level ct.rc (set here via _set_rc)."""
+        rc = pd.DataFrame({"poa": [777.0], "t_amb": [25.0], "w_vel": [2.0]})
+        ct_default._set_rc(rc, "meas")
+        assert ct_default.sim.rep_irr == pytest.approx(777.0)
+        assert ct_default.meas.rep_irr == pytest.approx(777.0)
+
+    def test_rep_irr_in_test_without_rc_raises(self, ct_default):
+        """In a test, rep_irr with ct.rc unset raises directing to rep_cond."""
+        assert ct_default.rc is None
+        with pytest.raises(ValueError, match="test reporting conditions"):
+            ct_default.sim.rep_irr
+
+    def test_sim_filter_irr_rep_irr_uses_ct_rc(self, ct_default):
+        """filter_irr(ref_val='rep_irr') on sim filters around ct.rc's poa."""
+        rc = pd.DataFrame({"poa": [500.0], "t_amb": [25.0], "w_vel": [2.0]})
+        ct_default._set_rc(rc, "meas")
+        ct_default.sim.filter_irr(0.8, 1.2, ref_val="rep_irr")
+        step = ct_default.sim.filters[-1]
+        assert step.ref_val_resolved == pytest.approx(500.0)
+        assert step.low_effective == pytest.approx(0.8 * 500.0)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_CapData.py` then `... test-module test_captest.py`
+Expected: FAIL — `AttributeError: 'CapData' object has no attribute '_captest'` (and the in-test `rep_irr` tests fail because `rep_irr` still reads `rc_source_resolved`).
+
+- [ ] **Step 3: Rename the CapData attribute in `__init__`**
+
+In `src/captest/capdata.py` line 842, change:
+
+```python
+        self.rc_source_resolved = None
+```
+
+to:
+
+```python
+        # Back-reference to the owning CapTest (set by CapTest.setup), or None
+        # for standalone use. Opaque runtime reference only — capdata.py never
+        # imports captest. Intentionally NOT copied by CapData.copy().
+        self._captest = None
+```
+
+- [ ] **Step 4: Rewrite the `rep_irr` property**
+
+In `src/captest/capdata.py`, replace the whole `rep_irr` property (lines ~943-980, ending at the `return float(...)`):
+
+```python
+    @property
+    def rep_irr(self):
+        """Reporting POA irradiance anchoring relative irradiance filters.
+
+        Resolved when ``filter_irr`` is called with ``ref_val='rep_irr'`` (or the
+        legacy ``'self_val'``). Inside a CapTest (``self._captest`` set by
+        ``CapTest.setup``) it reads the single test RC ``self._captest.rc``;
+        standalone it reads this instance's own ``self.rc``.
+
+        Returns
+        -------
+        float
+            The ``'poa'`` reporting condition of the resolved RC.
+
+        Raises
+        ------
+        ValueError
+            If no RC is available, or the resolved RC lacks a ``'poa'`` column.
+        """
+        in_test = self._captest is not None
+        rc = self._captest.rc if in_test else self.rc
+        if rc is None:
+            if in_test:
+                raise ValueError(
+                    "ref_val='rep_irr' requires test reporting conditions. Call "
+                    "ct.rep_cond(which) or assign ct.rc = df before filtering."
+                )
+            raise ValueError(
+                "ref_val='rep_irr' requires reporting conditions. Call "
+                "rep_cond() before filtering with ref_val='rep_irr'."
+            )
+        if "poa" not in rc.columns:
+            raise ValueError(
+                "ref_val='rep_irr' requires a 'poa' column in the reporting "
+                "conditions."
+            )
+        return float(rc["poa"].iloc[0])
+```
+
+- [ ] **Step 5: Rewrite the `setup()` wiring**
+
+In `src/captest/captest.py`, replace lines ~2185-2193 (the `rc_source_resolved` block):
+
+```python
+        # Wire each CapData back to this CapTest so filter_irr(ref_val='rep_irr')
+        # resolves against the single test RC (ct.rc), and (Plan 3) so cd.rep_cond
+        # can update it. Runtime reference only; capdata.py never imports captest.
+        # Assigned per side so a future per-side setup can re-wire one side alone.
+        self.meas._captest = self
+        self.sim._captest = self
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_CapData.py` then `... test-module test_captest.py`
+Expected: PASS for the new/updated tests.
+
+- [ ] **Step 7: Verify no stale `rc_source_resolved` references remain**
+
+Run: `grep -rn "rc_source_resolved" src/ tests/`
+Expected: no output.
+
+- [ ] **Step 8: Lint**
+
+Run: `uv run ruff check src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py && uv run ruff format src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py
+git commit -m "refactor: resolve rep_irr from CapTest.rc via _captest back-reference
+
+Replace CapData.rc_source_resolved (CapData->CapData) with a _captest
+back-reference; rep_irr reads the single test rc (ct.rc) in a test, else
+self.rc. setup() wires _captest on both sides.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full-suite green + standalone regression guard
+
+**Files:**
+- Test: full suite (no new source changes expected; this task is the integration gate).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-2.
+- Produces: nothing new — verifies the plan's deliverable holds across the whole suite.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
+Expected: all tests pass. If any test outside the updated classes references `rc_source_resolved` or relied on the old per-CapData `rep_irr` resolution, fix it to the `_captest`/`ct.rc` model (set `ct.rc` via `_set_rc` in test setup) and re-run.
+
+- [ ] **Step 2: Confirm standalone CapData behavior is unchanged**
+
+Run: `uv run pytest tests/test_CapData.py -q -k "rep_cond or filter_irr or RepIrr"`
+Expected: PASS — standalone `rep_cond`/`filter_irr` tests are green, demonstrating no behavior change for CapData used without a CapTest.
+
+- [ ] **Step 3: Lint + format the whole change**
+
+Run: `uv run ruff check src/ tests/ && uv run ruff format --check src/captest/capdata.py src/captest/captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 4: Commit (only if Step 1 required fixes; otherwise skip)**
+
+```bash
+git add -A
+git commit -m "test: migrate remaining suites to _captest/ct.rc resolution model
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 1 scope = §4.1 data model, §4.2 resolution, §4.8 setup wiring, partial §4.5 via `_set_rc`):**
+- §4.1 `CapTest.rc` property + `_rc` + `rc_source` incl. `"manual"` → Task 1. ✓
+- §4.1 `CapData._captest` replacing `rc_source_resolved` → Task 2. ✓
+- §4.2 `rep_irr` reads `ct.rc` in test else `self.rc`, with messages → Task 2. ✓
+- §4.5 source-change warning logic lives in `_set_rc` → Task 1 (the rep_cond/manual *callers* are Plans 2-3). ✓
+- §4.8 `setup()` wires `_captest`; does not touch `ct.rc` → Task 2. ✓
+- Out of scope (later plans): manual setter (Plan 2), `rep_cond` auto-sync (Plan 3), `captest_results` (Plan 4), serialization/load incl. `_loading` use (Plan 5). `_loading` is *declared* here (Task 1) but only read in Plan 5.
+
+**Placeholder scan:** none — every step shows exact code/commands.
+
+**Type consistency:** `_set_rc(rc, source, warn=True)` signature is consistent across Task 1 definition and Task 2/3 usage; `rc` getter returns DataFrame|None; `_captest` is CapTest|None; `rep_irr` returns float. The `TestRepIrrCrossInstance` tests set `ct.rc` via `_set_rc` (the only write path available until Plan 2's setter / Plan 3's sync).

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-1-data-model.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-1-data-model.md
@@ -16,6 +16,16 @@
 - Line length 88 (ruff). NumPy-style docstrings on public API.
 - Execution is deferred until after the `filters-refactor` branch merges and releases.
 - Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` and `uv run ruff format`.
+- **Plans 1-5 must merge and release as a unit — do not release Plan 1 alone.** In
+  Plan 1 the only writer of `ct.rc` is `_set_rc` (used directly in tests); the
+  `rep_cond → ct.rc` auto-sync lands in Plan 3 and load-seeding in Plan 5.
+  Therefore, between Plan 1 and Plan 3, the real cross-instance workflow
+  `ct.meas.rep_cond(); ct.sim.filter_irr(ref_val="rep_irr")` is **intentionally
+  non-functional** (the bare `rep_cond` writes `cd.rc`, not `ct.rc`, so
+  `sim.rep_irr` raises `ValueError`), and the `rep_irr` YAML round-trip is
+  intentionally not yet exercised. This regression versus the current
+  `rc_source_resolved` behavior is expected and tracked by an `xfail` placeholder
+  test (Task 2, Step 1) that Plan 5 un-marks.
 
 ---
 
@@ -194,7 +204,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ### Task 2: `CapData._captest` back-reference, `rep_irr` rewrite, `setup()` wiring
 
 **Files:**
-- Modify: `src/captest/capdata.py` — `__init__` (line 842), `rep_irr` property (lines 943-980).
+- Modify: `src/captest/capdata.py` — `__init__` (line 842), `rep_irr` property (lines 943-980), `filter_irr` docstring (lines 1742-1748).
 - Modify: `src/captest/captest.py` — `setup()` wiring (lines 2185-2193).
 - Test: `tests/test_CapData.py` (standalone `rep_irr`), `tests/test_captest.py` (`setup()` wiring + in-test `rep_irr`).
 
@@ -268,6 +278,28 @@ via `_set_rc` because `rep_cond` auto-sync lands in Plan 3):
         step = ct_default.sim.filters[-1]
         assert step.ref_val_resolved == pytest.approx(500.0)
         assert step.low_effective == pytest.approx(0.8 * 500.0)
+
+    @pytest.mark.xfail(
+        reason="rep_cond->ct.rc auto-sync lands in Plan 3 and the rep_irr YAML "
+        "round-trip in Plan 5; placeholder keeps the deferred end-to-end "
+        "coverage gap visible. Plan 5 removes this marker.",
+        strict=False,
+    )
+    def test_meas_rep_cond_then_sim_rep_irr_roundtrips(self, ct_default, tmp_path):
+        """End-to-end: meas.rep_cond seeds ct.rc, sim filters around it, and the
+        pipeline round-trips through to_yaml. Enabled in Plan 5."""
+        import yaml
+
+        ct_default.meas.filter_irr(200, 800)
+        ct_default.meas.rep_cond()
+        ct_default.sim.filter_irr(0.8, 1.2, ref_val="rep_irr")
+        path = tmp_path / "ct.yaml"
+        ct_default.to_yaml(path, merge_into_existing=False)
+        doc = yaml.safe_load(path.read_text())
+        sim_irr = [
+            d for d in doc["captest"]["sim_filters"] if d["type"] == "Irradiance"
+        ]
+        assert sim_irr[-1]["ref_val"] == "rep_irr"
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -336,7 +368,30 @@ In `src/captest/capdata.py`, replace the whole `rep_irr` property (lines ~943-98
         return float(rc["poa"].iloc[0])
 ```
 
-- [ ] **Step 5: Rewrite the `setup()` wiring**
+- [ ] **Step 5: Update the `filter_irr` docstring to the `ct.rc` model**
+
+In `src/captest/capdata.py`, the `filter_irr` `ref_val` docstring (lines ~1744-1748) still describes the old per-instance `rc_source` resolution. Replace:
+
+```python
+            Pass ``'rep_irr'`` to use the reporting irradiance from
+            :attr:`rep_irr` (set by calling :meth:`rep_cond` first). Within a
+            :class:`~captest.captest.CapTest`, ``'rep_irr'`` resolves against
+            the ``rc_source`` instance, so a ``sim`` filter can anchor on the
+            ``meas`` reporting irradiance without passing the value manually.
+```
+
+with:
+
+```python
+            Pass ``'rep_irr'`` to use the reporting irradiance from
+            :attr:`rep_irr` (set by calling :meth:`rep_cond` first). Within a
+            :class:`~captest.captest.CapTest`, ``'rep_irr'`` resolves against the
+            single test reporting conditions ``ct.rc``, so a ``sim`` filter can
+            anchor on the test's reporting irradiance without passing the value
+            manually.
+```
+
+- [ ] **Step 6: Rewrite the `setup()` wiring**
 
 In `src/captest/captest.py`, replace lines ~2185-2193 (the `rc_source_resolved` block):
 
@@ -349,22 +404,25 @@ In `src/captest/captest.py`, replace lines ~2185-2193 (the `rc_source_resolved` 
         self.sim._captest = self
 ```
 
-- [ ] **Step 6: Run the tests to verify they pass**
+- [ ] **Step 7: Run the tests to verify they pass**
 
 Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_CapData.py` then `... test-module test_captest.py`
-Expected: PASS for the new/updated tests.
+Expected: PASS for the new/updated tests; `test_meas_rep_cond_then_sim_rep_irr_roundtrips` reports XFAIL (expected).
 
-- [ ] **Step 7: Verify no stale `rc_source_resolved` references remain**
+- [ ] **Step 8: Verify no stale references remain**
 
 Run: `grep -rn "rc_source_resolved" src/ tests/`
 Expected: no output.
 
-- [ ] **Step 8: Lint**
+Run: `grep -rn "rc_source" src/captest/capdata.py`
+Expected: no output (the `filter_irr` docstring no longer mentions `rc_source`; `capdata.py` should hold no `rc_source` references at all). If any line prints, update its phrasing to the `ct.rc` model.
+
+- [ ] **Step 9: Lint**
 
 Run: `uv run ruff check src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py && uv run ruff format src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py`
 Expected: All checks pass.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/captest/capdata.py src/captest/captest.py tests/test_CapData.py tests/test_captest.py
@@ -424,6 +482,17 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - §4.8 `setup()` wires `_captest`; does not touch `ct.rc` → Task 2. ✓
 - Out of scope (later plans): manual setter (Plan 2), `rep_cond` auto-sync (Plan 3), `captest_results` (Plan 4), serialization/load incl. `_loading` use (Plan 5). `_loading` is *declared* here (Task 1) but only read in Plan 5.
 
-**Placeholder scan:** none — every step shows exact code/commands.
+**Placeholder scan:** none — every step shows exact code/commands. The single
+`@pytest.mark.xfail` test (Task 2, Step 1) is a deliberate, documented coverage
+marker for the deferred end-to-end workflow, not an unfinished step.
+
+**Stale-docstring scan:** the `filter_irr` `ref_val` docstring (capdata.py:1744-1748)
+described the old per-instance `rc_source` resolution and is updated in Task 2
+Step 5; Task 2 Step 8 greps `capdata.py` for any residual `rc_source` mention.
+
+**Intermediate-regression flag:** Global Constraints states that the cross-instance
+`rep_cond → rep_irr` workflow and its YAML round-trip are intentionally
+non-functional between Plan 1 and Plans 3/5, tracked by the `xfail` placeholder,
+and that Plans 1-5 must merge/release as a unit.
 
 **Type consistency:** `_set_rc(rc, source, warn=True)` signature is consistent across Task 1 definition and Task 2/3 usage; `rc` getter returns DataFrame|None; `_captest` is CapTest|None; `rep_irr` returns float. The `TestRepIrrCrossInstance` tests set `ct.rc` via `_set_rc` (the only write path available until Plan 2's setter / Plan 3's sync).

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-2-manual-override.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-2-manual-override.md
@@ -1,0 +1,211 @@
+# CapTest RC Ownership — Plan 2: Manual Override (`ct.rc = df`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `CapTest.rc` settable — the single public way to supply reporting conditions manually (`rc_source="manual"`) — with validation that the value covers every right-hand-side regression variable.
+
+**Architecture:** Add a setter to the `rc` property introduced in Plan 1. The setter requires `setup()`, checks that `meas`/`sim` share a regression formula, coerces a DataFrame / Series / dict to a one-row DataFrame, validates RHS coverage via `util.parse_regression_formula`, then records the value through the existing `_set_rc(df, "manual")` write point (which applies the Plan 1 source-change warning). No new write path — the setter is the public face of `_set_rc(..., "manual")`.
+
+**Tech Stack:** Python, `param`, pandas, pytest, `uv`, `just`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md` §4.4, §6.
+- Builds on Plan 1 (`CapTest.rc` getter, `_set_rc`, `rc_source` incl. `"manual"`, `CapData._captest`). Plan 1 must be applied first.
+- **Plans 1-5 must merge and release as a unit** — the cross-instance `rep_cond → rep_irr` workflow remains intentionally non-functional until Plans 3/5 (see Plan 1).
+- `from captest import util` and `import pandas as pd` are already present in `captest.py` — no new imports required.
+- `_require_setup()` raises `RuntimeError` (existing helper). The spec §6 phrasing says "ValueError"; this plan reuses `_require_setup()` for DRY, so the not-setup error is `RuntimeError`. (Noted in Self-Review.)
+- Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
+
+---
+
+### Task 1: `CapTest.rc` setter with RHS-coverage validation
+
+**Files:**
+- Modify: `src/captest/captest.py` — add an `@rc.setter` immediately after the `rc` getter (added in Plan 1, just after `__init__`).
+- Test: `tests/test_captest.py` — new class `TestManualRc`.
+
+**Interfaces:**
+- Consumes: `CapTest._set_rc(rc, source, warn=True)`, `CapTest._require_setup()`, `util.parse_regression_formula(formula) -> (lhs_list, rhs_list)`, `CapData.regression_formula`.
+- Produces:
+  - `CapTest.rc` setter: `ct.rc = value` where `value` is a one-row `pandas.DataFrame`, a `pandas.Series`, or a `dict` of `regression_variable -> value`. Sets `rc_source="manual"`. Raises `RuntimeError` (not setup), `ValueError` (meas/sim formula mismatch, or missing RHS variables), `TypeError` (unsupported `value` type). Warns (via `_set_rc`) only when it changes the source.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_captest.py` (the module already imports `pytest`, `pandas as pd`, `CapTest`; `ct_default` is a fixture in `conftest.py` providing a `setup()`-run CapTest with the `e2848_default` formula `power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1`, whose RHS variables are `poa, t_amb, w_vel`):
+
+```python
+class TestManualRc:
+    """The public ct.rc = df manual-override setter (rc_source='manual')."""
+
+    def _full_rc(self, poa=805.0):
+        return pd.DataFrame({"poa": [poa], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_set_rc_dataframe_sets_manual_source(self, ct_default):
+        df = self._full_rc()
+        ct_default.rc = df
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(805.0)
+
+    def test_set_rc_accepts_dict(self, ct_default):
+        ct_default.rc = {"poa": 700.0, "t_amb": 20.0, "w_vel": 1.5}
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(700.0)
+
+    def test_set_rc_accepts_series(self, ct_default):
+        ct_default.rc = pd.Series({"poa": 650.0, "t_amb": 18.0, "w_vel": 1.0})
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(650.0)
+
+    def test_set_rc_preserves_extra_columns(self, ct_default):
+        ct_default.rc = {"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0, "note": 1.0}
+        assert "note" in ct_default.rc.columns
+
+    def test_set_rc_missing_rhs_var_raises_listing_names(self, ct_default):
+        with pytest.raises(ValueError, match=r"missing required regression"):
+            ct_default.rc = pd.DataFrame({"poa": [805.0]})
+
+    def test_set_rc_missing_var_message_names_the_missing(self, ct_default):
+        with pytest.raises(ValueError) as exc:
+            ct_default.rc = {"poa": 805.0, "t_amb": 25.0}  # w_vel missing
+        assert "w_vel" in str(exc.value)
+
+    def test_set_rc_requires_setup(self):
+        ct = CapTest()  # bare, setup() not run
+        with pytest.raises(RuntimeError, match="setup"):
+            ct.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_set_rc_formula_mismatch_raises(self, ct_default):
+        ct_default.sim.regression_formula = "power ~ poa"
+        with pytest.raises(ValueError, match="different regression formulas"):
+            ct_default.rc = self._full_rc()
+
+    def test_set_rc_bad_type_raises(self, ct_default):
+        with pytest.raises(TypeError, match="DataFrame"):
+            ct_default.rc = [805.0, 25.0, 2.0]
+
+    def test_set_rc_first_set_is_silent(self, ct_default, recwarn):
+        ct_default.rc = self._full_rc()
+        assert len(recwarn) == 0
+
+    def test_set_rc_over_computed_source_warns(self, ct_default):
+        ct_default._set_rc(self._full_rc(), "meas")  # seed a computed source
+        with pytest.warns(UserWarning, match="changed from 'meas' to 'manual'"):
+            ct_default.rc = self._full_rc(810.0)
+
+    def test_set_rc_over_manual_is_silent(self, ct_default, recwarn):
+        ct_default.rc = self._full_rc()        # first -> manual (silent)
+        ct_default.rc = self._full_rc(810.0)   # manual -> manual (silent)
+        assert len(recwarn) == 0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `AttributeError: can't set attribute 'rc'` (the property has no setter yet).
+
+- [ ] **Step 3: Add the `rc` setter**
+
+In `src/captest/captest.py`, immediately after the `rc` getter (added in Plan 1), add:
+
+```python
+    @rc.setter
+    def rc(self, value):
+        """Set the test reporting conditions manually (``rc_source='manual'``).
+
+        This is the only public way to supply reporting conditions directly —
+        e.g. for sensitivity analysis or to check results against a reviewing
+        party's values. Computed conditions go through :meth:`rep_cond` instead.
+
+        Parameters
+        ----------
+        value : pandas.DataFrame or pandas.Series or dict
+            One-row reporting conditions. A Series or dict maps each regression
+            variable to its value; a DataFrame is used as given. Must provide a
+            value for every right-hand-side variable of the (shared meas/sim)
+            regression formula. Extra columns are preserved.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`setup` has not run (the regression formula is unknown).
+        ValueError
+            If ``meas`` and ``sim`` have different regression formulas, or
+            ``value`` omits a required right-hand-side variable.
+        TypeError
+            If ``value`` is not a DataFrame, Series, or dict.
+        """
+        self._require_setup()
+        meas_fml = self.meas.regression_formula
+        sim_fml = self.sim.regression_formula
+        if meas_fml != sim_fml:
+            raise ValueError(
+                "Cannot set reporting conditions manually: meas and sim have "
+                f"different regression formulas ({meas_fml!r} vs {sim_fml!r})."
+            )
+        _, rhs = util.parse_regression_formula(meas_fml)
+        if isinstance(value, pd.DataFrame):
+            df = value.copy()
+        elif isinstance(value, pd.Series):
+            df = value.to_frame().T
+        elif isinstance(value, dict):
+            df = pd.DataFrame([value])
+        else:
+            raise TypeError(
+                "ct.rc must be a one-row DataFrame, a pandas Series, or a dict "
+                f"mapping regression variable -> value; got "
+                f"{type(value).__name__}."
+            )
+        missing = [var for var in rhs if var not in df.columns]
+        if missing:
+            raise ValueError(
+                "Manual reporting conditions are missing required regression "
+                f"variable(s): {missing}. Required: {rhs}."
+            )
+        self._set_rc(df, "manual")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for `TestManualRc`; rest of module still passes.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
+Expected: all tests pass (Plan 1 tests included; the `xfail` placeholder still reports XFAIL).
+
+- [ ] **Step 6: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: add manual CapTest.rc setter with RHS-coverage validation
+
+ct.rc = df is the single public way to set reporting conditions manually
+(rc_source='manual'); validates the value covers every RHS regression
+variable of the shared meas/sim formula and records it via _set_rc.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 2 scope = §4.4 manual override):**
+- §4.4 "only public way is `ct.rc = df`" → setter is the sole public write path; `_set_rc` stays internal. ✓
+- §4.4 step 1 requires `setup()` → `self._require_setup()`. ✓
+- §4.4 step 2 RHS validation via `util.parse_regression_formula(self.meas.regression_formula)[1]`; formula-mismatch raises; missing vars listed; extra columns preserved → covered, with tests. ✓
+- §4.4 step 3 coerce to one-row DataFrame; apply §4.5 warning; record via `_set_rc(df, "manual")` → the warning lives in `_set_rc` (Plan 1), exercised by `test_set_rc_over_computed_source_warns`. ✓
+- §4.4 "internal vs public path" — computed/load assignments use `_set_rc` directly (Plans 3/5); the public setter is `_set_rc(..., "manual")` plus validation. ✓
+
+**Placeholder scan:** none — every step has exact code/commands.
+
+**Spec deviation (noted):** §6 lists the not-setup error as `ValueError`, but this plan reuses `_require_setup()` which raises `RuntimeError` (DRY with the rest of `CapTest`). `test_set_rc_requires_setup` asserts `RuntimeError`. Flag for reviewer; trivially switchable to a `ValueError` raise if the spec's letter is preferred over reuse.
+
+**Type consistency:** setter accepts `DataFrame | Series | dict`; coerces to a one-row DataFrame; delegates to `_set_rc(df, "manual")` (signature from Plan 1). `util.parse_regression_formula` returns `(lhs, rhs)` and only `rhs` is used. Required-vars list and the error message both reference `rhs`.

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-2-manual-override.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-2-manual-override.md
@@ -23,7 +23,7 @@
 
 **Files:**
 - Modify: `src/captest/captest.py` — add an `@rc.setter` immediately after the `rc` getter (added in Plan 1, just after `__init__`).
-- Test: `tests/test_captest.py` — new class `TestManualRc`.
+- Test: `tests/test_captest.py` — add `from captest import util` to imports; new class `TestManualRc`.
 
 **Interfaces:**
 - Consumes: `CapTest._set_rc(rc, source, warn=True)`, `CapTest._require_setup()`, `util.parse_regression_formula(formula) -> (lhs_list, rhs_list)`, `CapData.regression_formula`.
@@ -32,7 +32,9 @@
 
 - [ ] **Step 1: Write the failing tests**
 
-Add to `tests/test_captest.py` (the module already imports `pytest`, `pandas as pd`, `CapTest`; `ct_default` is a fixture in `conftest.py` providing a `setup()`-run CapTest with the `e2848_default` formula `power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1`, whose RHS variables are `poa, t_amb, w_vel`):
+First add `from captest import util` to the imports of `tests/test_captest.py` (the module imports `pytest`, `pandas as pd`, `CapTest` but not `util`; one new test calls `util.parse_regression_formula`). Then add the test class below.
+
+`ct_default` is a fixture in `conftest.py` providing a `setup()`-run CapTest with the `e2848_default` formula `power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1`. Its RHS variables appear *only* inside `I(...)` interaction blocks; `util.parse_regression_formula` unwraps them to the component set `poa, t_amb, w_vel`, which is what coverage is validated against:
 
 ```python
 class TestManualRc:
@@ -60,6 +62,31 @@ class TestManualRc:
     def test_set_rc_preserves_extra_columns(self, ct_default):
         ct_default.rc = {"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0, "note": 1.0}
         assert "note" in ct_default.rc.columns
+
+    def test_set_rc_series_preserves_extra_columns(self, ct_default):
+        """Extra fields survive the Series -> one-row DataFrame coercion."""
+        s = pd.Series({"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0, "note": 9.0})
+        ct_default.rc = s
+        assert "note" in ct_default.rc.columns
+        assert ct_default.rc["note"].iloc[0] == pytest.approx(9.0)
+
+    def test_required_vars_are_unwrapped_interaction_components(self, ct_default):
+        """Coverage keys off RHS *component* variables (poa, t_amb, w_vel), not
+        the I(...) interaction terms, for the default formula. Guards against a
+        parse_regression_formula change silently weakening validation."""
+        _, rhs = util.parse_regression_formula(ct_default.meas.regression_formula)
+        assert sorted(rhs) == ["poa", "t_amb", "w_vel"]
+        # A df with only the component vars (no I(poa*poa) columns) is accepted.
+        ct_default.rc = {"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0}
+        assert ct_default.rc_source == "manual"
+
+    def test_set_rc_multirow_raises(self, ct_default):
+        """A multi-row DataFrame is rejected with a clear error at set time."""
+        df = pd.DataFrame(
+            {"poa": [805.0, 810.0], "t_amb": [25.0, 26.0], "w_vel": [2.0, 2.1]}
+        )
+        with pytest.raises(ValueError, match="single row"):
+            ct_default.rc = df
 
     def test_set_rc_missing_rhs_var_raises_listing_names(self, ct_default):
         with pytest.raises(ValueError, match=r"missing required regression"):
@@ -130,8 +157,9 @@ In `src/captest/captest.py`, immediately after the `rc` getter (added in Plan 1)
         RuntimeError
             If :meth:`setup` has not run (the regression formula is unknown).
         ValueError
-            If ``meas`` and ``sim`` have different regression formulas, or
-            ``value`` omits a required right-hand-side variable.
+            If ``meas`` and ``sim`` have different regression formulas, if
+            ``value`` coerces to more than one row, or if ``value`` omits a
+            required right-hand-side variable.
         TypeError
             If ``value`` is not a DataFrame, Series, or dict.
         """
@@ -155,6 +183,10 @@ In `src/captest/captest.py`, immediately after the `rc` getter (added in Plan 1)
                 "ct.rc must be a one-row DataFrame, a pandas Series, or a dict "
                 f"mapping regression variable -> value; got "
                 f"{type(value).__name__}."
+            )
+        if len(df) != 1:
+            raise ValueError(
+                f"Reporting conditions must be a single row; got {len(df)} rows."
             )
         missing = [var for var in rhs if var not in df.columns]
         if missing:
@@ -200,7 +232,8 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 **Spec coverage (Plan 2 scope = §4.4 manual override):**
 - §4.4 "only public way is `ct.rc = df`" → setter is the sole public write path; `_set_rc` stays internal. ✓
 - §4.4 step 1 requires `setup()` → `self._require_setup()`. ✓
-- §4.4 step 2 RHS validation via `util.parse_regression_formula(self.meas.regression_formula)[1]`; formula-mismatch raises; missing vars listed; extra columns preserved → covered, with tests. ✓
+- §4.4 step 2 RHS validation via `util.parse_regression_formula(self.meas.regression_formula)[1]`; formula-mismatch raises; missing vars listed; extra columns preserved (DataFrame *and* Series paths tested) → covered. A dedicated test asserts the resolved RHS for the default formula is the *unwrapped* `["poa", "t_amb", "w_vel"]`, guarding that coverage keys off `I(...)` component symbols, not the interaction terms. ✓
+- §4.4 "one-row" contract enforced: after coercion the setter rejects `len(df) != 1` with a `ValueError` ("single row"); `test_set_rc_multirow_raises` covers it. ✓
 - §4.4 step 3 coerce to one-row DataFrame; apply §4.5 warning; record via `_set_rc(df, "manual")` → the warning lives in `_set_rc` (Plan 1), exercised by `test_set_rc_over_computed_source_warns`. ✓
 - §4.4 "internal vs public path" — computed/load assignments use `_set_rc` directly (Plans 3/5); the public setter is `_set_rc(..., "manual")` plus validation. ✓
 

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
@@ -265,14 +265,16 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 3: Un-mark the Plan 1 `xfail` placeholder + full-suite green
+### Task 3: Fix `_run_canonical_sequence`, un-mark the Plan 1 `xfail`, full-suite green
 
 **Files:**
-- Modify: `tests/test_captest.py` — `TestRepIrrCrossInstance.test_meas_rep_cond_then_sim_rep_irr_roundtrips` (drop the `xfail` marker).
+- Modify: `tests/test_captest.py` — `TestIntegration._run_canonical_sequence` (remove the redundant second `rep_cond`), and `TestRepIrrCrossInstance.test_meas_rep_cond_then_sim_rep_irr_roundtrips` (drop the `xfail` marker).
 
 **Interfaces:**
 - Consumes: the runtime sync from Tasks 1-2.
-- Produces: nothing new — converts the deferred placeholder into a live passing test now that the runtime path works.
+- Produces: nothing new — adapts the integration harness to last-writer-wins and converts the deferred placeholder into a live passing test.
+
+**Why `_run_canonical_sequence` must change:** it currently calls `capt.rep_cond()` *and then* `capt.rep_cond(which="sim")`. Pre-refactor this set both `meas.rc` and `sim.rc`, and `captest_results` used `rc_source` (default `"meas"`). After Task 1, the second call is the last writer, so it flips `rc_source` to `"sim"` (and warns) — `captest_results` would then use sim's RC, silently changing every `TestIntegration` cap ratio away from the meas-sourced baseline. The canonical single-RC workflow computes reporting conditions on the `rc_source` side only, so the redundant `rep_cond(which="sim")` is removed.
 
 - [ ] **Step 1: Confirm the placeholder now XPASSes**
 
@@ -294,21 +296,48 @@ In `tests/test_captest.py`, delete the decorator above `test_meas_rep_cond_then_
 
 Leave the test body unchanged; it now passes as a live test.
 
-- [ ] **Step 3: Run the full suite**
+- [ ] **Step 3: Adapt `_run_canonical_sequence` to last-writer-wins**
+
+In `tests/test_captest.py`, in `TestIntegration._run_canonical_sequence`, remove the redundant second reporting-conditions call so only the `rc_source`-default side is computed. Change:
+
+```python
+        capt.rep_cond()
+        capt.rep_cond(which="sim")
+        capt.meas.fit_regression(summary=False)
+        capt.sim.fit_regression(summary=False)
+```
+
+to:
+
+```python
+        # Single test RC from the rc_source side (default 'meas'). Under
+        # last-writer-wins a second rep_cond(which='sim') would flip rc_source
+        # to 'sim' and change captest_results; the canonical workflow uses one
+        # source.
+        capt.rep_cond()
+        capt.meas.fit_regression(summary=False)
+        capt.sim.fit_regression(summary=False)
+```
+
+- [ ] **Step 4: Run the full suite**
 
 Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
-Expected: all tests pass; no XFAIL/XPASS remaining for this test.
+Expected: all tests pass; no XFAIL/XPASS remaining for the un-marked test; `TestIntegration` cap ratios unchanged from baseline (meas-sourced RC, no source-change warnings).
 
-- [ ] **Step 4: Lint**
+- [ ] **Step 5: Lint**
 
 Run: `uv run ruff check tests/test_captest.py && uv run ruff format tests/test_captest.py`
 Expected: All checks pass.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add tests/test_captest.py
-git commit -m "test: un-xfail cross-instance rep_cond->rep_irr now that sync lands
+git commit -m "test: adapt integration harness to last-writer-wins; un-xfail rep_irr
+
+Remove the redundant rep_cond(which='sim') from _run_canonical_sequence so
+the single test RC stays meas-sourced (avoids a source flip), and drop the
+Plan 1 xfail now that cd.rep_cond syncs ct.rc.
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
@@ -1,0 +1,316 @@
+# CapTest RC Ownership — Plan 3: Last-Writer-Wins `rep_cond → ct.rc` Sync
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make any `cd.rep_cond()` on a CapData that belongs to a test update the single test RC (`ct.rc` + `ct.rc_source`), with a warning only when the source changes; and make `ct.rep_cond()`'s `which` default to the current `rc_source`.
+
+**Architecture:** `CapData._calc_rep_cond` calls `self._captest._on_capdata_rep_cond(self)` after it sets `self.rc` (only when `_captest` is set — standalone is untouched, and the call is duck-typed so `capdata.py` still never imports `captest`). `CapTest._on_capdata_rep_cond(cd)` resolves which side `cd` is and records the value via `_set_rc` (Plan 1). It has two modes: runtime last-writer-wins (warn on source change) and a config-seeded `_loading` branch (only the configured `rc_source` side updates, silently) — the `_loading` branch is implemented here but stays dormant until Plan 5 sets `_loading`.
+
+**Tech Stack:** Python, `param`, pandas, pytest, `uv`, `just`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md` §4.3, §4.5.
+- Builds on Plans 1-2 (`CapTest.rc`/`_set_rc`/`_loading`, `CapData._captest`, manual setter). Apply them first.
+- **Plans 1-5 must merge and release as a unit.** This plan makes the *runtime* cross-instance workflow (`ct.meas.rep_cond(); ct.sim.filter_irr(ref_val="rep_irr")`) functional; the `from_yaml` load path for the `rc_source="sim"` and manual cases still needs Plan 5.
+- `capdata.py` must NOT import `captest` — `self._captest._on_capdata_rep_cond(...)` is an opaque runtime call.
+- Standalone `CapData` (no `_captest`) behavior must not change: `cd.rep_cond()` sets only `cd.rc`, no sync, no warning.
+- Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
+
+---
+
+### Task 1: `_on_capdata_rep_cond` + sync call from `_calc_rep_cond`
+
+**Files:**
+- Modify: `src/captest/captest.py` — add `_on_capdata_rep_cond` immediately after `_set_rc`.
+- Modify: `src/captest/capdata.py` — `_calc_rep_cond`, after `self.rc = RCs_df` (line ~2245).
+- Test: `tests/test_captest.py` — new class `TestRepCondSync`.
+
+**Interfaces:**
+- Consumes: `CapTest._set_rc(rc, source, warn=True)` (Plan 1), `CapTest._loading` (Plan 1), `CapData._captest` (Plan 1), `CapData.rc`.
+- Produces:
+  - `CapTest._on_capdata_rep_cond(cd: CapData) -> None` — called by `CapData._calc_rep_cond` when `cd._captest is self`. Runtime: `_set_rc(cd.rc.copy(), side, warn=True)` where `side` is `"meas"`/`"sim"`. Load (`_loading`): updates only when `side == self.rc_source`, `warn=False`.
+  - `CapData._calc_rep_cond` now ends by calling `self._captest._on_capdata_rep_cond(self)` when `self._captest is not None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_captest.py` (module already imports `pytest`, `pandas as pd`; `ct_default` and `pvsyst` are fixtures — `pvsyst` is a standalone CapData with `regression_cols` set, defined in `conftest.py`):
+
+```python
+class TestRepCondSync:
+    """cd.rep_cond updates ct.rc (last-writer-wins); standalone is unaffected."""
+
+    def test_meas_rep_cond_sets_ct_rc_from_meas(self, ct_default):
+        ct_default.meas.rep_cond()
+        assert ct_default.rc_source == "meas"
+        assert ct_default.rc is not None
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(
+            ct_default.meas.rc["poa"].iloc[0]
+        )
+
+    def test_meas_rep_cond_first_set_is_silent(self, ct_default, recwarn):
+        ct_default.meas.rep_cond()
+        assert not any(
+            "rc_source changed" in str(w.message) for w in recwarn
+        )
+
+    def test_sim_rep_cond_after_meas_flips_source_and_warns(self, ct_default):
+        ct_default.meas.rep_cond()
+        with pytest.warns(UserWarning, match="changed from 'meas' to 'sim'"):
+            ct_default.sim.rep_cond()
+        assert ct_default.rc_source == "sim"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(
+            ct_default.sim.rc["poa"].iloc[0]
+        )
+
+    def test_same_source_recompute_is_silent(self, ct_default, recwarn):
+        ct_default.meas.rep_cond()
+        ct_default.meas.filter_irr(200, 800)
+        ct_default.meas.rep_cond()  # still 'meas' -> no source-change warning
+        assert ct_default.rc_source == "meas"
+        assert not any(
+            "rc_source changed" in str(w.message) for w in recwarn
+        )
+
+    def test_ct_rc_is_a_copy_not_aliased(self, ct_default):
+        ct_default.meas.rep_cond()
+        # Mutating meas.rc must not change ct.rc.
+        ct_default.meas.rc.loc[ct_default.meas.rc.index[0], "poa"] = -999.0
+        assert ct_default.rc["poa"].iloc[0] != -999.0
+
+    def test_standalone_rep_cond_does_not_sync_or_warn(self, pvsyst, recwarn):
+        assert pvsyst._captest is None
+        pvsyst.filter_irr(200, 800)
+        pvsyst.rep_cond()  # must not raise (the _captest guard) and not warn
+        assert pvsyst.rc is not None
+        assert not any(
+            "rc_source changed" in str(w.message) for w in recwarn
+        )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `ct.rc` stays `None` after `meas.rep_cond()` (no sync yet), so `test_meas_rep_cond_sets_ct_rc_from_meas` fails on `ct.rc is not None`, and the flip/warn test does not warn.
+
+- [ ] **Step 3: Add `_on_capdata_rep_cond` to `CapTest`**
+
+In `src/captest/captest.py`, immediately after the `_set_rc` method (added in Plan 1), add:
+
+```python
+    def _on_capdata_rep_cond(self, cd):
+        """Update the test RC after a member CapData computed its own ``rc``.
+
+        Called by :meth:`CapData._calc_rep_cond` when the CapData belongs to this
+        test. Runtime behavior is last-writer-wins: the calling side's ``rc``
+        becomes ``ct.rc`` and ``rc_source`` (a source-change ``UserWarning`` is
+        emitted by :meth:`_set_rc`). During ``from_yaml`` load (``_loading``
+        True) the update is config-seeded: only the configured ``rc_source``
+        side updates ``ct.rc``, silently (see Plan 5 / spec §4.7).
+
+        Parameters
+        ----------
+        cd : CapData
+            The member CapData that just (re)computed its ``rc``.
+        """
+        side = "meas" if cd is self.meas else "sim"
+        if self._loading:
+            if side == self.rc_source:
+                self._set_rc(cd.rc.copy(), side, warn=False)
+            return
+        self._set_rc(cd.rc.copy(), side, warn=True)
+```
+
+- [ ] **Step 4: Call the sync from `_calc_rep_cond`**
+
+In `src/captest/capdata.py`, at the end of `_calc_rep_cond` (after `self.rc = RCs_df`, line ~2245), add:
+
+```python
+        # When this CapData belongs to a CapTest, propagate the freshly computed
+        # rc to the single test rc (last-writer-wins). The CapTest decides warn
+        # vs silent and config-seeded load behavior. Opaque call — capdata.py
+        # never imports captest.
+        if self._captest is not None:
+            self._captest._on_capdata_rep_cond(self)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for `TestRepCondSync`.
+
+- [ ] **Step 6: Lint**
+
+Run: `uv run ruff check src/captest/capdata.py src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/capdata.py src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/captest/capdata.py src/captest/captest.py tests/test_captest.py
+git commit -m "feat: sync cd.rep_cond to CapTest.rc (last-writer-wins)
+
+A cd.rep_cond on a test member updates ct.rc/rc_source via
+_on_capdata_rep_cond, warning only on a source change; standalone CapData
+is unaffected. Includes the dormant _loading config-seeded branch.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `ct.rep_cond()` `which` defaults to current `rc_source`
+
+**Files:**
+- Modify: `src/captest/captest.py` — `rep_cond` (signature + body, lines ~2278-2306).
+- Test: `tests/test_captest.py` — add to `TestRepCondSync`.
+
+**Interfaces:**
+- Consumes: `CapTest.rc_source`, `CapTest._pick_cd`, `_merge_rep_conditions`, `CapData.rep_cond`.
+- Produces: `CapTest.rep_cond(which=None, **overrides)` — when `which is None`, resolves to `self.rc_source` if it is `"meas"`/`"sim"`, else `"meas"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestRepCondSync` in `tests/test_captest.py`:
+
+```python
+    def test_ct_rep_cond_default_which_follows_rc_source(self, ct_default, recwarn):
+        ct_default.sim.rep_cond()        # rc_source -> 'sim'
+        ct_default.rep_cond()            # which=None -> should pick 'sim'
+        assert ct_default.rc_source == "sim"
+        # If the default had picked 'meas', this would flip+warn.
+        assert not any(
+            "rc_source changed" in str(w.message) for w in recwarn
+        )
+
+    def test_ct_rep_cond_explicit_which_sim(self, ct_default):
+        ct_default.rep_cond("sim")
+        assert ct_default.rc_source == "sim"
+        assert ct_default.rc is not None
+
+    def test_ct_rep_cond_default_which_meas_when_rc_source_manual(self, ct_default):
+        # Seed a manual source, then default rep_cond should fall back to 'meas'.
+        ct_default.rc = pd.DataFrame(
+            {"poa": [800.0], "t_amb": [25.0], "w_vel": [2.0]}
+        )
+        assert ct_default.rc_source == "manual"
+        ct_default.rep_cond()  # which=None, rc_source='manual' -> 'meas'
+        assert ct_default.rc_source == "meas"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — with `which="meas"` still the default, `test_ct_rep_cond_default_which_follows_rc_source` flips to `"meas"` and warns.
+
+- [ ] **Step 3: Change the `rep_cond` signature and resolve `which`**
+
+In `src/captest/captest.py`, change the signature (line ~2278) from `def rep_cond(self, which="meas", **overrides):` to `def rep_cond(self, which=None, **overrides):` and update the body so it starts:
+
+```python
+        if which is None:
+            which = self.rc_source if self.rc_source in ("meas", "sim") else "meas"
+        cd = self._pick_cd(which)
+        self._require_setup()
+        resolved_rc = _merge_rep_conditions(
+            self._resolved_setup["rep_conditions"], overrides
+        )
+        return cd.rep_cond(**resolved_rc)
+```
+
+Also update the `rep_cond` docstring's `which` parameter entry to:
+
+```python
+        which : {'meas', 'sim', None}, default None
+            Which CapData to compute reporting conditions on. When None, defaults
+            to the current ``rc_source`` if it is ``'meas'``/``'sim'``, otherwise
+            ``'meas'``. The computed conditions become the test ``rc`` (and set
+            ``rc_source`` to ``which``) via the last-writer-wins sync.
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for the three new tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: ct.rep_cond which defaults to current rc_source
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Un-mark the Plan 1 `xfail` placeholder + full-suite green
+
+**Files:**
+- Modify: `tests/test_captest.py` — `TestRepIrrCrossInstance.test_meas_rep_cond_then_sim_rep_irr_roundtrips` (drop the `xfail` marker).
+
+**Interfaces:**
+- Consumes: the runtime sync from Tasks 1-2.
+- Produces: nothing new — converts the deferred placeholder into a live passing test now that the runtime path works.
+
+- [ ] **Step 1: Confirm the placeholder now XPASSes**
+
+Run: `uv run pytest "tests/test_captest.py::TestRepIrrCrossInstance::test_meas_rep_cond_then_sim_rep_irr_roundtrips" -rXp`
+Expected: XPASS — `meas.rep_cond()` now seeds `ct.rc`, so `sim.filter_irr(ref_val="rep_irr")` resolves and `to_yaml` succeeds. (The test only exercises `to_yaml`; the `from_yaml` round-trip for the `rc_source="sim"`/manual cases is added in Plan 5.)
+
+- [ ] **Step 2: Remove the `xfail` marker**
+
+In `tests/test_captest.py`, delete the decorator above `test_meas_rep_cond_then_sim_rep_irr_roundtrips`:
+
+```python
+    @pytest.mark.xfail(
+        reason="rep_cond->ct.rc auto-sync lands in Plan 3 and the rep_irr YAML "
+        "round-trip in Plan 5; placeholder keeps the deferred end-to-end "
+        "coverage gap visible. Plan 5 removes this marker.",
+        strict=False,
+    )
+```
+
+Leave the test body unchanged; it now passes as a live test.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
+Expected: all tests pass; no XFAIL/XPASS remaining for this test.
+
+- [ ] **Step 4: Lint**
+
+Run: `uv run ruff check tests/test_captest.py && uv run ruff format tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_captest.py
+git commit -m "test: un-xfail cross-instance rep_cond->rep_irr now that sync lands
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 3 scope = §4.3 last-writer-wins + §4.5 callers):**
+- §4.3 any `cd.rep_cond()` in a test updates `ct.rc` + `rc_source` → Task 1 (`_on_capdata_rep_cond` called from `_calc_rep_cond`). ✓
+- §4.3 `ct.rc` stores a *copy* → `cd.rc.copy()`; `test_ct_rc_is_a_copy_not_aliased`. ✓
+- §4.3 standalone unaffected (no `_captest` → no sync/warn) → `test_standalone_rep_cond_does_not_sync_or_warn`. ✓
+- §4.3 `ct.rep_cond()` `which` default to current `rc_source` (else meas) → Task 2. ✓
+- §4.5 warn only on source change, uniformly (incl. via `ct.rep_cond`) → handled by `_set_rc` (Plan 1); `test_sim_rep_cond_after_meas_flips_source_and_warns`, `test_same_source_recompute_is_silent`, `test_meas_rep_cond_first_set_is_silent`. ✓
+- `_loading` config-seeded branch implemented but dormant (set only in Plan 5). ✓
+
+**Placeholder scan:** none — every step has exact code/commands. The Plan 1 `xfail` is intentionally *removed* in Task 3 (the deferred path it guarded is now live for the runtime case).
+
+**Cross-plan note:** the Plan 1 placeholder exercises `to_yaml` only, which passes after Task 1-2; the genuine `from_yaml` round-trips for `rc_source="sim"` and the manual case (spec testing-plan items 8-11) are added in Plan 5. No coverage is silently dropped — Plan 5 introduces those tests alongside the load behavior they exercise.
+
+**Type consistency:** `_on_capdata_rep_cond(cd)` calls `_set_rc(cd.rc.copy(), side, warn=...)` with `side ∈ {"meas","sim"}`, matching the Plan 1 `_set_rc` signature and the `rc_source` Selector objects. `rep_cond(which=None, ...)` resolves `which` to a valid `_pick_cd` argument.

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-3-rep-cond-sync.md
@@ -15,6 +15,13 @@
 - **Plans 1-5 must merge and release as a unit.** This plan makes the *runtime* cross-instance workflow (`ct.meas.rep_cond(); ct.sim.filter_irr(ref_val="rep_irr")`) functional; the `from_yaml` load path for the `rc_source="sim"` and manual cases still needs Plan 5.
 - `capdata.py` must NOT import `captest` — `self._captest._on_capdata_rep_cond(...)` is an opaque runtime call.
 - Standalone `CapData` (no `_captest`) behavior must not change: `cd.rep_cond()` sets only `cd.rc`, no sync, no warning.
+- **`rep_cond_freq` is intentionally excluded from the sync.** It computes a
+  *multi-row* seasonal/monthly RC and sets `self.rc` on its own code path
+  (`capdata.py:2425`), bypassing `_calc_rep_cond`. A single-row `ct.rc` cannot
+  represent a multi-row result, so `ct.meas.rep_cond_freq(...)` deliberately
+  leaves `ct.rc`/`rc_source` untouched (sync hook lives only in `_calc_rep_cond`).
+  This is asserted by a guard test (Task 1, Step 1) so future readers don't treat
+  it as an oversight.
 - Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
 
 ---
@@ -86,6 +93,15 @@ class TestRepCondSync:
         assert not any(
             "rc_source changed" in str(w.message) for w in recwarn
         )
+
+    def test_rep_cond_freq_does_not_sync_to_ct_rc(self, ct_default):
+        """rep_cond_freq is intentionally NOT synced: it can produce a multi-row
+        seasonal RC that a single-row ct.rc cannot hold, and it sets self.rc on a
+        path that bypasses _calc_rep_cond. It must leave ct.rc/rc_source alone."""
+        ct_default.meas.rep_cond_freq(freq="ME")
+        assert ct_default.meas.rc is not None  # member CapData rc is set
+        assert ct_default.rc is None  # test rc untouched
+        assert ct_default.rc_source == "meas"  # default, unchanged
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -305,6 +321,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - §4.3 any `cd.rep_cond()` in a test updates `ct.rc` + `rc_source` → Task 1 (`_on_capdata_rep_cond` called from `_calc_rep_cond`). ✓
 - §4.3 `ct.rc` stores a *copy* → `cd.rc.copy()`; `test_ct_rc_is_a_copy_not_aliased`. ✓
 - §4.3 standalone unaffected (no `_captest` → no sync/warn) → `test_standalone_rep_cond_does_not_sync_or_warn`. ✓
+- `rep_cond_freq` boundary: intentionally NOT synced (multi-row RC vs single-row `ct.rc`; sets `self.rc` outside `_calc_rep_cond`). Documented in Global Constraints and guarded by `test_rep_cond_freq_does_not_sync_to_ct_rc`. ✓
 - §4.3 `ct.rep_cond()` `which` default to current `rc_source` (else meas) → Task 2. ✓
 - §4.5 warn only on source change, uniformly (incl. via `ct.rep_cond`) → handled by `_set_rc` (Plan 1); `test_sim_rep_cond_after_meas_flips_source_and_warns`, `test_same_source_recompute_is_silent`, `test_meas_rep_cond_first_set_is_silent`. ✓
 - `_loading` config-seeded branch implemented but dormant (set only in Plan 5). ✓

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-4-captest-results.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-4-captest-results.md
@@ -1,0 +1,168 @@
+# CapTest RC Ownership — Plan 4: `captest_results` Reads `ct.rc`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `captest_results` predict at the single test RC `ct.rc` instead of re-picking `meas.rc`/`sim.rc` by `rc_source`, and raise a clear error when no test RC has been established.
+
+**Architecture:** Replace the `if self.rc_source == "meas": rc = self.meas.rc else: rc = self.sim.rc` block in `captest_results` with `rc = self.rc` plus a `None` guard. The provenance print line keeps using `self.rc_source`. The formula-mismatch check and `_require_meas_and_sim` ordering are unchanged. `captest_results_check_pvalues` calls `captest_results` internally, so it inherits the change with no edits.
+
+**Tech Stack:** Python, `param`, pandas, statsmodels, pytest, `uv`, `just`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md` §4.6.
+- Builds on Plans 1-3 (`CapTest.rc`/`rc_source`, `_set_rc`, manual setter, `rep_cond` sync). Apply them first; the integration harness fix lands in Plan 3.
+- **Plans 1-5 must merge and release as a unit.**
+- Order of checks in `captest_results` is preserved: `_require_meas_and_sim()` → formula-match → RC resolution. The `None`-RC `ValueError` therefore only fires after meas/sim exist and formulas match.
+- Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
+
+---
+
+### Task 1: `captest_results` predicts at `ct.rc`
+
+**Files:**
+- Modify: `src/captest/captest.py` — `captest_results` (the `rc_source`-based pick).
+- Test: `tests/test_captest.py` — update `TestPortedMethods` RC tests; add a `None`-RC test.
+
+**Interfaces:**
+- Consumes: `CapTest.rc` (Plan 1), `CapTest.rc_source`, `CapTest._set_rc` (Plan 1, used by tests to seed `ct.rc`).
+- Produces: `captest_results(check_pvalues=False, pval=0.05, print_res=True)` now reads `self.rc`; raises `ValueError` when `self.rc is None` (after the meas/sim and formula checks). Return type unchanged (float cap ratio). `captest_results_check_pvalues` unchanged but now requires `ct.rc` (it calls `captest_results`).
+
+- [ ] **Step 1: Update the existing RC-dependent tests and add the None-guard test**
+
+In `tests/test_captest.py`, replace the three tests `test_captest_results_matches_direct_prediction`, `test_captest_results_uses_rc_source_meas_by_default`, and `test_captest_results_uses_rc_source_sim` (the ones that set `meas.rc`/`sim.rc` and rely on the `rc_source` pick) with these, which seed the single `ct.rc` via `_set_rc`:
+
+```python
+    def test_captest_results_predicts_at_ct_rc(self):
+        capt = self._build_ct()
+        rc = pd.DataFrame({"poa": [6], "t_amb": [5], "w_vel": [3]})
+        capt._set_rc(rc, "meas")
+        expected_actual = capt.meas.regression_results.predict(rc)[0]
+        expected_expected = capt.sim.regression_results.predict(rc)[0]
+        expected_ratio = expected_actual / expected_expected
+
+        cp_rat = capt.captest_results(print_res=False)
+
+        assert cp_rat == pytest.approx(expected_ratio, rel=1e-10)
+
+    def test_captest_results_uses_ct_rc_values_regardless_of_source(self):
+        capt = self._build_ct()
+        # Distinct RC values; both meas and sim predict at the SAME ct.rc.
+        rc = pd.DataFrame({"poa": [8], "t_amb": [4], "w_vel": [2]})
+        capt._set_rc(rc, "sim")
+        expected_ratio = (
+            capt.meas.regression_results.predict(rc)[0]
+            / capt.sim.regression_results.predict(rc)[0]
+        )
+
+        cp_rat = capt.captest_results(print_res=False)
+
+        assert cp_rat == pytest.approx(expected_ratio, rel=1e-10)
+
+    def test_captest_results_raises_when_ct_rc_none(self):
+        capt = self._build_ct()
+        assert capt.rc is None
+        with pytest.raises(ValueError, match="requires test reporting conditions"):
+            capt.captest_results(print_res=False)
+```
+
+Then update `test_captest_results_check_pvalues_returns_styled_df` to seed `ct.rc` before calling (it routes through `captest_results`):
+
+```python
+    def test_captest_results_check_pvalues_returns_styled_df(self):
+        capt = self._build_ct()
+        capt._set_rc(pd.DataFrame({"poa": [6], "t_amb": [5], "w_vel": [3]}), "meas")
+        styled = capt.captest_results_check_pvalues(print_res=False)
+```
+
+(Leave the remaining body of `test_captest_results_check_pvalues_returns_styled_df` unchanged. `test_captest_results_requires_meas_and_sim` and `test_captest_results_warns_on_mismatched_formulas` need no change — the meas/sim and formula checks run before the RC resolution.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `captest_results` still reads `meas.rc`/`sim.rc` (which `_build_ct` sets to `{poa:6,...}`), so `test_captest_results_predicts_at_ct_rc` may pass by luck but `test_captest_results_uses_ct_rc_values_regardless_of_source` fails (it reads `meas.rc`=`{poa:6}`, not the seeded `ct.rc`=`{poa:8}`) and `test_captest_results_raises_when_ct_rc_none` fails (no error raised; it reads `meas.rc`).
+
+- [ ] **Step 3: Rewrite the RC resolution in `captest_results`**
+
+In `src/captest/captest.py`, in `captest_results`, replace:
+
+```python
+        if self.rc_source == "meas":
+            rc = self.meas.rc
+        else:
+            rc = self.sim.rc
+
+        if print_res:
+            print(f"Using reporting conditions from {self.rc_source}. \n")
+```
+
+with:
+
+```python
+        rc = self.rc
+        if rc is None:
+            raise ValueError(
+                "captest_results requires test reporting conditions. Call "
+                "ct.rep_cond(which) or assign ct.rc = df first."
+            )
+
+        if print_res:
+            print(f"Using reporting conditions from {self.rc_source}. \n")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for the updated/added tests.
+
+- [ ] **Step 5: Update the `captest_results` docstring**
+
+In `src/captest/captest.py`, the `captest_results` docstring currently says it "Picks reporting conditions from `self.meas.rc` or `self.sim.rc` based on `self.rc_source`." Replace that sentence with:
+
+```
+        Predicts both regressions at the single test reporting conditions
+        ``self.rc`` (set via :meth:`rep_cond` or the ``rc`` setter);
+        ``self.rc_source`` is reported for provenance. Raises ``ValueError``
+        if ``self.rc`` is ``None``.
+```
+
+(Find the existing wording in the method's docstring and swap it; keep the rest.)
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
+Expected: all tests pass. `TestIntegration` already seeds `ct.rc` via `capt.rep_cond()` in `_run_canonical_sequence` (Plan 3), so its `captest_results` calls resolve normally.
+
+- [ ] **Step 7: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: captest_results predicts at the single test rc (ct.rc)
+
+Replace the rc_source-based pick of meas.rc/sim.rc with ct.rc; raise a clear
+ValueError when no test reporting conditions are set. captest_results_check_pvalues
+inherits the change via its internal captest_results calls.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 4 scope = §4.6 `captest_results`):**
+- §4.6 replace `rc_source` pick with `self.rc` → Task 1, Step 3. ✓
+- §4.6 raise a clear error directing to `ct.rep_cond(which)` / `ct.rc = df` when `self.rc is None` → `ValueError`; `test_captest_results_raises_when_ct_rc_none`. ✓
+- §4.6 provenance print uses `self.rc_source` → unchanged print line. ✓
+- `captest_results_check_pvalues` inherits the change (calls `captest_results`) → test seeds `ct.rc`. ✓
+
+**Placeholder scan:** none — every step shows exact code/commands.
+
+**Check ordering:** `_require_meas_and_sim()` and the formula-mismatch check run *before* the `None`-RC guard, so `test_captest_results_requires_meas_and_sim` (RuntimeError) and `test_captest_results_warns_on_mismatched_formulas` (UserWarning + early return) keep passing without seeding `ct.rc`. ✓
+
+**Type consistency:** `captest_results` still returns the float cap ratio; `rc = self.rc` is a one-row DataFrame (or None → ValueError). Tests seed `ct.rc` via `_set_rc(df, source)` (Plan 1 signature). The integration harness change that makes `TestIntegration` compatible with the single-`ct.rc` model lives in Plan 3 (`_run_canonical_sequence`), not here.

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-5-serialization-load.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-5-serialization-load.md
@@ -1,0 +1,377 @@
+# CapTest RC Ownership — Plan 5: Serialization + Deterministic Load
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist/restore the test RC across `to_yaml`/`from_yaml`: serialize *values* only for the manual case, and on load (a) seed a manual RC before replay, (b) replay the configured `rc_source` side first so cross-side `rep_irr` filters resolve mid-replay, and (c) make the `rep_cond` sync config-seeded and warning-suppressed via `_loading`.
+
+**Architecture:** `_build_yaml_sub_mapping` adds `reporting_conditions_values` (a yaml-safe one-row dict) only when `rc_source == "manual"`; computed RC is recomputed by replaying the source pipeline's `RepCond` step. `from_mapping` seeds a manual RC via `_set_rc(..., warn=False)` before replay, orders the two pipeline replays so the configured `rc_source` side runs first, and wraps replay in `_loading = True` (consumed by Plan 3's `_on_capdata_rep_cond` loading branch).
+
+**Tech Stack:** Python, `param`, pandas, pytest, `unittest.mock.MagicMock`, `uv`, `just`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md` §4.7.
+- Builds on Plans 1-4 (`CapTest.rc`/`_set_rc`/`_loading`, manual setter, `rep_cond` sync + `_on_capdata_rep_cond` loading branch, `captest_results` reads `ct.rc`). Apply them first.
+- **Plans 1-5 must merge and release as a unit.** This is the final plan; after it the full design is live.
+- `to_native` and `pd` are already imported in `captest.py`.
+- `from_yaml` delegates to `from_mapping`; the replay block lives in `from_mapping`.
+- Computed-RC serialization assumes the `rc_source` side's pipeline contains the `RepCond` step that produced `ct.rc` (true whenever `ct.rc` came from `rep_cond`). Manual RC carries its values; no `RepCond` is relied upon.
+- Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
+
+---
+
+### Task 1: Serialize manual RC values in `_build_yaml_sub_mapping`
+
+**Files:**
+- Modify: `src/captest/captest.py` — `_build_yaml_sub_mapping`, just before `return sub`.
+- Test: `tests/test_captest.py` — new class `TestManualRcSerialization`.
+
+**Interfaces:**
+- Consumes: `CapTest._rc`, `CapTest.rc_source`, `util.to_native` (imported as `to_native`).
+- Produces: the captest sub-mapping gains an optional `reporting_conditions_values` key — a `{column: native_scalar}` one-row dict — present iff `rc_source == "manual"` and `_rc is not None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_captest.py` (module imports `pytest`, `pandas as pd`, `CapTest`; `meas_cd_default`/`sim_cd_default` are `conftest.py` fixtures):
+
+```python
+class TestManualRcSerialization:
+    """to_yaml serializes manual RC values; computed RC is not value-serialized."""
+
+    def _capt(self, meas_cd_default, sim_cd_default):
+        return CapTest.from_params(
+            test_setup="e2848_default",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            ac_nameplate=6_000_000,
+        )
+
+    def test_manual_rc_serializes_native_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        sub = capt._build_yaml_sub_mapping()
+        assert sub["rc_source"] == "manual"
+        vals = sub["reporting_conditions_values"]
+        assert vals["poa"] == pytest.approx(805.0)
+        assert {"poa", "t_amb", "w_vel"} <= set(vals)
+        # Values must be native python types so yaml.safe_dump can represent them.
+        assert type(vals["poa"]) is float
+
+    def test_computed_rc_omits_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rep_cond(which="meas")  # rc_source='meas' (computed)
+        sub = capt._build_yaml_sub_mapping()
+        assert sub["rc_source"] == "meas"
+        assert "reporting_conditions_values" not in sub
+
+    def test_no_rc_omits_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        sub = capt._build_yaml_sub_mapping()
+        assert "reporting_conditions_values" not in sub
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `KeyError: 'reporting_conditions_values'` for the manual case (key not written yet).
+
+- [ ] **Step 3: Serialize manual RC values**
+
+In `src/captest/captest.py`, in `_build_yaml_sub_mapping`, replace:
+
+```python
+        if meas_filters:
+            sub["meas_filters"] = meas_filters
+        if sim_filters:
+            sub["sim_filters"] = sim_filters
+
+        return sub
+```
+
+with:
+
+```python
+        if meas_filters:
+            sub["meas_filters"] = meas_filters
+        if sim_filters:
+            sub["sim_filters"] = sim_filters
+
+        # Manual reporting conditions are data, not config: serialize their
+        # values so from_yaml can restore them (computed RC is recomputed by
+        # replaying the source pipeline's RepCond step). Numpy scalars are
+        # coerced to native python types for yaml.safe_dump.
+        if self.rc_source == "manual" and self._rc is not None:
+            row = self._rc.iloc[0]
+            sub["reporting_conditions_values"] = {
+                str(col): to_native(val) for col, val in row.items()
+            }
+
+        return sub
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for `TestManualRcSerialization`.
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: serialize manual reporting-conditions values to yaml
+
+When rc_source='manual', write the one-row RC under reporting_conditions_values
+(numpy scalars coerced via to_native). Computed RC is omitted; it is recomputed
+on load by replaying the source pipeline's RepCond step.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Deterministic load — manual seed, `_loading`, source-first replay
+
+**Files:**
+- Modify: `src/captest/captest.py` — `from_mapping` replay block.
+- Test: `tests/test_captest.py` — new class `TestRcOwnershipRoundTrip`.
+
+**Interfaces:**
+- Consumes: `CapTest._set_rc` (Plan 1), `CapTest._loading` (Plan 1), `CapTest.rc_source`, `CapData.run_pipeline`, `_on_capdata_rep_cond` loading branch (Plan 3).
+- Produces: `from_mapping` now (1) seeds `ct.rc` from `reporting_conditions_values` via `_set_rc(df, "manual", warn=False)` before replay when `rc_source == "manual"`, (2) replays the configured `rc_source` side's pipeline first (`sim`→`meas` when `rc_source == "sim"`, else `meas`→`sim`), and (3) sets `inst._loading = True` for the duration of replay (cleared in a `finally`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_captest.py` (module already imports `from unittest.mock import MagicMock`):
+
+```python
+class TestRcOwnershipRoundTrip:
+    """to_yaml/from_yaml round-trips of the single test RC across sources."""
+
+    def _capt(self, meas_cd_default, sim_cd_default, **kw):
+        return CapTest.from_params(
+            test_setup="e2848_default",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            ac_nameplate=6_000_000,
+            **kw,
+        )
+
+    def _roundtrip(self, capt, tmp_path, clean_meas, clean_sim):
+        capt._meas_path = str(tmp_path / "meas.csv")
+        capt._sim_path = str(tmp_path / "sim.csv")
+        path = tmp_path / "config.yaml"
+        capt.to_yaml(path, merge_into_existing=False)
+        return CapTest.from_yaml(
+            path,
+            meas_loader=MagicMock(return_value=clean_meas),
+            sim_loader=MagicMock(return_value=clean_sim),
+        )
+
+    def test_roundtrip_computed_meas_recomputes_ct_rc(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.meas.filter_irr(200, 800)
+        capt.rep_cond(which="meas")
+        expected_poa = capt.rc["poa"].iloc[0]
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "meas"
+        assert reloaded.rc is not None
+        assert reloaded.rc["poa"].iloc[0] == pytest.approx(expected_poa)
+
+    def test_roundtrip_manual_rc_restores_values(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "manual"
+        assert reloaded.rc["poa"].iloc[0] == pytest.approx(805.0)
+
+    def test_roundtrip_rc_source_sim_replays_sim_first(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        # The OTHER side (meas) carries the rep_irr filter; sim is the source.
+        # This fails under a fixed meas-before-sim load order.
+        capt = self._capt(meas_cd_default, sim_cd_default, rc_source="sim")
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.sim.filter_irr(200, 800)
+        capt.rep_cond(which="sim")  # ct.rc from sim, rc_source='sim'
+        capt.meas.filter_irr(0.8, 1.2, ref_val="rep_irr")  # anchors on sim rep irr
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "sim"
+        meas_irr = [
+            s for s in reloaded.meas.filters if type(s).__name__ == "Irradiance"
+        ][-1]
+        assert meas_irr.ref_val_resolved == pytest.approx(reloaded.rc["poa"].iloc[0])
+
+    def test_load_is_config_seeded_and_silent(
+        self, tmp_path, meas_cd_default, sim_cd_default, recwarn
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.rep_cond(which="sim")  # sim RepCond step (rc_source -> 'sim')
+        capt.rep_cond(which="meas")  # meas RepCond step (rc_source -> 'meas')
+        assert capt.rc_source == "meas"
+        recwarn.clear()
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        # Config-seeded: meas drives despite sim also carrying a RepCond step.
+        assert reloaded.rc_source == "meas"
+        # No source-change warning during load.
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: FAIL — `test_roundtrip_rc_source_sim_replays_sim_first` raises `ValueError` ("requires test reporting conditions") during load because the fixed meas-first order runs meas's `rep_irr` filter before sim establishes `ct.rc`; `test_roundtrip_manual_rc_restores_values` fails because manual values are never re-seeded; `test_load_is_config_seeded_and_silent` ends with `rc_source == "sim"` (last replayed) and emits a source-change warning.
+
+- [ ] **Step 3: Rewrite the `from_mapping` replay block**
+
+In `src/captest/captest.py`, in `from_mapping`, replace:
+
+```python
+        meas_filters = sub.get("meas_filters")
+        sim_filters = sub.get("sim_filters")
+        if inst._resolved_setup is not None:
+            if meas_filters and inst.meas is not None:
+                inst.meas.run_pipeline(meas_filters)
+            if sim_filters and inst.sim is not None:
+                inst.sim.run_pipeline(sim_filters)
+        elif meas_filters or sim_filters:
+```
+
+with:
+
+```python
+        meas_filters = sub.get("meas_filters")
+        sim_filters = sub.get("sim_filters")
+        rc_values = sub.get("reporting_conditions_values")
+        if inst._resolved_setup is not None:
+            # Seed a manual RC before replay so self-filtering pipelines resolve
+            # ref_val='rep_irr' against it; no RepCond step will set it. Computed
+            # RC is (re)established during replay by the configured rc_source
+            # side's RepCond step (see _on_capdata_rep_cond's _loading branch).
+            if inst.rc_source == "manual" and rc_values is not None:
+                inst._set_rc(pd.DataFrame([rc_values]), "manual", warn=False)
+            # Replay the configured rc_source side FIRST so its RepCond populates
+            # ct.rc before the other side's rep_irr filters run. _loading makes
+            # the rep_cond sync config-seeded and warning-suppressed.
+            pipelines = [(inst.meas, meas_filters), (inst.sim, sim_filters)]
+            if inst.rc_source == "sim":
+                pipelines.reverse()
+            inst._loading = True
+            try:
+                for cd, filters in pipelines:
+                    if filters and cd is not None:
+                        cd.run_pipeline(filters)
+            finally:
+                inst._loading = False
+        elif meas_filters or sim_filters:
+```
+
+(Leave the `elif meas_filters or sim_filters:` warning block and `return inst` unchanged.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
+Expected: PASS for all four `TestRcOwnershipRoundTrip` tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/captest/captest.py tests/test_captest.py
+git commit -m "feat: deterministic RC load - source-first replay, manual seed, _loading
+
+from_mapping seeds a manual RC before replay, replays the configured rc_source
+side first (sim->meas when rc_source='sim') so cross-side rep_irr filters
+resolve mid-replay, and wraps replay in _loading so the rep_cond sync is
+config-seeded and warning-suppressed.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Extend the existing reconstitute test + full-suite green
+
+**Files:**
+- Modify: `tests/test_captest.py` — `TestPipelineYaml.test_file_roundtrip_with_rep_cond_step_reconstitutes_rc`.
+
+**Interfaces:**
+- Consumes: the load path from Task 2.
+- Produces: nothing new — strengthens an existing test to assert the test-level `ct.rc` is reconstituted, and gates the whole stack.
+
+- [ ] **Step 1: Strengthen the existing reconstitute test**
+
+In `tests/test_captest.py`, in `TestPipelineYaml.test_file_roundtrip_with_rep_cond_step_reconstitutes_rc`, after the existing assertions:
+
+```python
+        assert any(type(s).__name__ == "RepCond" for s in reloaded.meas.filters)
+        assert reloaded.meas.rc is not None
+```
+
+add:
+
+```python
+        # The test-level ct.rc is reconstituted from the replayed RepCond step.
+        assert reloaded.rc is not None
+        assert reloaded.rc_source == "meas"
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `just -f ~/python/pvcaptest_bt-/.justfile test`
+Expected: all tests pass (Plans 1-5 complete).
+
+- [ ] **Step 3: Lint + format the whole change**
+
+Run: `uv run ruff check src/ tests/ && uv run ruff format --check src/captest/captest.py tests/test_captest.py`
+Expected: All checks pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_captest.py
+git commit -m "test: assert ct.rc is reconstituted on RepCond-step round-trip
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan 5 scope = §4.7 serialization + load):**
+- §4.7 computed RC not value-serialized; recomputed by replaying the source's `RepCond` → `test_computed_rc_omits_values`, `test_roundtrip_computed_meas_recomputes_ct_rc`. ✓
+- §4.7 manual RC serialized as `reporting_conditions_values` (numpy → native via `to_native`) → Task 1; `test_manual_rc_serializes_native_values`, `test_roundtrip_manual_rc_restores_values`. ✓
+- §4.7 point 1 warnings suppressed during load → `_loading` + `_set_rc(warn=False)` in the loading branch; `test_load_is_config_seeded_and_silent`. ✓
+- §4.7 point 2 configured `rc_source` side replayed first → `pipelines.reverse()` when `rc_source == "sim"`; `test_roundtrip_rc_source_sim_replays_sim_first` (the regression guard that fails under fixed meas-first). ✓ (testing-plan items 10 sim-case + 11.)
+- §4.7 point 3 config-seeded auto-update (only configured side updates `ct.rc`) → Plan 3's `_on_capdata_rep_cond` `_loading` branch, exercised here; `test_load_is_config_seeded_and_silent` (item 9). ✓
+- §4.7 point 4 manual RC seeded before replay, not clobbered by any `RepCond` (no side matches `"manual"`) → seed step + Plan 3 loading guard. ✓
+
+**Placeholder scan:** none — every step has exact code/commands. No `xfail` remains (Plan 3 removed the Plan 1 placeholder; the genuine `from_yaml` round-trips land here as live tests).
+
+**Type consistency:** `reporting_conditions_values` is a `{str: native}` dict; load reconstructs via `pd.DataFrame([rc_values])` (one row) and `_set_rc(df, "manual", warn=False)` (Plan 1 signature). `pipelines` is a list of `(CapData, filters)` tuples; `_loading` is the bool from Plan 1; the `_on_capdata_rep_cond` loading branch (Plan 3) keys off `side == self.rc_source`. Round-trip tests use the established `clean_* = capt.<cd>.copy()` + `MagicMock(return_value=clean_*)` loader pattern from `TestPipelineYaml`.
+
+**Whole-design check (Plans 1-5):** data model + resolution (1), manual override (2), last-writer-wins sync (3), `captest_results` (4), serialization/load (5). Spec §§4.1-4.8 and testing-plan items 1-12 are each covered by a task across the five plans.

--- a/docs/superpowers/plans/2026-06-27-captest-rc-ownership-5-serialization-load.md
+++ b/docs/superpowers/plans/2026-06-27-captest-rc-ownership-5-serialization-load.md
@@ -16,6 +16,7 @@
 - `to_native` and `pd` are already imported in `captest.py`.
 - `from_yaml` delegates to `from_mapping`; the replay block lives in `from_mapping`.
 - Computed-RC serialization assumes the `rc_source` side's pipeline contains the `RepCond` step that produced `ct.rc` (true whenever `ct.rc` came from `rep_cond`). Manual RC carries its values; no `RepCond` is relied upon.
+- For `rc_source == "manual"`, `reporting_conditions_values` is the **authoritative** RC. `overrides.rep_conditions` (aggregation *config*, not RC values) is **not** co-serialized in that case, so a file never carries two RC-bearing keys. Even if a hand-edited file did contain both, the manual seed wins on load and `rep_conditions` is restored only as inert config (never auto-applied).
 - Line length 88 (ruff). NumPy-style docstrings. Run tests with `just -f ~/python/pvcaptest_bt-/.justfile test-module <file>`; lint with `uv run ruff check` / `uv run ruff format`.
 
 ---
@@ -68,6 +69,19 @@ class TestManualRcSerialization:
         capt = self._capt(meas_cd_default, sim_cd_default)
         sub = capt._build_yaml_sub_mapping()
         assert "reporting_conditions_values" not in sub
+
+    def test_manual_rc_omits_overrides_rep_conditions(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """A manual rc_source serializes reporting_conditions_values as the
+        authoritative RC and does NOT also write overrides.rep_conditions, so
+        the file never carries two RC-bearing keys."""
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rep_conditions = {"func": {"poa": "mean"}}  # would normally serialize
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        sub = capt._build_yaml_sub_mapping()
+        assert "reporting_conditions_values" in sub
+        assert "rep_conditions" not in sub.get("overrides", {})
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -75,7 +89,30 @@ class TestManualRcSerialization:
 Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
 Expected: FAIL — `KeyError: 'reporting_conditions_values'` for the manual case (key not written yet).
 
-- [ ] **Step 3: Serialize manual RC values**
+- [ ] **Step 3: Skip `overrides.rep_conditions` when `rc_source == "manual"`**
+
+In `src/captest/captest.py`, in `_build_yaml_sub_mapping`, replace:
+
+```python
+        if self.rep_conditions is not None and not has_rep_cond_step:
+            overrides["rep_conditions"] = _serialize_rep_conditions(self.rep_conditions)
+```
+
+with:
+
+```python
+        # For a manual rc_source, reporting_conditions_values (written below) is
+        # the authoritative RC; do not also serialize overrides.rep_conditions,
+        # which is only aggregation config and would read as a second RC source.
+        if (
+            self.rep_conditions is not None
+            and not has_rep_cond_step
+            and self.rc_source != "manual"
+        ):
+            overrides["rep_conditions"] = _serialize_rep_conditions(self.rep_conditions)
+```
+
+- [ ] **Step 4: Serialize manual RC values**
 
 In `src/captest/captest.py`, in `_build_yaml_sub_mapping`, replace:
 
@@ -109,24 +146,25 @@ with:
         return sub
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `just -f ~/python/pvcaptest_bt-/.justfile test-module test_captest.py`
-Expected: PASS for `TestManualRcSerialization`.
+Expected: PASS for `TestManualRcSerialization` (including `test_manual_rc_omits_overrides_rep_conditions`).
 
-- [ ] **Step 5: Lint**
+- [ ] **Step 6: Lint**
 
 Run: `uv run ruff check src/captest/captest.py tests/test_captest.py && uv run ruff format src/captest/captest.py tests/test_captest.py`
 Expected: All checks pass.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/captest/captest.py tests/test_captest.py
 git commit -m "feat: serialize manual reporting-conditions values to yaml
 
 When rc_source='manual', write the one-row RC under reporting_conditions_values
-(numpy scalars coerced via to_native). Computed RC is omitted; it is recomputed
+(numpy scalars coerced via to_native) and skip overrides.rep_conditions so the
+file carries a single authoritative RC. Computed RC is omitted; it is recomputed
 on load by replaying the source pipeline's RepCond step.
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
@@ -365,6 +403,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 **Spec coverage (Plan 5 scope = §4.7 serialization + load):**
 - §4.7 computed RC not value-serialized; recomputed by replaying the source's `RepCond` → `test_computed_rc_omits_values`, `test_roundtrip_computed_meas_recomputes_ct_rc`. ✓
 - §4.7 manual RC serialized as `reporting_conditions_values` (numpy → native via `to_native`) → Task 1; `test_manual_rc_serializes_native_values`, `test_roundtrip_manual_rc_restores_values`. ✓
+- Single-source-of-truth on disk: when `rc_source == "manual"`, `overrides.rep_conditions` is skipped so the file never holds two RC-bearing keys → Task 1 Step 3; `test_manual_rc_omits_overrides_rep_conditions`. ✓
 - §4.7 point 1 warnings suppressed during load → `_loading` + `_set_rc(warn=False)` in the loading branch; `test_load_is_config_seeded_and_silent`. ✓
 - §4.7 point 2 configured `rc_source` side replayed first → `pipelines.reverse()` when `rc_source == "sim"`; `test_roundtrip_rc_source_sim_replays_sim_first` (the regression guard that fails under fixed meas-first). ✓ (testing-plan items 10 sim-case + 11.)
 - §4.7 point 3 config-seeded auto-update (only configured side updates `ct.rc`) → Plan 3's `_on_capdata_rep_cond` `_loading` branch, exercised here; `test_load_is_config_seeded_and_silent` (item 9). ✓

--- a/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
@@ -52,10 +52,13 @@ results against RCs a reviewing party calculated.
 
 On `CapTest`:
 
-- `rc` — `param.Parameter(default=None)`, the one-row test RC DataFrame (or None).
+- `rc` — a **Python property** backed by a private `self._rc` (one-row test RC
+  DataFrame, or None). It is intentionally *not* a `param`, so the setter can run
+  validation and provenance logic (§4.4). The getter returns `self._rc`.
 - `rc_source` — extend the existing `param.Selector` objects to
-  `["meas", "sim", "manual"]`, default `"meas"`. It now records the **provenance
-  of the current `rc`** (and serves as the default `which` for `rep_cond`).
+  `["meas", "sim", "manual"]`, default `"meas"`. It records the **provenance
+  of the current `rc`** (and serves as the default `which` for `rep_cond`). It is
+  set by internal code (`_set_rc`), not assigned directly by users in normal use.
 
 On `CapData`:
 
@@ -92,32 +95,77 @@ In a test, resolution reads **only** `CapTest.rc` (no silent fallback to
 `cd.rep_cond(...)`, which appends the `RepCond` step to that CapData's pipeline
 and populates `cd.rc` — and then:
 
-1. Sets `self.rc = cd.rc` (the just-computed value).
-2. Sets `self.rc_source = which`.
-3. Emits the overwrite warning per §4.5 **before** overwriting.
+1. Emits the overwrite warning per §4.5 **before** overwriting.
+2. Records the result via `self._set_rc(cd.rc, which)` (a **copy**, per §4.3),
+   which sets both `self._rc` and `self.rc_source = which`.
 
 `which` defaults to the current `self.rc_source` when it is `"meas"`/`"sim"`,
 else `"meas"`.
 
-**Drift decision (point 3):** calling `cd.rep_cond()` directly on a test's
-CapData updates `cd.rc` but **not** `CapTest.rc`. This is documented and
-discouraged in favor of `ct.rep_cond(which)`. Because `rep_irr` reads
-`CapTest.rc`, a stray `cd.rep_cond()` cannot silently change filtering behavior.
+**Drift decision (point 3).** Inside a test there are two RC stores: each
+CapData's own `cd.rc` and the test-level `CapTest.rc`. `ct.rep_cond(which)` is the
+**only** supported way to populate the test RC from data. `cd.rep_cond()` is not
+removed — it still works on a CapData that happens to belong to a test (it
+updates that CapData's own `cd.rc` and appends the `RepCond` step to its
+pipeline) — but it deliberately does **not** propagate to `CapTest.rc`.
+
+Rationale:
+
+1. **Unambiguous ownership.** The test RC changes only when a `CapTest` method is
+   called, so "what are the test's reporting conditions?" has one answer with one
+   place to look.
+2. **No hidden cross-dataset coupling.** Filtering on either dataset resolves
+   `ref_val="rep_irr"` from `CapTest.rc` (§4.2). If a bare `cd.rep_cond()` on
+   `meas` silently became the test RC, it would change `sim`'s filtering behavior
+   from across the pair — exactly the kind of action-at-a-distance this design
+   removes.
+3. **Drift fails loudly, not silently.** Because in-test resolution reads only
+   `CapTest.rc` (never `cd.rc`), a user who calls `cd.rep_cond()` but never
+   `ct.rep_cond(...)` will hit the "`CapTest.rc` is None" error from `rep_irr` /
+   `captest_results` (§6), which points them at `ct.rep_cond(which)`. They cannot
+   accidentally filter or compute results against a stale or mismatched per-
+   dataset value.
+
+Consistency note: `ct.rep_cond(which)` calls `cd.rep_cond` internally, so
+immediately afterward `CapTest.rc` equals a **copy** of that CapData's `cd.rc`
+(copied to avoid aliasing). A *subsequent* direct `cd.rep_cond()` may then
+diverge `cd.rc` from `CapTest.rc`; that divergence is intentional and affects
+only standalone-style reads of `cd.rc`, never in-test behavior.
 
 ### 4.4 Manual override
 
-`ct.set_reporting_conditions(rc)`:
+The **only** public way to set RCs manually is assigning the `CapTest.rc`
+property (one spelling, by design):
 
-- Accepts a one-row DataFrame (or a mapping coerced to one) with at least a
-  `"poa"` column.
-- Sets `self.rc = rc`, `self.rc_source = "manual"`, after the §4.5 warning check.
+```python
+ct.rc = df   # df: one-row DataFrame, or a mapping coerced to one row
+```
 
-A `CapTest.rc` property setter routes assignment (`ct.rc = df`) through the same
-path so both spellings behave identically.
+The setter:
+
+1. **Requires `setup()`** (`_require_setup()`) — needed to know the regression
+   formula.
+2. **Validates RHS coverage.** The required variables are
+   `util.parse_regression_formula(self.meas.regression_formula)[1]` — the same
+   rhs variable set the computed path aggregates in `_calc_rep_cond`
+   (e.g. `poa, t_amb, w_vel`). `meas` and `sim` share the formula after
+   `setup()`; if they differ, raise pointing to the mismatch. If `df` is missing
+   any required variable, raise `ValueError` listing the missing names. (Extra
+   columns are allowed and preserved.)
+3. Coerces to a one-row DataFrame, applies the §4.5 overwrite warning, then
+   records the override via `self._set_rc(df, "manual")`.
+
+**Internal vs public path.** Because the public setter always means "manual", the
+computed-RC assignments from `rep_cond` (§4.3) and `from_yaml` (§4.7) must not go
+through it. They call the private helper `self._set_rc(df, source)`, which sets
+`self._rc` and `self.rc_source` and records the true `source`. The public
+property setter is exactly that helper with `source="manual"`, preceded by the
+validation above. This preserves a single public spelling (`ct.rc = df`) while
+keeping provenance correct for internally-computed RCs.
 
 ### 4.5 Overwrite warning
 
-When setting RC (via `rep_cond` or `set_reporting_conditions`): if `self.rc is
+When setting RC (via `rep_cond` or the `rc` setter): if `self.rc is
 not None` **and** the new source differs from the current `self.rc_source`, warn:
 
 > "Overwriting test reporting conditions sourced from '{old}' with conditions
@@ -130,8 +178,8 @@ does not warn.
 
 Replace the `rc_source`-based pick of `meas.rc`/`sim.rc` with `self.rc`. If
 `self.rc is None`, raise a clear error directing the user to call
-`ct.rep_cond(which)` or `ct.set_reporting_conditions(...)`. The printed
-provenance line uses `self.rc_source`.
+`ct.rep_cond(which)` or assign `ct.rc = df`. The printed provenance line uses
+`self.rc_source`.
 
 ### 4.7 Serialization
 
@@ -140,14 +188,15 @@ Two cases, distinguished by `rc_source`:
 - **Computed (`"meas"`/`"sim"`)** — RC *values* are not serialized; they are
   recomputed by replaying the source pipeline's `RepCond` step on `from_yaml`.
   The existing "drop `overrides.rep_conditions` when a `RepCond` step is present"
-  rule is unchanged. After pipeline replay, `from_yaml` sets `ct.rc` from the
-  `rc_source` CapData's recomputed `rc`.
+  rule is unchanged. After pipeline replay, `from_yaml` calls
+  `_set_rc(<rc_source cd>.rc, rc_source)` to populate `ct.rc` from the recomputed
+  per-dataset `rc`.
 - **Manual (`"manual"`)** — RC values *are* data, not config, so they cannot be
   recomputed. Serialize the one-row RC as a yaml-safe mapping under a new
   optional key `reporting_conditions_values` in the captest sub-mapping (numpy
-  scalars coerced via `util.to_native`). On load, reconstruct the DataFrame, set
-  `ct.rc`, and set `rc_source="manual"` **after** pipeline replay so the manual
-  override wins over anything a `RepCond` step produced.
+  scalars coerced via `util.to_native`). On load, reconstruct the DataFrame and
+  call `_set_rc(df, "manual")` **after** pipeline replay so the manual override
+  wins over anything a `RepCond` step produced.
 
 `rc_source` continues to serialize via the existing `scalar_names` list.
 
@@ -156,16 +205,17 @@ Two cases, distinguished by `rc_source`:
 - Remove the `rc_source_resolved` wiring.
 - Set `self.meas._captest = self` and `self.sim._captest = self`.
 - `setup()` does **not** compute or clear `ct.rc` (RC lifecycle is driven by
-  `rep_cond`/`set_reporting_conditions`). Re-running `setup()` leaves an existing
-  `ct.rc` intact unless the user recomputes.
+  `rep_cond` / the `rc` setter). Re-running `setup()` leaves an existing `ct.rc`
+  intact unless the user recomputes.
 
 ## 5. Components and interfaces (summary)
 
 | Unit | Responsibility | Depends on |
 |------|----------------|------------|
-| `CapTest.rc` / `rc_source` | Hold the one test RC + provenance | — |
+| `CapTest.rc` (property) / `rc_source` | Hold the one test RC + provenance; getter over `_rc` | `_set_rc` |
+| `CapTest._set_rc(df, source)` (private) | Single internal write point for `_rc` + `rc_source` | — |
+| `CapTest.rc` setter | Manual override: validate RHS coverage → `_set_rc(df, "manual")` | `util.parse_regression_formula` |
 | `CapTest.rep_cond(which)` | Compute via a CapData, store onto `ct.rc` | `CapData.rep_cond` |
-| `CapTest.set_reporting_conditions(rc)` | Manual override | — |
 | `CapData.rep_irr` | Resolve reporting POA (test → `ct.rc`, else `self.rc`) | `_captest` |
 | `Irradiance._execute` | `ref_val="rep_irr"` → `capdata.rep_irr` | unchanged |
 | `CapTest.captest_results` | Predict at `ct.rc` | `ct.rc` |
@@ -177,7 +227,10 @@ Two cases, distinguished by `rc_source`:
   remedy.
 - `captest_results` with `ct.rc is None` → `ValueError` directing to `rep_cond`.
 - Source-change overwrite → `UserWarning` (§4.5).
-- `set_reporting_conditions` with a missing `"poa"` column → `ValueError`.
+- `rc` setter when `setup()` has not run → `ValueError` (`_require_setup`).
+- `rc` setter when `df` omits a required RHS regression variable → `ValueError`
+  listing the missing names (§4.4).
+- `rc` setter when `meas`/`sim` regression formulas differ → `ValueError`.
 
 ## 7. Migration impact
 
@@ -196,7 +249,9 @@ Two cases, distinguished by `rc_source`:
    `setup()`.
 2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and
    `rc_source="meas"`; same for `"sim"`.
-3. `set_reporting_conditions(df)` sets `ct.rc` and `rc_source="manual"`.
+3. `ct.rc = df` sets `ct.rc` and `rc_source="manual"`; raises when `setup()` has
+   not run, when a required RHS variable is missing (message lists them), and
+   when `meas`/`sim` formulas differ; extra columns are preserved.
 4. Overwrite warning fires on source change; no warning on same-source recompute.
 5. `rep_irr`: in-test reads `ct.rc`; standalone reads `cd.rc`; `ValueError` when
    `ct.rc` is None in a test.

--- a/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
@@ -94,18 +94,17 @@ In a test, resolution reads **only** `CapTest.rc` (no silent fallback to
 CapData that belongs to a test (`cd._captest is not None`) does what it does
 standalone — appends the `RepCond` step and sets `cd.rc` — and then updates the
 test RC by calling `ct._set_rc(cd.rc.copy(), <this cd's side>)`, which sets
-`ct.rc` and flips `ct.rc_source` to that side. It emits a `UserWarning` that the
-test reporting conditions and `rc_source` were updated, so a CapData-level call's
-side effect on test-level state is visible. The warning fires on every such
-update, including recomputing the same source.
+`ct.rc` and sets `ct.rc_source` to that side. When this **changes the source**
+(§4.5) it emits a `UserWarning` so the flip is visible; recomputing the current
+source is silent.
 
 `ct.rep_cond(which="meas", **overrides)` remains the convenience entry point: it
 picks the CapData, merges the preset / `self.rep_conditions` config as today, and
-calls `cd.rep_cond(...)`, so the test RC is updated through the same path. Because
-updating `ct.rc` is the explicit purpose of `ct.rep_cond`, it **suppresses** the
-side-effect warning (the warning targets the bare `cd.rep_cond()` case). `which`
-defaults to the current `self.rc_source` when it is `"meas"`/`"sim"`, else
-`"meas"`.
+calls `cd.rep_cond(...)`, so the test RC is updated through the same path. The
+source-change warning rule (§4.5) applies uniformly — there is no path-specific
+suppression — so a flip warns whether triggered via `cd.rep_cond()` or
+`ct.rep_cond(other_side)`. `which` defaults to the current `self.rc_source` when
+it is `"meas"`/`"sim"`, else `"meas"`.
 
 `ct.rc` stores a **copy** of `cd.rc` (avoids aliasing); a later direct
 `cd.rep_cond()` re-runs the whole update, so `ct.rc` simply tracks the most recent
@@ -140,7 +139,7 @@ The setter:
    `setup()`; if they differ, raise pointing to the mismatch. If `df` is missing
    any required variable, raise `ValueError` listing the missing names. (Extra
    columns are allowed and preserved.)
-3. Coerces to a one-row DataFrame, applies the §4.5 manual-override warning, then
+3. Coerces to a one-row DataFrame, applies the §4.5 source-change warning, then
    records the override via `self._set_rc(df, "manual")`.
 
 **Internal vs public path.** Because the public setter always means "manual", the
@@ -151,16 +150,19 @@ property setter is exactly that helper with `source="manual"`, preceded by the
 validation above. This preserves a single public spelling (`ct.rc = df`) while
 keeping provenance correct for internally-computed RCs.
 
-### 4.5 Update / overwrite warnings
+### 4.5 Source-change warning
 
-- **`cd.rep_cond()` in a test (runtime):** always warn that the test reporting
-  conditions and `rc_source` were updated, naming the new source — e.g.
-  *"Test reporting conditions updated from the 'sim' CapData; rc_source set to
-  'sim'."* Suppressed when invoked via `ct.rep_cond` (the explicit path) and
-  during `from_yaml` load (§4.7).
-- **`ct.rc = df` (manual setter):** if `self.rc is not None` and the current
-  `self.rc_source` differs from `"manual"`, warn that a computed RC is being
-  replaced by a manual override.
+A single rule governs **every** runtime path that sets the test RC
+(`cd.rep_cond()` in a test, `ct.rep_cond(which)`, and the `ct.rc = df` manual
+setter): warn **only when the source changes** — i.e. `self.rc is not None` *and*
+the new source differs from the current `self.rc_source`. This covers a meas↔sim
+flip and any change to or from `"manual"`. Recomputing the current source (same
+`rc_source`) and the first time an RC is established (`self.rc is None`) are
+**silent**.
+
+The warning names the old and new source, e.g. *"Test reporting conditions
+rc_source changed from 'meas' to 'sim'."* It is suppressed during `from_yaml`
+load (§4.7).
 
 ### 4.6 `captest_results`
 
@@ -215,8 +217,8 @@ meas-before-sim replay order must be retained (see §10).
 | `CapTest.rc` (property) / `rc_source` | Hold the one test RC + provenance; getter over `_rc` | `_set_rc` |
 | `CapTest._set_rc(df, source)` (private) | Single internal write point for `_rc` + `rc_source` | — |
 | `CapTest.rc` setter | Manual override: validate RHS coverage → `_set_rc(df, "manual")` | `util.parse_regression_formula` |
-| `CapTest.rep_cond(which)` | Convenience: pick cd, merge config, call `cd.rep_cond` (warning suppressed) | `CapData.rep_cond` |
-| `CapData.rep_cond` / `_calc_rep_cond` | Set `cd.rc`; if in a test, update `ct.rc` (last-writer) + warn | `_captest`, `_set_rc` |
+| `CapTest.rep_cond(which)` | Convenience: pick cd, merge config, call `cd.rep_cond` | `CapData.rep_cond` |
+| `CapData.rep_cond` / `_calc_rep_cond` | Set `cd.rc`; if in a test, update `ct.rc` (last-writer) + warn on source change | `_captest`, `_set_rc` |
 | `CapData.rep_irr` | Resolve reporting POA (test → `ct.rc`, else `self.rc`) | `_captest` |
 | `Irradiance._execute` | `ref_val="rep_irr"` → `capdata.rep_irr` | unchanged |
 | `CapTest.captest_results` | Predict at `ct.rc` | `ct.rc` |
@@ -227,9 +229,9 @@ meas-before-sim replay order must be retained (see §10).
 - `rep_irr` with no resolvable RC → `ValueError` naming the in-test vs standalone
   remedy.
 - `captest_results` with `ct.rc is None` → `ValueError` directing to `rep_cond`.
-- `cd.rep_cond()` in a test updating `ct.rc` → `UserWarning` (§4.5), suppressed via
-  `ct.rep_cond` and during load.
-- `ct.rc = df` replacing a non-manual RC → `UserWarning` (§4.5).
+- Test RC **source change** (meas↔sim, or to/from `"manual"`) via any runtime
+  path → `UserWarning` (§4.5); silent on same-source recompute and first
+  establishment; suppressed during load.
 - `rc` setter when `setup()` has not run → `ValueError` (`_require_setup`).
 - `rc` setter when `df` omits a required RHS regression variable → `ValueError`
   listing the missing names (§4.4).
@@ -241,10 +243,11 @@ meas-before-sim replay order must be retained (see §10).
   attribute, its `setup()` wiring, and the `rep_irr` branch that read it.
 - Behavior change: `captest_results` now reads `ct.rc`. Existing flows that call
   `cd.rep_cond()` (e.g. via `run_test`) and then `captest_results` keep working —
-  last-writer-wins means the bare `cd.rep_cond()` now populates `ct.rc` — but they
-  emit the §4.5 side-effect warning. Flows can quiet the warning by using
-  `ct.rep_cond(which)`. The example notebook is being reworked by the user
-  separately.
+  last-writer-wins means the bare `cd.rep_cond()` now populates `ct.rc`. With the
+  default `rc_source` matching the computed side (the common case) this is silent
+  (first establishment / same source); the §4.5 warning fires only if a flow
+  computes RC on the other side and flips the source. The example notebook is
+  being reworked by the user separately.
 - Tests added this session (`TestRepIrrCrossInstance`, the `rc_source_resolved`
   wiring asserts in `TestSetup`) are updated to the `_captest` / `ct.rc` model.
 
@@ -252,15 +255,18 @@ meas-before-sim replay order must be retained (see §10).
 
 1. `CapTest.rc`/`rc_source` defaults; `_captest` wired on both CapData by
    `setup()`.
-2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and `rc_source="meas"`
-   without a warning; same for `"sim"`.
-3. **Last-writer-wins:** bare `meas.rep_cond()` in a test sets `ct.rc` +
-   `rc_source="meas"` and warns; a following `sim.rep_cond()` flips to `sim` and
-   warns. Standalone `cd.rep_cond()` (no `_captest`) does neither.
+2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and `rc_source="meas"`;
+   same for `"sim"`.
+3. **Last-writer-wins + source-change warning:** with `rc_source="meas"`,
+   `meas.rep_cond()` again is **silent** (same source, recomputed values); a
+   following `sim.rep_cond()` flips to `sim` and **warns**; the first
+   establishment (when `ct.rc` was None) is silent. Standalone `cd.rep_cond()`
+   (no `_captest`) updates only `cd.rc` and never warns.
 4. `ct.rc = df` sets `ct.rc` and `rc_source="manual"`; raises when `setup()` has
    not run, when a required RHS variable is missing (message lists them), and when
-   `meas`/`sim` formulas differ; extra columns are preserved; warns when replacing
-   a non-manual RC.
+   `meas`/`sim` formulas differ; extra columns are preserved; **warns** when it
+   changes the source (e.g. meas→manual), silent if the prior source was already
+   `"manual"`.
 5. `rep_irr`: in-test reads `ct.rc`; standalone reads `cd.rc`; `ValueError` when
    `ct.rc` is None in a test.
 6. `filter_irr(ref_val="rep_irr")` on sim uses `ct.rc` set from meas, without a
@@ -282,9 +288,9 @@ None outstanding. Resolved during brainstorming:
 
 - Standalone CapData keeps owning `cd.rc` (yes).
 - **Runtime: last-writer-wins.** Any `cd.rep_cond()` in a test updates `ct.rc` +
-  `rc_source` and warns; `ct.rep_cond(which)` is the convenience path and
-  suppresses the warning. Config/constructor `rc_source` seeds the value but does
-  not pin it after load.
+  `rc_source`; a `UserWarning` fires **only on a source change** (meas↔sim or to/
+  from `"manual"`), uniformly across paths (no per-path suppression).
+  Config/constructor `rc_source` seeds the value but does not pin it after load.
 - Load is config-seeded and warning-suppressed for deterministic round-trips
   (§4.7).
 - Manual override is a first-class source (`rc_source="manual"`), serialized by

--- a/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
@@ -1,0 +1,218 @@
+# CapTest as the single owner of test reporting conditions
+
+- **Status:** Draft for review
+- **Date:** 2026-06-27
+- **Branch:** filters-refactor
+- **Supersedes:** the `CapData.rc_source_resolved` reference mechanism added earlier
+  on this branch (commit `71c462e`).
+
+## 1. Background and motivation
+
+A capacity test conceptually has **exactly one set of reporting conditions
+(RCs)**. Today the codebase does not model that directly:
+
+- `CapData` owns its own `rc` DataFrame, computed by `CapData.rep_cond()` (which
+  appends a `RepCond` step to the filter pipeline).
+- `CapTest.rc_source` (a `param.Selector` of `{"meas", "sim"}`) tells
+  `captest_results` *which* CapData's `rc` to predict at.
+- `CapTest.rc_source_resolved` (a `CapData` → `CapData` reference wired in
+  `setup()`) tells the `Irradiance` filter which CapData's `rc` to resolve
+  `ref_val="rep_irr"` against.
+
+So "the test's reporting conditions" is spread across three related concepts
+(`cd.rc`, `rc_source`, `rc_source_resolved`), both `meas.rc` and `sim.rc` can
+exist simultaneously, and it is non-obvious that one of them is ignored for
+filtering. There is also no way to **manually supply** an RC set that does not
+come from either dataset — needed for sensitivity analysis and for checking
+results against RCs a reviewing party calculated.
+
+## 2. Goals
+
+1. `CapTest.rc` is **the** test reporting conditions: one DataFrame, accessible
+   in one place.
+2. The RC is sourced from `meas`, from `sim`, **or** set manually — tracked by
+   `CapTest.rc_source ∈ {"meas", "sim", "manual"}`.
+3. Warn when RC is replaced **from a different source** (e.g. recomputing over a
+   manual override, or switching meas→sim).
+4. `filter_irr(ref_val="rep_irr")` inside a test resolves from `CapTest.rc`.
+5. Net **simplification**: remove `rc_source_resolved`; `captest_results` and
+   irradiance filtering read the same `CapTest.rc`.
+
+## 3. Non-goals
+
+- Standalone `CapData` behavior is **unchanged**: `cd.rep_cond()` still populates
+  `cd.rc`, and `cd.filter_irr(ref_val="rep_irr")` outside a test still resolves
+  from `cd.rc`. (Confirmed hard constraint.)
+- No changes to `rep_cond_freq` / grouped `predict_capacities` RC handling.
+- No deprecation shims (pre-1.0 refactor branch; clean break is acceptable).
+
+## 4. Design
+
+### 4.1 Data model
+
+On `CapTest`:
+
+- `rc` — `param.Parameter(default=None)`, the one-row test RC DataFrame (or None).
+- `rc_source` — extend the existing `param.Selector` objects to
+  `["meas", "sim", "manual"]`, default `"meas"`. It now records the **provenance
+  of the current `rc`** (and serves as the default `which` for `rep_cond`).
+
+On `CapData`:
+
+- Replace `rc_source_resolved` (CapData→CapData reference) with `_captest`
+  (CapData→CapTest reference, default `None`), set in `CapTest.setup()`. This is a
+  runtime object reference only; `capdata.py` still never imports `captest`, so
+  the module import layering is preserved.
+- `cd.rc` is retained for standalone use, unchanged.
+
+### 4.2 Reporting-conditions resolution (`CapData.rep_irr`)
+
+```python
+@property
+def rep_irr(self):
+    rc = self._captest.rc if self._captest is not None else self.rc
+    if rc is None:
+        raise ValueError(
+            # in-test message points to ct.rep_cond(which); standalone to rep_cond()
+            ...
+        )
+    if "poa" not in rc.columns:
+        raise ValueError(...)
+    return float(rc["poa"].iloc[0])
+```
+
+In a test, resolution reads **only** `CapTest.rc` (no silent fallback to
+`cd.rc`). `Irradiance._execute` is unchanged — it already delegates to
+`capdata.rep_irr`.
+
+### 4.3 Computing RC inside a test (`CapTest.rep_cond`)
+
+`ct.rep_cond(which="meas", **overrides)` is the single in-test entry point
+(point 3, confirmed). It keeps its current behavior — delegating to
+`cd.rep_cond(...)`, which appends the `RepCond` step to that CapData's pipeline
+and populates `cd.rc` — and then:
+
+1. Sets `self.rc = cd.rc` (the just-computed value).
+2. Sets `self.rc_source = which`.
+3. Emits the overwrite warning per §4.5 **before** overwriting.
+
+`which` defaults to the current `self.rc_source` when it is `"meas"`/`"sim"`,
+else `"meas"`.
+
+**Drift decision (point 3):** calling `cd.rep_cond()` directly on a test's
+CapData updates `cd.rc` but **not** `CapTest.rc`. This is documented and
+discouraged in favor of `ct.rep_cond(which)`. Because `rep_irr` reads
+`CapTest.rc`, a stray `cd.rep_cond()` cannot silently change filtering behavior.
+
+### 4.4 Manual override
+
+`ct.set_reporting_conditions(rc)`:
+
+- Accepts a one-row DataFrame (or a mapping coerced to one) with at least a
+  `"poa"` column.
+- Sets `self.rc = rc`, `self.rc_source = "manual"`, after the §4.5 warning check.
+
+A `CapTest.rc` property setter routes assignment (`ct.rc = df`) through the same
+path so both spellings behave identically.
+
+### 4.5 Overwrite warning
+
+When setting RC (via `rep_cond` or `set_reporting_conditions`): if `self.rc is
+not None` **and** the new source differs from the current `self.rc_source`, warn:
+
+> "Overwriting test reporting conditions sourced from '{old}' with conditions
+> from '{new}'."
+
+Re-running the **same** source (e.g. recomputing meas RC after changing filters)
+does not warn.
+
+### 4.6 `captest_results`
+
+Replace the `rc_source`-based pick of `meas.rc`/`sim.rc` with `self.rc`. If
+`self.rc is None`, raise a clear error directing the user to call
+`ct.rep_cond(which)` or `ct.set_reporting_conditions(...)`. The printed
+provenance line uses `self.rc_source`.
+
+### 4.7 Serialization
+
+Two cases, distinguished by `rc_source`:
+
+- **Computed (`"meas"`/`"sim"`)** — RC *values* are not serialized; they are
+  recomputed by replaying the source pipeline's `RepCond` step on `from_yaml`.
+  The existing "drop `overrides.rep_conditions` when a `RepCond` step is present"
+  rule is unchanged. After pipeline replay, `from_yaml` sets `ct.rc` from the
+  `rc_source` CapData's recomputed `rc`.
+- **Manual (`"manual"`)** — RC values *are* data, not config, so they cannot be
+  recomputed. Serialize the one-row RC as a yaml-safe mapping under a new
+  optional key `reporting_conditions_values` in the captest sub-mapping (numpy
+  scalars coerced via `util.to_native`). On load, reconstruct the DataFrame, set
+  `ct.rc`, and set `rc_source="manual"` **after** pipeline replay so the manual
+  override wins over anything a `RepCond` step produced.
+
+`rc_source` continues to serialize via the existing `scalar_names` list.
+
+### 4.8 `setup()` changes
+
+- Remove the `rc_source_resolved` wiring.
+- Set `self.meas._captest = self` and `self.sim._captest = self`.
+- `setup()` does **not** compute or clear `ct.rc` (RC lifecycle is driven by
+  `rep_cond`/`set_reporting_conditions`). Re-running `setup()` leaves an existing
+  `ct.rc` intact unless the user recomputes.
+
+## 5. Components and interfaces (summary)
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| `CapTest.rc` / `rc_source` | Hold the one test RC + provenance | — |
+| `CapTest.rep_cond(which)` | Compute via a CapData, store onto `ct.rc` | `CapData.rep_cond` |
+| `CapTest.set_reporting_conditions(rc)` | Manual override | — |
+| `CapData.rep_irr` | Resolve reporting POA (test → `ct.rc`, else `self.rc`) | `_captest` |
+| `Irradiance._execute` | `ref_val="rep_irr"` → `capdata.rep_irr` | unchanged |
+| `CapTest.captest_results` | Predict at `ct.rc` | `ct.rc` |
+| `to_yaml` / `from_yaml` | Persist/restore `rc_source` (+ manual values) | `util.to_native` |
+
+## 6. Error handling and warnings
+
+- `rep_irr` with no resolvable RC → `ValueError` naming the in-test vs standalone
+  remedy.
+- `captest_results` with `ct.rc is None` → `ValueError` directing to `rep_cond`.
+- Source-change overwrite → `UserWarning` (§4.5).
+- `set_reporting_conditions` with a missing `"poa"` column → `ValueError`.
+
+## 7. Migration impact
+
+- Internal-only removals (added this session, unreleased): `rc_source_resolved`
+  attribute, its `setup()` wiring, and the `rep_irr` branch that read it.
+- Behavior change: `captest_results` now reads `ct.rc`. Existing flows that call
+  `cd.rep_cond()` (e.g. via `run_test`) and then `captest_results` must switch to
+  `ct.rep_cond(which)`. The example notebook is being reworked by the user
+  separately.
+- Tests added this session (`TestRepIrrCrossInstance`, the `rc_source_resolved`
+  wiring asserts in `TestSetup`) are updated to the `_captest` / `ct.rc` model.
+
+## 8. Testing plan
+
+1. `CapTest.rc`/`rc_source` defaults; `_captest` wired on both CapData by
+   `setup()`.
+2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and
+   `rc_source="meas"`; same for `"sim"`.
+3. `set_reporting_conditions(df)` sets `ct.rc` and `rc_source="manual"`.
+4. Overwrite warning fires on source change; no warning on same-source recompute.
+5. `rep_irr`: in-test reads `ct.rc`; standalone reads `cd.rc`; `ValueError` when
+   `ct.rc` is None in a test.
+6. `filter_irr(ref_val="rep_irr")` on sim uses `ct.rc` set from meas, without a
+   manual value pass (the original bug's real-world scenario).
+7. `captest_results` predicts at `ct.rc`; `ValueError` when None.
+8. Serialization round-trip: computed source recomputes `ct.rc` on load; manual
+   override serializes values and restores `ct.rc` + `rc_source="manual"`.
+9. Standalone `CapData` regression tests remain green (no behavior change).
+
+## 9. Open questions
+
+None outstanding. Resolved during brainstorming:
+
+- Standalone CapData keeps owning `cd.rc` (yes).
+- `ct.rep_cond(which)` is the single in-test entry point; `cd.rep_cond()` does
+  not sync to `ct.rc` (point 3).
+- Manual override is a first-class source (`rc_source="manual"`), serialized by
+  value.

--- a/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
@@ -188,19 +188,25 @@ self-filtering pipelines stay correct. During `from_yaml`, a `_loading` flag on
 the CapTest modifies the §4.3 auto-update for the duration of replay:
 
 1. Warnings are suppressed.
-2. The auto-update applies **only when the CapData is the configured `rc_source`
+2. **The configured `rc_source` side's pipeline is replayed first** (not a fixed
+   meas-before-sim order). This is required: the *other* side's pipeline may
+   contain `filter_irr(ref_val="rep_irr")` (the standard "filter one dataset
+   around the other's rep irr" pattern), which resolves against `ct.rc`. `ct.rc`
+   is populated only by the configured source's `RepCond` (point 3), so that side
+   must run first or the other side's filter raises on a `None` `ct.rc`. For
+   `rc_source="meas"` this is meas→sim; for `rc_source="sim"` it is **sim→meas**.
+3. The auto-update applies **only when the CapData is the configured `rc_source`
    side** (config-seeded, not last-writer-wins). So the configured source's
    `RepCond` step populates `ct.rc` *mid-replay*, making `ref_val="rep_irr"`
-   resolvable for that side's own filters during replay, while the other side's
+   resolvable for both sides' filters during replay, while the other side's
    `RepCond` (if any) updates only its `cd.rc`.
-3. For `rc_source="manual"`, `ct.rc` is set from `reporting_conditions_values`
+4. For `rc_source="manual"`, `ct.rc` is set from `reporting_conditions_values`
    **before** replay; no `RepCond` step overwrites it (no side matches a
    `"manual"` source), so the manual values are in effect for any self-filtering
-   pipeline during replay.
+   pipeline during replay regardless of order (meas→sim is fine).
 
 After replay, `_loading` is cleared; `ct.rc` / `rc_source` reflect the configured
-state and interactive last-writer-wins (§4.3) takes over. The existing
-meas-before-sim replay order must be retained (see §10).
+state and interactive last-writer-wins (§4.3) takes over.
 
 ### 4.8 `setup()` changes
 
@@ -241,6 +247,10 @@ meas-before-sim replay order must be retained (see §10).
 
 - Internal-only removals (added this session, unreleased): `rc_source_resolved`
   attribute, its `setup()` wiring, and the `rep_irr` branch that read it.
+- Implementation change: `from_yaml` currently replays meas then sim
+  (captest.py:1818-1821, the unconditional order). It must instead replay the
+  configured `rc_source` side first (§4.7), falling back to meas→sim for
+  `rc_source="manual"`.
 - Behavior change: `captest_results` now reads `ct.rc`. Existing flows that call
   `cd.rep_cond()` (e.g. via `run_test`) and then `captest_results` keep working —
   last-writer-wins means the bare `cd.rep_cond()` now populates `ct.rc`. With the
@@ -277,10 +287,19 @@ meas-before-sim replay order must be retained (see §10).
 9. **Load determinism:** a config where both pipelines contain a `RepCond` step
    restores `ct.rc`/`rc_source` to the configured source (config-seeded, not the
    last replayed step); no warnings emit during load.
-10. **Mid-replay self-filtering:** a meas pipeline of
-    `RepCond → filter_irr(ref_val="rep_irr")` round-trips through `to_yaml`/
-    `from_yaml` without error (regression guard for the load path).
-11. Standalone `CapData` regression tests remain green (no behavior change).
+10. **Mid-replay self-filtering, both source sides:**
+    - `rc_source="meas"`: a meas pipeline of
+      `RepCond → filter_irr(ref_val="rep_irr")` (plus a sim pipeline whose
+      `filter_irr(ref_val="rep_irr")` references `ct.rc`) round-trips through
+      `to_yaml`/`from_yaml` without error.
+    - `rc_source="sim"`: the **other** side carries the `rep_irr` filter — a meas
+      pipeline with `filter_irr(ref_val="rep_irr")` and a sim pipeline with the
+      `RepCond` — round-trips without error, proving the sim→meas replay order
+      (the configured-source-first rule); this case fails under a fixed
+      meas-before-sim order, so it is the explicit regression guard.
+11. **Replay order:** `from_yaml` replays the configured `rc_source` side first
+    (sim→meas when `rc_source="sim"`).
+12. Standalone `CapData` regression tests remain green (no behavior change).
 
 ## 9. Open questions
 
@@ -319,6 +338,9 @@ to accommodate it; notes for the future implementer:
   changes `ct.rc`, leaving meas's `rep_irr`-based filters stale. This is inherent
   to "filter one dataset around the other's rep irr," not a flaw here; the future
   work should add staleness detection at the `_set_rc` hook.
-- **Retain the meas-before-sim replay order** in `from_yaml` (§4.7) so a
-  meas-sourced `ct.rc` exists before sim's filters at initial load. At re-run time
-  `ct.rc` persists, so ordering no longer matters then.
+- **Replay the configured `rc_source` side first** in `from_yaml` (§4.7) so the
+  source's `ct.rc` exists before the other side's `rep_irr` filters at initial
+  load (sim→meas when `rc_source="sim"`; meas→sim when `"meas"`). At re-run time
+  `ct.rc` persists, so ordering no longer matters then — but a future
+  `setup(which=...)` re-run must still ensure `ct.rc` is current for the source
+  side before re-filtering the dependent side.

--- a/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
+++ b/docs/superpowers/specs/2026-06-27-captest-rc-ownership-design.md
@@ -88,49 +88,37 @@ In a test, resolution reads **only** `CapTest.rc` (no silent fallback to
 `cd.rc`). `Irradiance._execute` is unchanged — it already delegates to
 `capdata.rep_irr`.
 
-### 4.3 Computing RC inside a test (`CapTest.rep_cond`)
+### 4.3 Updating the test RC from a CapData (`rep_cond`)
 
-`ct.rep_cond(which="meas", **overrides)` is the single in-test entry point
-(point 3, confirmed). It keeps its current behavior — delegating to
-`cd.rep_cond(...)`, which appends the `RepCond` step to that CapData's pipeline
-and populates `cd.rc` — and then:
+**Runtime rule (after construction): last-writer-wins.** Any `cd.rep_cond()` on a
+CapData that belongs to a test (`cd._captest is not None`) does what it does
+standalone — appends the `RepCond` step and sets `cd.rc` — and then updates the
+test RC by calling `ct._set_rc(cd.rc.copy(), <this cd's side>)`, which sets
+`ct.rc` and flips `ct.rc_source` to that side. It emits a `UserWarning` that the
+test reporting conditions and `rc_source` were updated, so a CapData-level call's
+side effect on test-level state is visible. The warning fires on every such
+update, including recomputing the same source.
 
-1. Emits the overwrite warning per §4.5 **before** overwriting.
-2. Records the result via `self._set_rc(cd.rc, which)` (a **copy**, per §4.3),
-   which sets both `self._rc` and `self.rc_source = which`.
+`ct.rep_cond(which="meas", **overrides)` remains the convenience entry point: it
+picks the CapData, merges the preset / `self.rep_conditions` config as today, and
+calls `cd.rep_cond(...)`, so the test RC is updated through the same path. Because
+updating `ct.rc` is the explicit purpose of `ct.rep_cond`, it **suppresses** the
+side-effect warning (the warning targets the bare `cd.rep_cond()` case). `which`
+defaults to the current `self.rc_source` when it is `"meas"`/`"sim"`, else
+`"meas"`.
 
-`which` defaults to the current `self.rc_source` when it is `"meas"`/`"sim"`,
-else `"meas"`.
+`ct.rc` stores a **copy** of `cd.rc` (avoids aliasing); a later direct
+`cd.rep_cond()` re-runs the whole update, so `ct.rc` simply tracks the most recent
+`rep_cond` across either dataset.
 
-**Drift decision (point 3).** Inside a test there are two RC stores: each
-CapData's own `cd.rc` and the test-level `CapTest.rc`. `ct.rep_cond(which)` is the
-**only** supported way to populate the test RC from data. `cd.rep_cond()` is not
-removed — it still works on a CapData that happens to belong to a test (it
-updates that CapData's own `cd.rc` and appends the `RepCond` step to its
-pipeline) — but it deliberately does **not** propagate to `CapTest.rc`.
+**Standalone unaffected:** when `cd._captest is None`, `cd.rep_cond()` only sets
+`cd.rc` — no test-level update, no warning.
 
-Rationale:
-
-1. **Unambiguous ownership.** The test RC changes only when a `CapTest` method is
-   called, so "what are the test's reporting conditions?" has one answer with one
-   place to look.
-2. **No hidden cross-dataset coupling.** Filtering on either dataset resolves
-   `ref_val="rep_irr"` from `CapTest.rc` (§4.2). If a bare `cd.rep_cond()` on
-   `meas` silently became the test RC, it would change `sim`'s filtering behavior
-   from across the pair — exactly the kind of action-at-a-distance this design
-   removes.
-3. **Drift fails loudly, not silently.** Because in-test resolution reads only
-   `CapTest.rc` (never `cd.rc`), a user who calls `cd.rep_cond()` but never
-   `ct.rep_cond(...)` will hit the "`CapTest.rc` is None" error from `rep_irr` /
-   `captest_results` (§6), which points them at `ct.rep_cond(which)`. They cannot
-   accidentally filter or compute results against a stale or mismatched per-
-   dataset value.
-
-Consistency note: `ct.rep_cond(which)` calls `cd.rep_cond` internally, so
-immediately afterward `CapTest.rc` equals a **copy** of that CapData's `cd.rc`
-(copied to avoid aliasing). A *subsequent* direct `cd.rep_cond()` may then
-diverge `cd.rc` from `CapTest.rc`; that divergence is intentional and affects
-only standalone-style reads of `cd.rc`, never in-test behavior.
+**Why last-writer-wins (vs pinning to config).** Chosen for the interactive
+post-load workflow: a user adjusting filters and recomputing `rep_cond` wants the
+latest computation to become the test RC, flagged by a warning rather than
+blocked by an error. Config/constructor `rc_source` *seeds* the value (and is
+restored deterministically on load, §4.7) but does not lock it afterward.
 
 ### 4.4 Manual override
 
@@ -152,7 +140,7 @@ The setter:
    `setup()`; if they differ, raise pointing to the mismatch. If `df` is missing
    any required variable, raise `ValueError` listing the missing names. (Extra
    columns are allowed and preserved.)
-3. Coerces to a one-row DataFrame, applies the §4.5 overwrite warning, then
+3. Coerces to a one-row DataFrame, applies the §4.5 manual-override warning, then
    records the override via `self._set_rc(df, "manual")`.
 
 **Internal vs public path.** Because the public setter always means "manual", the
@@ -163,16 +151,16 @@ property setter is exactly that helper with `source="manual"`, preceded by the
 validation above. This preserves a single public spelling (`ct.rc = df`) while
 keeping provenance correct for internally-computed RCs.
 
-### 4.5 Overwrite warning
+### 4.5 Update / overwrite warnings
 
-When setting RC (via `rep_cond` or the `rc` setter): if `self.rc is
-not None` **and** the new source differs from the current `self.rc_source`, warn:
-
-> "Overwriting test reporting conditions sourced from '{old}' with conditions
-> from '{new}'."
-
-Re-running the **same** source (e.g. recomputing meas RC after changing filters)
-does not warn.
+- **`cd.rep_cond()` in a test (runtime):** always warn that the test reporting
+  conditions and `rc_source` were updated, naming the new source — e.g.
+  *"Test reporting conditions updated from the 'sim' CapData; rc_source set to
+  'sim'."* Suppressed when invoked via `ct.rep_cond` (the explicit path) and
+  during `from_yaml` load (§4.7).
+- **`ct.rc = df` (manual setter):** if `self.rc is not None` and the current
+  `self.rc_source` differs from `"manual"`, warn that a computed RC is being
+  replaced by a manual override.
 
 ### 4.6 `captest_results`
 
@@ -181,24 +169,36 @@ Replace the `rc_source`-based pick of `meas.rc`/`sim.rc` with `self.rc`. If
 `ct.rep_cond(which)` or assign `ct.rc = df`. The printed provenance line uses
 `self.rc_source`.
 
-### 4.7 Serialization
+### 4.7 Serialization and load
 
-Two cases, distinguished by `rc_source`:
+`rc_source` serializes via the existing `scalar_names` list. RC *values* are
+serialized only for the manual case:
 
-- **Computed (`"meas"`/`"sim"`)** — RC *values* are not serialized; they are
-  recomputed by replaying the source pipeline's `RepCond` step on `from_yaml`.
-  The existing "drop `overrides.rep_conditions` when a `RepCond` step is present"
-  rule is unchanged. After pipeline replay, `from_yaml` calls
-  `_set_rc(<rc_source cd>.rc, rc_source)` to populate `ct.rc` from the recomputed
-  per-dataset `rc`.
-- **Manual (`"manual"`)** — RC values *are* data, not config, so they cannot be
-  recomputed. Serialize the one-row RC as a yaml-safe mapping under a new
-  optional key `reporting_conditions_values` in the captest sub-mapping (numpy
-  scalars coerced via `util.to_native`). On load, reconstruct the DataFrame and
-  call `_set_rc(df, "manual")` **after** pipeline replay so the manual override
-  wins over anything a `RepCond` step produced.
+- **Computed (`"meas"`/`"sim"`)** — values are not serialized; they are recomputed
+  by replaying the source pipeline's `RepCond` step. The existing "drop
+  `overrides.rep_conditions` when a `RepCond` step is present" rule is unchanged.
+- **Manual (`"manual"`)** — values *are* data; serialize the one-row RC as a
+  yaml-safe mapping under a new optional key `reporting_conditions_values`
+  (numpy scalars coerced via `util.to_native`).
 
-`rc_source` continues to serialize via the existing `scalar_names` list.
+**Load differs from interactive runtime** so round-trips are deterministic and
+self-filtering pipelines stay correct. During `from_yaml`, a `_loading` flag on
+the CapTest modifies the §4.3 auto-update for the duration of replay:
+
+1. Warnings are suppressed.
+2. The auto-update applies **only when the CapData is the configured `rc_source`
+   side** (config-seeded, not last-writer-wins). So the configured source's
+   `RepCond` step populates `ct.rc` *mid-replay*, making `ref_val="rep_irr"`
+   resolvable for that side's own filters during replay, while the other side's
+   `RepCond` (if any) updates only its `cd.rc`.
+3. For `rc_source="manual"`, `ct.rc` is set from `reporting_conditions_values`
+   **before** replay; no `RepCond` step overwrites it (no side matches a
+   `"manual"` source), so the manual values are in effect for any self-filtering
+   pipeline during replay.
+
+After replay, `_loading` is cleared; `ct.rc` / `rc_source` reflect the configured
+state and interactive last-writer-wins (§4.3) takes over. The existing
+meas-before-sim replay order must be retained (see §10).
 
 ### 4.8 `setup()` changes
 
@@ -215,7 +215,8 @@ Two cases, distinguished by `rc_source`:
 | `CapTest.rc` (property) / `rc_source` | Hold the one test RC + provenance; getter over `_rc` | `_set_rc` |
 | `CapTest._set_rc(df, source)` (private) | Single internal write point for `_rc` + `rc_source` | — |
 | `CapTest.rc` setter | Manual override: validate RHS coverage → `_set_rc(df, "manual")` | `util.parse_regression_formula` |
-| `CapTest.rep_cond(which)` | Compute via a CapData, store onto `ct.rc` | `CapData.rep_cond` |
+| `CapTest.rep_cond(which)` | Convenience: pick cd, merge config, call `cd.rep_cond` (warning suppressed) | `CapData.rep_cond` |
+| `CapData.rep_cond` / `_calc_rep_cond` | Set `cd.rc`; if in a test, update `ct.rc` (last-writer) + warn | `_captest`, `_set_rc` |
 | `CapData.rep_irr` | Resolve reporting POA (test → `ct.rc`, else `self.rc`) | `_captest` |
 | `Irradiance._execute` | `ref_val="rep_irr"` → `capdata.rep_irr` | unchanged |
 | `CapTest.captest_results` | Predict at `ct.rc` | `ct.rc` |
@@ -226,7 +227,9 @@ Two cases, distinguished by `rc_source`:
 - `rep_irr` with no resolvable RC → `ValueError` naming the in-test vs standalone
   remedy.
 - `captest_results` with `ct.rc is None` → `ValueError` directing to `rep_cond`.
-- Source-change overwrite → `UserWarning` (§4.5).
+- `cd.rep_cond()` in a test updating `ct.rc` → `UserWarning` (§4.5), suppressed via
+  `ct.rep_cond` and during load.
+- `ct.rc = df` replacing a non-manual RC → `UserWarning` (§4.5).
 - `rc` setter when `setup()` has not run → `ValueError` (`_require_setup`).
 - `rc` setter when `df` omits a required RHS regression variable → `ValueError`
   listing the missing names (§4.4).
@@ -237,7 +240,9 @@ Two cases, distinguished by `rc_source`:
 - Internal-only removals (added this session, unreleased): `rc_source_resolved`
   attribute, its `setup()` wiring, and the `rep_irr` branch that read it.
 - Behavior change: `captest_results` now reads `ct.rc`. Existing flows that call
-  `cd.rep_cond()` (e.g. via `run_test`) and then `captest_results` must switch to
+  `cd.rep_cond()` (e.g. via `run_test`) and then `captest_results` keep working —
+  last-writer-wins means the bare `cd.rep_cond()` now populates `ct.rc` — but they
+  emit the §4.5 side-effect warning. Flows can quiet the warning by using
   `ct.rep_cond(which)`. The example notebook is being reworked by the user
   separately.
 - Tests added this session (`TestRepIrrCrossInstance`, the `rc_source_resolved`
@@ -247,27 +252,67 @@ Two cases, distinguished by `rc_source`:
 
 1. `CapTest.rc`/`rc_source` defaults; `_captest` wired on both CapData by
    `setup()`.
-2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and
-   `rc_source="meas"`; same for `"sim"`.
-3. `ct.rc = df` sets `ct.rc` and `rc_source="manual"`; raises when `setup()` has
-   not run, when a required RHS variable is missing (message lists them), and
-   when `meas`/`sim` formulas differ; extra columns are preserved.
-4. Overwrite warning fires on source change; no warning on same-source recompute.
+2. `ct.rep_cond("meas")` sets `ct.rc` (== meas computation) and `rc_source="meas"`
+   without a warning; same for `"sim"`.
+3. **Last-writer-wins:** bare `meas.rep_cond()` in a test sets `ct.rc` +
+   `rc_source="meas"` and warns; a following `sim.rep_cond()` flips to `sim` and
+   warns. Standalone `cd.rep_cond()` (no `_captest`) does neither.
+4. `ct.rc = df` sets `ct.rc` and `rc_source="manual"`; raises when `setup()` has
+   not run, when a required RHS variable is missing (message lists them), and when
+   `meas`/`sim` formulas differ; extra columns are preserved; warns when replacing
+   a non-manual RC.
 5. `rep_irr`: in-test reads `ct.rc`; standalone reads `cd.rc`; `ValueError` when
    `ct.rc` is None in a test.
 6. `filter_irr(ref_val="rep_irr")` on sim uses `ct.rc` set from meas, without a
    manual value pass (the original bug's real-world scenario).
 7. `captest_results` predicts at `ct.rc`; `ValueError` when None.
-8. Serialization round-trip: computed source recomputes `ct.rc` on load; manual
+8. Serialization round-trip — computed source recomputes `ct.rc` on load; manual
    override serializes values and restores `ct.rc` + `rc_source="manual"`.
-9. Standalone `CapData` regression tests remain green (no behavior change).
+9. **Load determinism:** a config where both pipelines contain a `RepCond` step
+   restores `ct.rc`/`rc_source` to the configured source (config-seeded, not the
+   last replayed step); no warnings emit during load.
+10. **Mid-replay self-filtering:** a meas pipeline of
+    `RepCond → filter_irr(ref_val="rep_irr")` round-trips through `to_yaml`/
+    `from_yaml` without error (regression guard for the load path).
+11. Standalone `CapData` regression tests remain green (no behavior change).
 
 ## 9. Open questions
 
 None outstanding. Resolved during brainstorming:
 
 - Standalone CapData keeps owning `cd.rc` (yes).
-- `ct.rep_cond(which)` is the single in-test entry point; `cd.rep_cond()` does
-  not sync to `ct.rc` (point 3).
+- **Runtime: last-writer-wins.** Any `cd.rep_cond()` in a test updates `ct.rc` +
+  `rc_source` and warns; `ct.rep_cond(which)` is the convenience path and
+  suppresses the warning. Config/constructor `rc_source` seeds the value but does
+  not pin it after load.
+- Load is config-seeded and warning-suppressed for deterministic round-trips
+  (§4.7).
 - Manual override is a first-class source (`rc_source="manual"`), serialized by
-  value.
+  value, set only via the `ct.rc = df` setter.
+
+## 10. Forward compatibility: separate meas/sim setup + filter re-runs
+
+Known future work (not started; deferred until after this branch merges and
+releases): support re-running **all of one side's** setup + filtering when its
+source data changes — e.g. new `sim` data, re-run sim only. This design is built
+to accommodate it; notes for the future implementer:
+
+- **The common case is already decoupled.** With `rc_source="meas"`, re-running
+  sim's setup + filter pipeline needs nothing from meas: sim's
+  `filter_irr(ref_val="rep_irr")` reads the test-level `ct.rc` (meas-derived,
+  unchanged), sim refits, `captest_results` recomputes. Moving RC to the test
+  level is what removes the old per-CapData dependency.
+- **`_set_rc` is the single mutation point** for `ct.rc` — the natural hook for a
+  future "RC changed → invalidate dependent filters" mechanism.
+- **`_captest` wiring and any per-side RC (re)population must stay decomposable**
+  so a future `setup(which="sim")` / per-side re-run can touch one side without
+  disturbing the other. Keep the two `_captest` assignments and the
+  `process_regression_columns` calls independently invokable per side.
+- **Directional staleness to handle later.** When `rc_source` points at the side
+  *not* being re-run, dependents can go stale: e.g. `rc_source="sim"` + re-run-sim
+  changes `ct.rc`, leaving meas's `rep_irr`-based filters stale. This is inherent
+  to "filter one dataset around the other's rep irr," not a flaw here; the future
+  work should add staleness detection at the `_set_rc` hook.
+- **Retain the meas-before-sim replay order** in `from_yaml` (§4.7) so a
+  meas-sourced `ct.rc` exists before sim's filters at initial load. At re-run time
+  `ct.rc` persists, so ordering no longer matters then.

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -408,7 +408,10 @@ to apply these consistently in the filtering of the measured and simulated data.
         ref_val='rep_irr',
     )
 
-The ``ref_val='rep_irr'`` argument uses the ``CapData.rc`` attribute if it set.
+The ``ref_val='rep_irr'`` argument resolves the reference irradiance from the
+single test reporting conditions (``ct.rc``), so the measured and modeled
+filters anchor on the same value. See :ref:`reporting_conditions` for the full
+reporting-conditions model.
 
 Reviewing results
 -----------------

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -6,6 +6,7 @@ User Guide
     :maxdepth: 2
 
     captest
+    reporting_conditions
     saving_reproducing
     dataload
     custom_test_setups

--- a/docs/user_guide/reporting_conditions.rst
+++ b/docs/user_guide/reporting_conditions.rst
@@ -1,0 +1,169 @@
+.. _reporting_conditions:
+
+====================
+Reporting Conditions
+====================
+An ASTM E2848 capacity test compares the measured capacity to the modeled
+capacity at a single, agreed-upon set of **reporting conditions** (RCs) — the
+representative irradiance, temperature, and wind speed the plant is rated at.
+Because both regressions are evaluated at the *same* point, pvcaptest models the
+reporting conditions as one value owned by the test:
+:py:attr:`~captest.captest.CapTest.rc`.
+
+This page explains how the single test RC is established, overridden, tracked,
+used in filtering and results, and persisted across a yaml round-trip. It
+assumes a :py:class:`~captest.captest.CapTest` instance ``ct`` has been created
+and set up as described in :ref:`captest`.
+
+The single test reporting conditions
+------------------------------------
+:py:attr:`~captest.captest.CapTest.rc` is a one-row
+:class:`pandas.DataFrame` (or ``None`` before any have been established) holding
+one value per regression variable:
+
+.. code-block:: Python
+
+    >>> ct.rc
+         poa  t_amb  w_vel
+    0  805.1   24.7    2.1
+
+Its provenance is tracked by :py:attr:`~captest.captest.CapTest.rc_source`,
+which is one of ``'meas'``, ``'sim'``, or ``'manual'`` — recording whether the
+conditions were computed from the measured data, computed from the modeled data,
+or supplied directly.
+
+.. note::
+
+    A standalone :py:class:`~captest.capdata.CapData` used without a
+    ``CapTest`` keeps its own ``cd.rc`` and is unaffected by the test-level
+    ownership described here. Inside a ``CapTest`` the test RC is authoritative
+    and ``ct.meas`` / ``ct.sim`` resolve reporting values from it.
+
+Computing reporting conditions
+------------------------------
+:py:meth:`~captest.captest.CapTest.rep_cond` computes the reporting conditions
+from one dataset using the selected test setup's default aggregations. For the
+standard E2848 setup, POA uses the 60th percentile of the filtered POA while
+ambient temperature and wind speed use the mean.
+
+.. code-block:: Python
+
+    ct.rep_cond()              # compute from measured data (rc_source -> 'meas')
+    ct.rep_cond(which='sim')   # compute from modeled data  (rc_source -> 'sim')
+
+Whichever side it is computed on becomes the single test RC: the call updates
+:py:attr:`~captest.captest.CapTest.rc` and sets
+:py:attr:`~captest.captest.CapTest.rc_source` accordingly. Calling
+``ct.meas.rep_cond()`` (or ``ct.sim.rep_cond()``) directly has the same effect —
+any reporting-conditions calculation on a test member flows up to ``ct.rc``
+(last writer wins). With no ``which`` argument, ``ct.rep_cond()`` defaults to the
+current ``rc_source``, so re-running it does not silently switch sides.
+
+When a computation *changes* the source — for example computing from ``sim``
+after the RC was previously taken from ``meas``, or overwriting a computed RC
+with a manual one — a ``UserWarning`` is emitted so an unintended switch is
+visible. Re-computing on the same side is silent.
+
+Anchoring irradiance filters on the reporting irradiance
+--------------------------------------------------------
+After the reporting conditions are computed it is common to apply a second,
+narrower irradiance filter around the reporting irradiance.
+:py:attr:`~captest.captest.CapTest.rep_irr_filter_low` and
+:py:attr:`~captest.captest.CapTest.rep_irr_filter_high` provide the fractional
+bounds (``0.8`` and ``1.2`` with the default ``rep_irr_filter=0.2``), so the
+same window is applied consistently to the measured and modeled data:
+
+.. code-block:: Python
+
+    ct.meas.filter_irr(
+        ct.rep_irr_filter_low,
+        ct.rep_irr_filter_high,
+        ref_val='rep_irr',
+    )
+
+    ct.sim.filter_irr(
+        ct.rep_irr_filter_low,
+        ct.rep_irr_filter_high,
+        ref_val='rep_irr',
+    )
+
+Passing ``ref_val='rep_irr'`` resolves the reference irradiance from the single
+test RC: within a ``CapTest`` both ``ct.meas`` and ``ct.sim`` read
+:py:attr:`~captest.capdata.CapData.rep_irr` from ``ct.rc``. This means a modeled
+filter can anchor on the test's reporting irradiance even when the conditions
+were computed from the measured data — without passing the value by hand. If no
+test RC has been established, ``ref_val='rep_irr'`` raises a ``ValueError``
+directing you to compute or set the reporting conditions first.
+
+Setting reporting conditions manually
+-------------------------------------
+Sometimes the reporting conditions should be supplied directly rather than
+computed — for a sensitivity study, or to reproduce a reviewing party's stated
+values. Assigning to :py:attr:`~captest.captest.CapTest.rc` is the single public
+way to do this; it records ``rc_source='manual'``:
+
+.. code-block:: Python
+
+    # a one-row DataFrame, a Series, or a dict of regression variable -> value
+    ct.rc = {'poa': 800.0, 't_amb': 25.0, 'w_vel': 2.0}
+
+The value must provide a number for every right-hand-side variable of the
+(shared measured/modeled) regression formula; interaction terms such as
+``I(poa * t_amb)`` are unwrapped to their component variables. Extra columns are
+preserved. The assignment validates the input and raises:
+
+- ``RuntimeError`` if :py:meth:`~captest.captest.CapTest.setup` has not run (the
+  regression formula is unknown);
+- ``ValueError`` if the measured and modeled formulas differ, if the value
+  resolves to more than one row, or if a required regression variable is
+  missing (the message names the missing variables);
+- ``TypeError`` if the value is not a DataFrame, Series, or dict.
+
+A manual RC is treated as the authoritative value: it is not overwritten by the
+filter-replay on load, and a later ``rep_cond`` call that would change the source
+back to a computed value emits the source-change warning.
+
+Reporting conditions and results
+--------------------------------
+:py:meth:`~captest.captest.CapTest.captest_results` (and
+:py:meth:`~captest.captest.CapTest.captest_results_check_pvalues`) predict both
+the measured and modeled regressions at the single test RC ``ct.rc`` and return
+the capacity ratio. ``ct.rc_source`` is reported for provenance. If no reporting
+conditions have been established, ``captest_results`` raises a ``ValueError`` —
+call ``ct.rep_cond(...)`` or assign ``ct.rc`` first.
+
+Saving and restoring reporting conditions
+-----------------------------------------
+The single test RC round-trips through
+:py:meth:`~captest.captest.CapTest.to_yaml` /
+:py:meth:`~captest.captest.CapTest.from_yaml` (see :ref:`saving_reproducing`):
+
+- **Computed** reporting conditions are not value-serialized. They are recomputed
+  on load by replaying the ``RepCond`` step in the ``rc_source`` side's filter
+  pipeline, so the restored RC reflects the same filtered data.
+- **Manual** reporting conditions carry their values in a
+  ``reporting_conditions_values`` block. On load they are re-validated and seeded
+  before the filter pipelines replay, so a self-anchoring ``ref_val='rep_irr'``
+  filter resolves correctly.
+
+On load the configured ``rc_source`` side's pipeline is replayed first, so a
+cross-side ``ref_val='rep_irr'`` filter (for example a measured filter anchored on
+a modeled reporting irradiance) resolves against an already-established ``ct.rc``.
+
+Adjusting the default aggregation
+---------------------------------
+The reporting-condition *recipe* — how each regression variable is aggregated —
+comes from the selected test setup and can be customized per call (e.g.
+``ct.rep_cond(func={'poa': perc_wrap(55)})``) or in the config file. See
+:ref:`captest` for the ``rep_conditions`` configuration and percentile helpers.
+
+See also
+--------
+- :py:attr:`~captest.captest.CapTest.rc`,
+  :py:attr:`~captest.captest.CapTest.rc_source`, and
+  :py:meth:`~captest.captest.CapTest.rep_cond` in the
+  :doc:`CapTest API reference <../source/api_reference/captest>`.
+- :py:meth:`~captest.capdata.CapData.rep_cond` and
+  :py:attr:`~captest.capdata.CapData.rep_irr` in the
+  :doc:`CapData API reference <../source/api_reference/capdata>`.
+- :ref:`saving_reproducing` for the full configuration round-trip.

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -839,7 +839,10 @@ class CapData(param.Parameterized):
         self.column_groups = {}
         self.regression_cols = {}
         self.rc = None
-        self.rc_source_resolved = None
+        # Back-reference to the owning CapTest (set by CapTest.setup), or None
+        # for standalone use. Opaque runtime reference only — capdata.py never
+        # imports captest. Intentionally NOT copied by CapData.copy().
+        self._captest = None
         self.regression_results = None
         self.regression_formula = (
             "power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1"
@@ -944,40 +947,38 @@ class CapData(param.Parameterized):
     def rep_irr(self):
         """Reporting POA irradiance anchoring relative irradiance filters.
 
-        This is the value resolved when ``filter_irr`` is called with
-        ``ref_val='rep_irr'`` (or the legacy ``'self_val'``). It is read from
-        ``rc_source_resolved.rc`` when a source has been wired (by
-        ``CapTest.setup``, so e.g. a ``sim`` filter can anchor on the ``meas``
-        reporting irradiance), and otherwise from this instance's own ``rc``.
-        Resolved lazily on access, so it reflects ``rep_cond()`` runs that
-        happen after the source is wired.
+        Resolved when ``filter_irr`` is called with ``ref_val='rep_irr'`` (or the
+        legacy ``'self_val'``). Inside a CapTest (``self._captest`` set by
+        ``CapTest.setup``) it reads the single test RC ``self._captest.rc``;
+        standalone it reads this instance's own ``self.rc``.
 
         Returns
         -------
         float
-            The ``'poa'`` reporting condition of the resolved source.
+            The ``'poa'`` reporting condition of the resolved RC.
 
         Raises
         ------
         ValueError
-            If the resolved source has no reporting conditions, or its ``rc``
-            lacks a ``'poa'`` column.
+            If no RC is available, or the resolved RC lacks a ``'poa'`` column.
         """
-        source = (
-            self.rc_source_resolved if self.rc_source_resolved is not None else self
-        )
-        if source.rc is None:
+        in_test = self._captest is not None
+        rc = self._captest.rc if in_test else self.rc
+        if rc is None:
+            if in_test:
+                raise ValueError(
+                    "ref_val='rep_irr' requires test reporting conditions. Call "
+                    "ct.rep_cond(which) or assign ct.rc = df before filtering."
+                )
             raise ValueError(
-                "ref_val='rep_irr' requires reporting conditions on the "
-                f"'{source.name}' dataset. Call rep_cond() on it before "
-                "filtering with ref_val='rep_irr'."
+                "ref_val='rep_irr' requires reporting conditions. Call "
+                "rep_cond() before filtering with ref_val='rep_irr'."
             )
-        if "poa" not in source.rc.columns:
+        if "poa" not in rc.columns:
             raise ValueError(
-                "ref_val='rep_irr' requires a 'poa' column in the reporting "
-                f"conditions of the '{source.name}' dataset."
+                "ref_val='rep_irr' requires a 'poa' column in the reporting conditions."
             )
-        return float(source.rc["poa"].iloc[0])
+        return float(rc["poa"].iloc[0])
 
     def drop_cols(self, columns):
         """
@@ -1743,9 +1744,10 @@ class CapData(param.Parameterized):
             Must provide arg when `low` and `high` are fractions.
             Pass ``'rep_irr'`` to use the reporting irradiance from
             :attr:`rep_irr` (set by calling :meth:`rep_cond` first). Within a
-            :class:`~captest.captest.CapTest`, ``'rep_irr'`` resolves against
-            the ``rc_source`` instance, so a ``sim`` filter can anchor on the
-            ``meas`` reporting irradiance without passing the value manually.
+            :class:`~captest.captest.CapTest`, ``'rep_irr'`` resolves against the
+            single test reporting conditions ``ct.rc``, so a ``sim`` filter can
+            anchor on the test's reporting irradiance without passing the value
+            manually.
         col_name : str, default None
             Column name of irradiance data to filter.  By default uses the POA
             irradiance set in regression_cols attribute or average of the POA

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2245,6 +2245,12 @@ class CapData(param.Parameterized):
         print("Reporting conditions saved to rc attribute.")
         print(RCs_df)
         self.rc = RCs_df
+        # When this CapData belongs to a CapTest, propagate the freshly computed
+        # rc to the single test rc (last-writer-wins). The CapTest decides warn
+        # vs silent and config-seeded load behavior. Opaque call — capdata.py
+        # never imports captest.
+        if self._captest is not None:
+            self._captest._on_capdata_rep_cond(self)
 
     def rep_cond(
         self,

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1350,7 +1350,12 @@ class CapTest(param.Parameterized):
         default="meas",
         doc="Provenance of the single test RC (CapTest.rc): 'meas'/'sim' when "
         "computed from that dataset's rep_cond, or 'manual' when set directly. "
-        "Seeds the default 'which' for rep_cond.",
+        "Seeds the default 'which' for rep_cond. This is a provenance label "
+        "managed alongside CapTest.rc by the sanctioned mutation paths "
+        "(rep_cond / the ct.rc setter, both routed through _set_rc) and is "
+        "accepted as a construction-time config input; assigning it directly "
+        "afterward relabels provenance without changing the stored rc and is "
+        "not recommended.",
     )
 
     # Test scope / time

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1603,6 +1603,39 @@ class CapTest(param.Parameterized):
         TypeError
             If ``value`` is not a DataFrame, Series, or dict.
         """
+        self._set_rc(self._coerce_and_validate_manual_rc(value), "manual")
+
+    def _coerce_and_validate_manual_rc(self, value):
+        """Validate and coerce a candidate manual reporting-conditions value.
+
+        Shared by the public :attr:`rc` setter and the ``from_mapping`` load
+        path so that a hand-edited YAML with a missing required regression
+        variable fails fast (at load) rather than silently at predict/rep_irr.
+
+        Parameters
+        ----------
+        value : pandas.DataFrame or pandas.Series or dict
+            Candidate reporting conditions. A Series or dict maps each
+            regression variable to its value; a DataFrame is used as given.
+            Must supply a value for every right-hand-side variable of the
+            (shared meas/sim) regression formula.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A validated, one-row reporting-conditions DataFrame.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`setup` has not been run (regression formula unknown).
+        ValueError
+            If ``meas`` and ``sim`` have different regression formulas, if
+            ``value`` coerces to more than one row, or if ``value`` omits a
+            required right-hand-side variable.
+        TypeError
+            If ``value`` is not a DataFrame, Series, or dict.
+        """
         self._require_setup()
         meas_fml = self.meas.regression_formula
         sim_fml = self.sim.regression_formula
@@ -1634,7 +1667,7 @@ class CapTest(param.Parameterized):
                 "Manual reporting conditions are missing required regression "
                 f"variable(s): {missing}. Required: {rhs}."
             )
-        self._set_rc(df, "manual")
+        return df
 
     def _set_rc(self, rc, source, warn=True):
         """Single internal write point for ``_rc`` and ``rc_source``.
@@ -1955,7 +1988,8 @@ class CapTest(param.Parameterized):
             # RC is (re)established during replay by the configured rc_source
             # side's RepCond step (see _on_capdata_rep_cond's _loading branch).
             if inst.rc_source == "manual" and rc_values is not None:
-                inst._set_rc(pd.DataFrame([rc_values]), "manual", warn=False)
+                df = inst._coerce_and_validate_manual_rc(rc_values)
+                inst._set_rc(df, "manual", warn=False)
             # Replay the configured rc_source side FIRST so its RepCond populates
             # ct.rc before the other side's rep_irr filters run. _loading makes
             # the rep_cond sync config-seeded and warning-suppressed.

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1595,7 +1595,7 @@ class CapTest(param.Parameterized):
         Raises
         ------
         RuntimeError
-            If :meth:`setup` has not run (the regression formula is unknown).
+            If ``meas`` or ``sim`` is missing, or lacks a regression formula.
         ValueError
             If ``meas`` and ``sim`` have different regression formulas, if
             ``value`` coerces to more than one row, or if ``value`` omits a
@@ -1628,7 +1628,7 @@ class CapTest(param.Parameterized):
         Raises
         ------
         RuntimeError
-            If :meth:`setup` has not been run (regression formula unknown).
+            If ``meas`` or ``sim`` is missing, or lacks a regression formula.
         ValueError
             If ``meas`` and ``sim`` have different regression formulas, if
             ``value`` coerces to more than one row, or if ``value`` omits a
@@ -1636,7 +1636,7 @@ class CapTest(param.Parameterized):
         TypeError
             If ``value`` is not a DataFrame, Series, or dict.
         """
-        self._require_setup()
+        self._require_regression_formula()
         meas_fml = self.meas.regression_formula
         sim_fml = self.sim.regression_formula
         if meas_fml != sim_fml:
@@ -2793,6 +2793,23 @@ class CapTest(param.Parameterized):
             raise RuntimeError("CapTest.meas must be set.")
         if self.sim is None:
             raise RuntimeError("CapTest.sim must be set.")
+
+    def _require_regression_formula(self):
+        """Require meas/sim present and each carrying a regression formula.
+
+        Looser than :meth:`_require_setup`: the manual ``rc`` setter only needs
+        the regression formula (to validate RHS coverage and the meas/sim
+        match), not a fully resolved ``test_setup``. This lets the "prepare each
+        CapData, then wrap them in a CapTest" workflow set reporting conditions
+        without calling :meth:`setup`.
+        """
+        self._require_meas_and_sim()
+        if self.meas.regression_formula is None or self.sim.regression_formula is None:
+            raise RuntimeError(
+                "Setting reporting conditions requires a regression formula on "
+                "meas and sim. Call CapTest.setup(), or set regression columns "
+                "on each CapData, first."
+            )
 
     def _pick_cd(self, which):
         if which == "meas":

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -2222,15 +2222,12 @@ class CapTest(param.Parameterized):
         self.meas.process_regression_columns(verbose=verbose)
         self.sim.process_regression_columns(verbose=verbose)
 
-        # Wire the reporting-conditions source onto both CapData instances so
-        # filter_irr(ref_val='rep_irr') resolves against the rc_source dataset
-        # (e.g. sim filtered around meas's reporting irradiance), regardless of
-        # which instance is being filtered. Stored as a lazy reference and read
-        # at filter time, so it reflects rep_cond() runs that happen after
-        # setup().
-        rc_source_cd = self.meas if self.rc_source == "meas" else self.sim
-        self.meas.rc_source_resolved = rc_source_cd
-        self.sim.rc_source_resolved = rc_source_cd
+        # Wire each CapData back to this CapTest so filter_irr(ref_val='rep_irr')
+        # resolves against the single test RC (ct.rc), and (Plan 3) so cd.rep_cond
+        # can update it. Runtime reference only; capdata.py never imports captest.
+        # Assigned per side so a future per-side setup can re-wire one side alone.
+        self.meas._captest = self
+        self.sim._captest = self
 
         return self
 

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -2081,7 +2081,14 @@ class CapTest(param.Parameterized):
         # Decision B: when a RepCond step is in either pipeline, it is the
         # unambiguous source of reporting conditions — drop the redundant
         # overrides.rep_conditions.
-        if self.rep_conditions is not None and not has_rep_cond_step:
+        # For a manual rc_source, reporting_conditions_values (written below) is
+        # the authoritative RC; do not also serialize overrides.rep_conditions,
+        # which is only aggregation config and would read as a second RC source.
+        if (
+            self.rep_conditions is not None
+            and not has_rep_cond_step
+            and self.rc_source != "manual"
+        ):
             overrides["rep_conditions"] = _serialize_rep_conditions(self.rep_conditions)
         if overrides:
             sub["overrides"] = overrides
@@ -2127,6 +2134,16 @@ class CapTest(param.Parameterized):
             sub["meas_filters"] = meas_filters
         if sim_filters:
             sub["sim_filters"] = sim_filters
+
+        # Manual reporting conditions are data, not config: serialize their
+        # values so from_yaml can restore them (computed RC is recomputed by
+        # replaying the source pipeline's RepCond step). Numpy scalars are
+        # coerced to native python types for yaml.safe_dump.
+        if self.rc_source == "manual" and self._rc is not None:
+            row = self._rc.iloc[0]
+            sub["reporting_conditions_values"] = {
+                str(col): to_native(val) for col, val in row.items()
+            }
 
         return sub
 

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -2394,7 +2394,7 @@ class CapTest(param.Parameterized):
         self._require_setup()
         return self._resolved_setup["scatter_plots"](cd, **kwargs)
 
-    def rep_cond(self, which="meas", **overrides):
+    def rep_cond(self, which=None, **overrides):
         """Call ``cd.rep_cond`` with the resolved preset's rep_conditions.
 
         The preset's ``rep_conditions`` dict (after any ``self.rep_conditions``
@@ -2407,8 +2407,11 @@ class CapTest(param.Parameterized):
 
         Parameters
         ----------
-        which : {'meas', 'sim'}
-            Which CapData instance's ``rep_cond`` to call.
+        which : {'meas', 'sim', None}, default None
+            Which CapData to compute reporting conditions on. When None, defaults
+            to the current ``rc_source`` if it is ``'meas'``/``'sim'``, otherwise
+            ``'meas'``. The computed conditions become the test ``rc`` (and set
+            ``rc_source`` to ``which``) via the last-writer-wins sync.
         **overrides
             Partial-merged onto the resolved ``rep_conditions`` dict.
 
@@ -2417,6 +2420,8 @@ class CapTest(param.Parameterized):
         None
             ``cd.rep_cond`` writes to ``cd.rc``.
         """
+        if which is None:
+            which = self.rc_source if self.rc_source in ("meas", "sim") else "meas"
         cd = self._pick_cd(which)
         self._require_setup()
         resolved_rc = _merge_rep_conditions(

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1345,11 +1345,11 @@ class CapTest(param.Parameterized):
         doc="If set, partial-merged onto the preset rep_conditions at setup().",
     )
     rc_source = param.Selector(
-        objects=["meas", "sim"],
+        objects=["meas", "sim", "manual"],
         default="meas",
-        doc="Which CapData provides reporting conditions: used by "
-        "captest_results and as the source that filter_irr(ref_val='rep_irr') "
-        "resolves against on both meas and sim.",
+        doc="Provenance of the single test RC (CapTest.rc): 'meas'/'sim' when "
+        "computed from that dataset's rep_cond, or 'manual' when set directly. "
+        "Seeds the default 'which' for rep_cond.",
     )
 
     # Test scope / time
@@ -1553,6 +1553,46 @@ class CapTest(param.Parameterized):
         # was built from without cluttering the param surface.
         self._meas_path = None
         self._sim_path = None
+        # The single test reporting-conditions DataFrame (or None). Plain attr,
+        # not a param.*, so the `rc` property setter can validate and the
+        # `_set_rc` write point can manage provenance. `_loading` is True only
+        # during from_yaml replay (see Plan 5) to seed RC from config.
+        self._rc = None
+        self._loading = False
+
+    @property
+    def rc(self):
+        """The single test reporting-conditions DataFrame, or ``None``.
+
+        Sourced from ``meas``/``sim`` via :meth:`rep_cond` or set manually via
+        the property setter; provenance is tracked by :attr:`rc_source`. See the
+        RC-ownership design spec for the full lifecycle.
+        """
+        return self._rc
+
+    def _set_rc(self, rc, source, warn=True):
+        """Single internal write point for ``_rc`` and ``rc_source``.
+
+        Emits a source-change ``UserWarning`` when ``warn`` is True, an RC is
+        already set, and ``source`` differs from the current ``rc_source``
+        (silent on first establishment and same-source recompute).
+
+        Parameters
+        ----------
+        rc : pandas.DataFrame
+            One-row reporting-conditions DataFrame.
+        source : {'meas', 'sim', 'manual'}
+            Provenance to record in ``rc_source``.
+        warn : bool, default True
+            Suppress the source-change warning when False (used during load).
+        """
+        if warn and self._rc is not None and source != self.rc_source:
+            warnings.warn(
+                f"Test reporting conditions rc_source changed from "
+                f"'{self.rc_source}' to '{source}'."
+            )
+        self._rc = rc
+        self.rc_source = source
 
     # --- constructors ----------------------------------------------------
 

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1654,6 +1654,28 @@ class CapTest(param.Parameterized):
         self._rc = rc
         self.rc_source = source
 
+    def _on_capdata_rep_cond(self, cd):
+        """Update the test RC after a member CapData computed its own ``rc``.
+
+        Called by :meth:`CapData._calc_rep_cond` when the CapData belongs to this
+        test. Runtime behavior is last-writer-wins: the calling side's ``rc``
+        becomes ``ct.rc`` and ``rc_source`` (a source-change ``UserWarning`` is
+        emitted by :meth:`_set_rc`). During ``from_yaml`` load (``_loading``
+        True) the update is config-seeded: only the configured ``rc_source``
+        side updates ``ct.rc``, silently (see Plan 5 / spec §4.7).
+
+        Parameters
+        ----------
+        cd : CapData
+            The member CapData that just (re)computed its ``rc``.
+        """
+        side = "meas" if cd is self.meas else "sim"
+        if self._loading:
+            if side == self.rc_source:
+                self._set_rc(cd.rc.copy(), side, warn=False)
+            return
+        self._set_rc(cd.rc.copy(), side, warn=True)
+
     # --- constructors ----------------------------------------------------
 
     @classmethod

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -2467,8 +2467,10 @@ class CapTest(param.Parameterized):
     def captest_results(self, check_pvalues=False, pval=0.05, print_res=True):
         """Compute the capacity test ratio for ``self.meas`` vs ``self.sim``.
 
-        Picks reporting conditions from ``self.meas.rc`` or ``self.sim.rc``
-        based on ``self.rc_source``. Uses ``self.ac_nameplate`` for the
+        Predicts both regressions at the single test reporting conditions
+        ``self.rc`` (set via :meth:`rep_cond` or the ``rc`` setter);
+        ``self.rc_source`` is reported for provenance. Raises ``ValueError``
+        if ``self.rc`` is ``None``. Uses ``self.ac_nameplate`` for the
         tested-capacity printout and ``self.test_tolerance`` (via
         ``self.determine_pass_or_fail``) for the pass/fail result.
 
@@ -2493,10 +2495,12 @@ class CapTest(param.Parameterized):
                 "CapData objects do not have the same regression formula."
             )
 
-        if self.rc_source == "meas":
-            rc = self.meas.rc
-        else:
-            rc = self.sim.rc
+        rc = self.rc
+        if rc is None:
+            raise ValueError(
+                "captest_results requires test reporting conditions. Call "
+                "ct.rep_cond(which) or assign ct.rc = df first."
+            )
 
         if print_res:
             print(f"Using reporting conditions from {self.rc_source}. \n")

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1142,6 +1142,7 @@ _CAPTEST_YAML_KEYS = frozenset(
         "overrides",
         "meas_filters",
         "sim_filters",
+        "reporting_conditions_values",
     }
 )
 
@@ -1865,7 +1866,13 @@ class CapTest(param.Parameterized):
         kwargs = {
             k: v
             for k, v in sub.items()
-            if k not in ("overrides", "meas_filters", "sim_filters")
+            if k
+            not in (
+                "overrides",
+                "meas_filters",
+                "sim_filters",
+                "reporting_conditions_values",
+            )
         }
 
         # Lift override keys into direct kwargs.
@@ -1936,11 +1943,27 @@ class CapTest(param.Parameterized):
         # try to filter un-setup data.
         meas_filters = sub.get("meas_filters")
         sim_filters = sub.get("sim_filters")
+        rc_values = sub.get("reporting_conditions_values")
         if inst._resolved_setup is not None:
-            if meas_filters and inst.meas is not None:
-                inst.meas.run_pipeline(meas_filters)
-            if sim_filters and inst.sim is not None:
-                inst.sim.run_pipeline(sim_filters)
+            # Seed a manual RC before replay so self-filtering pipelines resolve
+            # ref_val='rep_irr' against it; no RepCond step will set it. Computed
+            # RC is (re)established during replay by the configured rc_source
+            # side's RepCond step (see _on_capdata_rep_cond's _loading branch).
+            if inst.rc_source == "manual" and rc_values is not None:
+                inst._set_rc(pd.DataFrame([rc_values]), "manual", warn=False)
+            # Replay the configured rc_source side FIRST so its RepCond populates
+            # ct.rc before the other side's rep_irr filters run. _loading makes
+            # the rep_cond sync config-seeded and warning-suppressed.
+            pipelines = [(inst.meas, meas_filters), (inst.sim, sim_filters)]
+            if inst.rc_source == "sim":
+                pipelines.reverse()
+            inst._loading = True
+            try:
+                for cd, filters in pipelines:
+                    if filters and cd is not None:
+                        cd.run_pipeline(filters)
+            finally:
+                inst._loading = False
         elif meas_filters or sim_filters:
             # Pipelines were serialized but setup() never ran (both meas and
             # sim must be loaded). Don't silently drop them — warn so the

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1570,6 +1570,66 @@ class CapTest(param.Parameterized):
         """
         return self._rc
 
+    @rc.setter
+    def rc(self, value):
+        """Set the test reporting conditions manually (``rc_source='manual'``).
+
+        This is the only public way to supply reporting conditions directly —
+        e.g. for sensitivity analysis or to check results against a reviewing
+        party's values. Computed conditions go through :meth:`rep_cond` instead.
+
+        Parameters
+        ----------
+        value : pandas.DataFrame or pandas.Series or dict
+            One-row reporting conditions. A Series or dict maps each regression
+            variable to its value; a DataFrame is used as given. Must provide a
+            value for every right-hand-side variable of the (shared meas/sim)
+            regression formula. Extra columns are preserved.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`setup` has not run (the regression formula is unknown).
+        ValueError
+            If ``meas`` and ``sim`` have different regression formulas, if
+            ``value`` coerces to more than one row, or if ``value`` omits a
+            required right-hand-side variable.
+        TypeError
+            If ``value`` is not a DataFrame, Series, or dict.
+        """
+        self._require_setup()
+        meas_fml = self.meas.regression_formula
+        sim_fml = self.sim.regression_formula
+        if meas_fml != sim_fml:
+            raise ValueError(
+                "Cannot set reporting conditions manually: meas and sim have "
+                f"different regression formulas ({meas_fml!r} vs {sim_fml!r})."
+            )
+        _, rhs = util.parse_regression_formula(meas_fml)
+        if isinstance(value, pd.DataFrame):
+            df = value.copy()
+        elif isinstance(value, pd.Series):
+            df = value.to_frame().T
+        elif isinstance(value, dict):
+            df = pd.DataFrame([value])
+        else:
+            raise TypeError(
+                "ct.rc must be a one-row DataFrame, a pandas Series, or a dict "
+                f"mapping regression variable -> value; got "
+                f"{type(value).__name__}."
+            )
+        if len(df) != 1:
+            raise ValueError(
+                f"Reporting conditions must be a single row; got {len(df)} rows."
+            )
+        missing = [var for var in rhs if var not in df.columns]
+        if missing:
+            raise ValueError(
+                "Manual reporting conditions are missing required regression "
+                f"variable(s): {missing}. Required: {rhs}."
+            )
+        self._set_rc(df, "manual")
+
     def _set_rc(self, rc, source, warn=True):
         """Single internal write point for ``_rc`` and ``rc_source``.
 

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2853,6 +2853,7 @@ class TestCapTestCpResultsSingleCoeff(unittest.TestCase):
         ct = CapTest(test_tolerance="+/- 5", ac_nameplate=100)
         ct.meas = self.meas
         ct.sim = self.sim
+        ct._set_rc(self.meas.rc, "meas")
         res = ct.captest_results(print_res=False)
 
         self.assertIsInstance(res, float, "Returned value is not a tuple")
@@ -2905,6 +2906,7 @@ class TestCapTestCpResultsMultCoeffKwVsW(unittest.TestCase):
         ct = CapTest(test_tolerance="+/- 5", ac_nameplate=100)
         ct.meas = meas
         ct.sim = sim
+        ct._set_rc(meas.rc, "meas")
 
         with self.assertWarns(UserWarning):
             cp_rat = ct.captest_results(check_pvalues=False, print_res=False)
@@ -3007,6 +3009,7 @@ class TestCapTestCpResultsMultCoeff(unittest.TestCase):
         ct = CapTest(test_tolerance="+/- 5", ac_nameplate=100)
         ct.meas = self.meas
         ct.sim = self.sim
+        ct._set_rc(self.meas.rc.copy(), "meas")
         return ct
 
     def test_pvals_default_false(self):

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -2318,40 +2318,25 @@ class TestFilterIrr:
 
 
 class TestRepIrr:
-    """The rep_irr property and its use by filter_irr(ref_val='rep_irr')."""
+    """The standalone CapData.rep_irr property (no CapTest attached)."""
 
-    def test_rep_irr_falls_back_to_self_rc(self, nrel):
-        """rep_irr reads self.rc when no rc_source_resolved is wired."""
+    def test_rep_irr_reads_self_rc_when_standalone(self, nrel):
+        """rep_irr reads self.rc when this CapData has no _captest."""
+        assert nrel._captest is None
         nrel.rc = pd.DataFrame({"poa": [222.0], "t_amb": [20], "w_vel": [2]})
         assert nrel.rep_irr == pytest.approx(222.0)
 
-    def test_rep_irr_resolves_from_rc_source(self, nrel):
-        """rep_irr reads the wired source CapData's rc, not self.rc."""
-        partner = pvc.CapData("partner")
-        partner.rc = pd.DataFrame({"poa": [654.0], "t_amb": [20], "w_vel": [2]})
-        nrel.rc = pd.DataFrame({"poa": [111.0], "t_amb": [20], "w_vel": [2]})
-        nrel.rc_source_resolved = partner
-        assert nrel.rep_irr == pytest.approx(654.0)
-
-    def test_filter_irr_rep_irr_uses_rc_source(self, nrel):
-        """filter_irr(ref_val='rep_irr') anchors on the wired source's rep irr
-        even when this instance has no rc of its own."""
-        partner = pvc.CapData("partner")
-        partner.rc = pd.DataFrame({"poa": [500.0], "t_amb": [20], "w_vel": [2]})
-        nrel.rc_source_resolved = partner
+    def test_rep_irr_standalone_none_rc_raises(self, nrel):
+        """Standalone with no rc raises directing to rep_cond()."""
         assert nrel.rc is None
-        nrel.filter_irr(0.8, 1.2, ref_val="rep_irr")
-        step = nrel.filters[-1]
-        assert step.ref_val_resolved == pytest.approx(500.0)
-        assert step.low_effective == pytest.approx(0.8 * 500.0)
-        assert step.high_effective == pytest.approx(1.2 * 500.0)
+        with pytest.raises(ValueError, match="requires reporting conditions"):
+            nrel.rep_irr
 
-    def test_rep_irr_missing_source_rc_names_dataset(self, nrel):
-        """The error message names the source dataset when its rc is unset."""
-        partner = pvc.CapData("partner")
-        nrel.rc_source_resolved = partner
-        with pytest.raises(ValueError, match="'partner' dataset"):
-            nrel.filter_irr(0.8, 1.2, ref_val="rep_irr")
+    def test_rep_irr_missing_poa_column_raises(self, nrel):
+        """rep_irr raises when the resolved rc lacks a 'poa' column."""
+        nrel.rc = pd.DataFrame({"irr": [500.0], "t_amb": [20], "w_vel": [2]})
+        with pytest.raises(ValueError, match="requires a 'poa' column"):
+            nrel.rep_irr
 
 
 class TestGetSummary:

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -976,24 +976,10 @@ class TestSetup:
         assert ct_default.meas.tolerance == "- 4"
         assert ct_default.sim.tolerance == "- 4"
 
-    def test_setup_wires_rc_source_resolved_to_meas(self, ct_default):
-        """setup() points both CapData.rc_source_resolved at meas by default."""
-        assert ct_default.meas.rc_source_resolved is ct_default.meas
-        assert ct_default.sim.rc_source_resolved is ct_default.meas
-
-    def test_setup_wires_rc_source_resolved_to_sim(
-        self, meas_cd_default, sim_cd_default
-    ):
-        """rc_source='sim' points both CapData.rc_source_resolved at sim."""
-        capt = CapTest.from_params(
-            test_setup="e2848_default",
-            meas=meas_cd_default,
-            sim=sim_cd_default,
-            ac_nameplate=6_000_000,
-            rc_source="sim",
-        )
-        assert capt.meas.rc_source_resolved is capt.sim
-        assert capt.sim.rc_source_resolved is capt.sim
+    def test_setup_wires_captest_backref_on_both(self, ct_default):
+        """setup() wires _captest back to the CapTest on both CapData."""
+        assert ct_default.meas._captest is ct_default
+        assert ct_default.sim._captest is ct_default
 
     def test_setup_assigns_resolved_setup(self, ct_default):
         resolved = ct_default._resolved_setup
@@ -1059,41 +1045,51 @@ class TestSetup:
 
 
 class TestRepIrrCrossInstance:
-    """filter_irr(ref_val='rep_irr') resolving against the rc_source instance."""
+    """filter_irr(ref_val='rep_irr') resolving against the ct.rc in a CapTest."""
 
-    def test_sim_rep_irr_filter_uses_meas_reporting_irradiance(self, ct_default):
-        """A sim filter_irr(ref_val='rep_irr') anchors on meas's reporting
-        irradiance (the default rc_source), without any rc set on sim and
-        without manually passing the value."""
-        ct_default.meas.filter_irr(200, 800)
-        ct_default.meas.rep_cond()
-        meas_rep_irr = float(ct_default.meas.rc["poa"].iloc[0])
+    def test_sim_rep_irr_resolves_from_ct_rc(self, ct_default):
+        """sim.rep_irr reads the test-level ct.rc (set here via _set_rc)."""
+        rc = pd.DataFrame({"poa": [777.0], "t_amb": [25.0], "w_vel": [2.0]})
+        ct_default._set_rc(rc, "meas")
+        assert ct_default.sim.rep_irr == pytest.approx(777.0)
+        assert ct_default.meas.rep_irr == pytest.approx(777.0)
 
-        # sim never computed its own reporting conditions.
-        assert ct_default.sim.rc is None
+    def test_rep_irr_in_test_without_rc_raises(self, ct_default):
+        """In a test, rep_irr with ct.rc unset raises directing to rep_cond."""
+        assert ct_default.rc is None
+        with pytest.raises(ValueError, match="test reporting conditions"):
+            ct_default.sim.rep_irr
 
+    def test_sim_filter_irr_rep_irr_uses_ct_rc(self, ct_default):
+        """filter_irr(ref_val='rep_irr') on sim filters around ct.rc's poa."""
+        rc = pd.DataFrame({"poa": [500.0], "t_amb": [25.0], "w_vel": [2.0]})
+        ct_default._set_rc(rc, "meas")
         ct_default.sim.filter_irr(0.8, 1.2, ref_val="rep_irr")
         step = ct_default.sim.filters[-1]
-        assert step.ref_val_resolved == pytest.approx(meas_rep_irr)
+        assert step.ref_val_resolved == pytest.approx(500.0)
+        assert step.low_effective == pytest.approx(0.8 * 500.0)
 
-    def test_sim_rep_irr_filter_roundtrips_through_yaml(self, ct_default, tmp_path):
-        """ref_val='rep_irr' serializes as a string and the rc_source wiring is
-        rebuilt on setup(), so the value is never written as a numpy float."""
+    @pytest.mark.xfail(
+        reason="rep_cond->ct.rc auto-sync lands in Plan 3 and the rep_irr YAML "
+        "round-trip in Plan 5; placeholder keeps the deferred end-to-end "
+        "coverage gap visible. Plan 5 removes this marker.",
+        strict=False,
+    )
+    def test_meas_rep_cond_then_sim_rep_irr_roundtrips(self, ct_default, tmp_path):
+        """End-to-end: meas.rep_cond seeds ct.rc, sim filters around it, and the
+        pipeline round-trips through to_yaml. Enabled in Plan 5."""
         import yaml
 
         ct_default.meas.filter_irr(200, 800)
         ct_default.meas.rep_cond()
         ct_default.sim.filter_irr(0.8, 1.2, ref_val="rep_irr")
-
         path = tmp_path / "ct.yaml"
-        # Must not raise RepresenterError on a numpy-float ref_val.
         ct_default.to_yaml(path, merge_into_existing=False)
-
         doc = yaml.safe_load(path.read_text())
-        sim_irr_steps = [
+        sim_irr = [
             d for d in doc["captest"]["sim_filters"] if d["type"] == "Irradiance"
         ]
-        assert sim_irr_steps[-1]["ref_val"] == "rep_irr"
+        assert sim_irr[-1]["ref_val"] == "rep_irr"
 
 
 class TestDownstreamPropagation:

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1071,7 +1071,7 @@ class TestRepIrrCrossInstance:
 
     def test_meas_rep_cond_then_sim_rep_irr_roundtrips(self, ct_default, tmp_path):
         """End-to-end: meas.rep_cond seeds ct.rc, sim filters around it, and the
-        pipeline round-trips through to_yaml. Enabled in Plan 5."""
+        pipeline round-trips through to_yaml."""
         import yaml
 
         ct_default.meas.filter_irr(200, 800)
@@ -2630,6 +2630,9 @@ class TestPipelineYaml:
         )
         assert any(type(s).__name__ == "RepCond" for s in reloaded.meas.filters)
         assert reloaded.meas.rc is not None
+        # The test-level ct.rc is reconstituted from the replayed RepCond step.
+        assert reloaded.rc is not None
+        assert reloaded.rc_source == "meas"
 
     def test_from_mapping_warns_when_pipelines_cannot_be_applied(
         self, tmp_path, meas_cd_default

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2768,9 +2768,27 @@ class TestManualRc:
             ct_default.rc = {"poa": 805.0, "t_amb": 25.0}  # w_vel missing
         assert "w_vel" in str(exc.value)
 
-    def test_set_rc_requires_setup(self):
-        ct = CapTest()  # bare, setup() not run
-        with pytest.raises(RuntimeError, match="setup"):
+    def test_set_rc_requires_meas_and_sim(self):
+        ct = CapTest()  # bare, no meas/sim
+        with pytest.raises(RuntimeError, match="meas"):
+            ct.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_set_rc_without_setup_when_formula_present(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """ts.rc = df works on a bare CapTest (no setup) when meas/sim carry a
+        regression formula — the 'prepare each CapData, then wrap them' flow."""
+        ct = CapTest(meas=meas_cd_default, sim=sim_cd_default)
+        assert ct._resolved_setup is None  # setup() not run
+        ct.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        assert ct.rc_source == "manual"
+        assert ct.rc["poa"].iloc[0] == pytest.approx(805.0)
+
+    def test_set_rc_requires_regression_formula(self, meas_cd_default, sim_cd_default):
+        """A missing regression formula on a member is a clear RuntimeError."""
+        ct = CapTest(meas=meas_cd_default, sim=sim_cd_default)
+        ct.meas.regression_formula = None
+        with pytest.raises(RuntimeError, match="regression formula"):
             ct.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
 
     def test_set_rc_formula_mismatch_raises(self, ct_default):

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2795,3 +2795,57 @@ class TestManualRc:
         ct_default.rc = self._full_rc()  # first -> manual (silent)
         ct_default.rc = self._full_rc(810.0)  # manual -> manual (silent)
         assert len(recwarn) == 0
+
+
+class TestRepCondSync:
+    """cd.rep_cond updates ct.rc (last-writer-wins); standalone is unaffected."""
+
+    def test_meas_rep_cond_sets_ct_rc_from_meas(self, ct_default):
+        ct_default.meas.rep_cond()
+        assert ct_default.rc_source == "meas"
+        assert ct_default.rc is not None
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(
+            ct_default.meas.rc["poa"].iloc[0]
+        )
+
+    def test_meas_rep_cond_first_set_is_silent(self, ct_default, recwarn):
+        ct_default.meas.rep_cond()
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)
+
+    def test_sim_rep_cond_after_meas_flips_source_and_warns(self, ct_default):
+        ct_default.meas.rep_cond()
+        with pytest.warns(UserWarning, match="changed from 'meas' to 'sim'"):
+            ct_default.sim.rep_cond()
+        assert ct_default.rc_source == "sim"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(
+            ct_default.sim.rc["poa"].iloc[0]
+        )
+
+    def test_same_source_recompute_is_silent(self, ct_default, recwarn):
+        ct_default.meas.rep_cond()
+        ct_default.meas.filter_irr(200, 800)
+        ct_default.meas.rep_cond()  # still 'meas' -> no source-change warning
+        assert ct_default.rc_source == "meas"
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)
+
+    def test_ct_rc_is_a_copy_not_aliased(self, ct_default):
+        ct_default.meas.rep_cond()
+        # Mutating meas.rc must not change ct.rc.
+        ct_default.meas.rc.loc[ct_default.meas.rc.index[0], "poa"] = -999.0
+        assert ct_default.rc["poa"].iloc[0] != -999.0
+
+    def test_standalone_rep_cond_does_not_sync_or_warn(self, pvsyst, recwarn):
+        assert pvsyst._captest is None
+        pvsyst.filter_irr(200, 800)
+        pvsyst.rep_cond()  # must not raise (the _captest guard) and not warn
+        assert pvsyst.rc is not None
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)
+
+    def test_rep_cond_freq_does_not_sync_to_ct_rc(self, ct_default):
+        """rep_cond_freq is intentionally NOT synced: it can produce a multi-row
+        seasonal RC that a single-row ct.rc cannot hold, and it sets self.rc on a
+        path that bypasses _calc_rep_cond. It must leave ct.rc/rc_source alone."""
+        ct_default.meas.rep_cond_freq(freq="ME")
+        assert ct_default.meas.rc is not None  # member CapData rc is set
+        assert ct_default.rc is None  # test rc untouched
+        assert ct_default.rc_source == "meas"  # default, unchanged

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2663,3 +2663,50 @@ class TestPipelineYaml:
             CapTest.from_mapping(
                 sub, meas_loader=MagicMock(return_value=meas_cd_default)
             )
+
+
+class TestTestRc:
+    """CapTest.rc storage, _set_rc write point, and source-change warning."""
+
+    def _rc_df(self, poa=800.0):
+        return pd.DataFrame({"poa": [poa], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_rc_defaults_none_and_source_meas(self):
+        ct = CapTest()
+        assert ct.rc is None
+        assert ct.rc_source == "meas"
+        assert ct._loading is False
+
+    def test_set_rc_first_set_is_silent_and_records_source(self, recwarn):
+        ct = CapTest()
+        df = self._rc_df()
+        ct._set_rc(df, "sim")
+        assert ct.rc is df
+        assert ct.rc_source == "sim"
+        assert len(recwarn) == 0
+
+    def test_set_rc_same_source_is_silent(self, recwarn):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        ct._set_rc(self._rc_df(810.0), "meas")
+        assert ct.rc_source == "meas"
+        assert len(recwarn) == 0
+
+    def test_set_rc_source_change_warns(self):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        with pytest.warns(UserWarning, match="rc_source changed from 'meas' to 'sim'"):
+            ct._set_rc(self._rc_df(), "sim")
+        assert ct.rc_source == "sim"
+
+    def test_set_rc_warn_false_suppresses(self, recwarn):
+        ct = CapTest()
+        ct._set_rc(self._rc_df(), "meas")
+        ct._set_rc(self._rc_df(), "manual", warn=False)
+        assert ct.rc_source == "manual"
+        assert len(recwarn) == 0
+
+    def test_rc_source_accepts_manual(self):
+        ct = CapTest()
+        ct.rc_source = "manual"  # must not raise (Selector now allows it)
+        assert ct.rc_source == "manual"

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2865,3 +2865,51 @@ class TestRepCondSync:
         assert ct_default.rc_source == "manual"
         ct_default.rep_cond()  # which=None, rc_source='manual' -> 'meas'
         assert ct_default.rc_source == "meas"
+
+
+class TestManualRcSerialization:
+    """to_yaml serializes manual RC values; computed RC is not value-serialized."""
+
+    def _capt(self, meas_cd_default, sim_cd_default):
+        return CapTest.from_params(
+            test_setup="e2848_default",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            ac_nameplate=6_000_000,
+        )
+
+    def test_manual_rc_serializes_native_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        sub = capt._build_yaml_sub_mapping()
+        assert sub["rc_source"] == "manual"
+        vals = sub["reporting_conditions_values"]
+        assert vals["poa"] == pytest.approx(805.0)
+        assert {"poa", "t_amb", "w_vel"} <= set(vals)
+        # Values must be native python types so yaml.safe_dump can represent them.
+        assert type(vals["poa"]) is float
+
+    def test_computed_rc_omits_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rep_cond(which="meas")  # rc_source='meas' (computed)
+        sub = capt._build_yaml_sub_mapping()
+        assert sub["rc_source"] == "meas"
+        assert "reporting_conditions_values" not in sub
+
+    def test_no_rc_omits_values(self, meas_cd_default, sim_cd_default):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        sub = capt._build_yaml_sub_mapping()
+        assert "reporting_conditions_values" not in sub
+
+    def test_manual_rc_omits_overrides_rep_conditions(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """A manual rc_source serializes reporting_conditions_values as the
+        authoritative RC and does NOT also write overrides.rep_conditions, so
+        the file never carries two RC-bearing keys."""
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        capt.rep_conditions = {"func": {"poa": "mean"}}  # would normally serialize
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        sub = capt._build_yaml_sub_mapping()
+        assert "reporting_conditions_values" in sub
+        assert "rep_conditions" not in sub.get("overrides", {})

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1730,38 +1730,37 @@ class TestPortedMethods:
         with pytest.raises(RuntimeError, match="meas"):
             capt.captest_results(print_res=False)
 
-    def test_captest_results_matches_direct_prediction(self):
+    def test_captest_results_predicts_at_ct_rc(self):
         capt = self._build_ct()
-        expected_actual = capt.meas.regression_results.predict(capt.meas.rc)[0]
-        expected_expected = capt.sim.regression_results.predict(capt.meas.rc)[0]
+        rc = pd.DataFrame({"poa": [6], "t_amb": [5], "w_vel": [3]})
+        capt._set_rc(rc, "meas")
+        expected_actual = capt.meas.regression_results.predict(rc)[0]
+        expected_expected = capt.sim.regression_results.predict(rc)[0]
         expected_ratio = expected_actual / expected_expected
 
         cp_rat = capt.captest_results(print_res=False)
 
         assert cp_rat == pytest.approx(expected_ratio, rel=1e-10)
 
-    def test_captest_results_uses_rc_source_meas_by_default(self):
+    def test_captest_results_uses_ct_rc_values_regardless_of_source(self):
         capt = self._build_ct()
-        # Set sim.rc to a different value; default rc_source="meas"
-        # should keep the meas rc.
-        capt.sim.rc = pd.DataFrame({"poa": [99], "t_amb": [99], "w_vel": [99]})
-        expected_actual = capt.meas.regression_results.predict(capt.meas.rc)[0]
-        expected_expected = capt.sim.regression_results.predict(capt.meas.rc)[0]
-        expected_ratio = expected_actual / expected_expected
+        # Distinct RC values; both meas and sim predict at the SAME ct.rc.
+        rc = pd.DataFrame({"poa": [8], "t_amb": [4], "w_vel": [2]})
+        capt._set_rc(rc, "sim")
+        expected_ratio = (
+            capt.meas.regression_results.predict(rc)[0]
+            / capt.sim.regression_results.predict(rc)[0]
+        )
 
         cp_rat = capt.captest_results(print_res=False)
+
         assert cp_rat == pytest.approx(expected_ratio, rel=1e-10)
 
-    def test_captest_results_uses_rc_source_sim(self):
+    def test_captest_results_raises_when_ct_rc_none(self):
         capt = self._build_ct()
-        capt.rc_source = "sim"
-        capt.sim.rc = pd.DataFrame({"poa": [8], "t_amb": [4], "w_vel": [2]})
-        expected_actual = capt.meas.regression_results.predict(capt.sim.rc)[0]
-        expected_expected = capt.sim.regression_results.predict(capt.sim.rc)[0]
-        expected_ratio = expected_actual / expected_expected
-
-        cp_rat = capt.captest_results(print_res=False)
-        assert cp_rat == pytest.approx(expected_ratio, rel=1e-10)
+        assert capt.rc is None
+        with pytest.raises(ValueError, match="requires test reporting conditions"):
+            capt.captest_results(print_res=False)
 
     def test_captest_results_warns_on_mismatched_formulas(self):
         capt = self._build_ct()
@@ -1771,6 +1770,7 @@ class TestPortedMethods:
 
     def test_captest_results_check_pvalues_returns_styled_df(self):
         capt = self._build_ct()
+        capt._set_rc(pd.DataFrame({"poa": [6], "t_amb": [5], "w_vel": [3]}), "meas")
         styled = capt.captest_results_check_pvalues(print_res=False)
         # Styler objects expose the underlying data via the .data attribute.
         underlying = styled.data

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from captest import CapTest, captest as ct
+from captest import CapTest, captest as ct, util
 from captest.capdata import CapData
 from captest.calcparams import (
     apparent_zenith_pvsyst,
@@ -2706,3 +2706,92 @@ class TestTestRc:
         ct = CapTest()
         ct.rc_source = "manual"  # must not raise (Selector now allows it)
         assert ct.rc_source == "manual"
+
+
+class TestManualRc:
+    """The public ct.rc = df manual-override setter (rc_source='manual')."""
+
+    def _full_rc(self, poa=805.0):
+        return pd.DataFrame({"poa": [poa], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_set_rc_dataframe_sets_manual_source(self, ct_default):
+        df = self._full_rc()
+        ct_default.rc = df
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(805.0)
+
+    def test_set_rc_accepts_dict(self, ct_default):
+        ct_default.rc = {"poa": 700.0, "t_amb": 20.0, "w_vel": 1.5}
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(700.0)
+
+    def test_set_rc_accepts_series(self, ct_default):
+        ct_default.rc = pd.Series({"poa": 650.0, "t_amb": 18.0, "w_vel": 1.0})
+        assert ct_default.rc_source == "manual"
+        assert ct_default.rc["poa"].iloc[0] == pytest.approx(650.0)
+
+    def test_set_rc_preserves_extra_columns(self, ct_default):
+        ct_default.rc = {"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0, "note": 1.0}
+        assert "note" in ct_default.rc.columns
+
+    def test_set_rc_series_preserves_extra_columns(self, ct_default):
+        """Extra fields survive the Series -> one-row DataFrame coercion."""
+        s = pd.Series({"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0, "note": 9.0})
+        ct_default.rc = s
+        assert "note" in ct_default.rc.columns
+        assert ct_default.rc["note"].iloc[0] == pytest.approx(9.0)
+
+    def test_required_vars_are_unwrapped_interaction_components(self, ct_default):
+        """Coverage keys off RHS *component* variables (poa, t_amb, w_vel), not
+        the I(...) interaction terms, for the default formula. Guards against a
+        parse_regression_formula change silently weakening validation."""
+        _, rhs = util.parse_regression_formula(ct_default.meas.regression_formula)
+        assert sorted(rhs) == ["poa", "t_amb", "w_vel"]
+        # A df with only the component vars (no I(poa*poa) columns) is accepted.
+        ct_default.rc = {"poa": 805.0, "t_amb": 25.0, "w_vel": 2.0}
+        assert ct_default.rc_source == "manual"
+
+    def test_set_rc_multirow_raises(self, ct_default):
+        """A multi-row DataFrame is rejected with a clear error at set time."""
+        df = pd.DataFrame(
+            {"poa": [805.0, 810.0], "t_amb": [25.0, 26.0], "w_vel": [2.0, 2.1]}
+        )
+        with pytest.raises(ValueError, match="single row"):
+            ct_default.rc = df
+
+    def test_set_rc_missing_rhs_var_raises_listing_names(self, ct_default):
+        with pytest.raises(ValueError, match=r"missing required regression"):
+            ct_default.rc = pd.DataFrame({"poa": [805.0]})
+
+    def test_set_rc_missing_var_message_names_the_missing(self, ct_default):
+        with pytest.raises(ValueError) as exc:
+            ct_default.rc = {"poa": 805.0, "t_amb": 25.0}  # w_vel missing
+        assert "w_vel" in str(exc.value)
+
+    def test_set_rc_requires_setup(self):
+        ct = CapTest()  # bare, setup() not run
+        with pytest.raises(RuntimeError, match="setup"):
+            ct.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+
+    def test_set_rc_formula_mismatch_raises(self, ct_default):
+        ct_default.sim.regression_formula = "power ~ poa"
+        with pytest.raises(ValueError, match="different regression formulas"):
+            ct_default.rc = self._full_rc()
+
+    def test_set_rc_bad_type_raises(self, ct_default):
+        with pytest.raises(TypeError, match="DataFrame"):
+            ct_default.rc = [805.0, 25.0, 2.0]
+
+    def test_set_rc_first_set_is_silent(self, ct_default, recwarn):
+        ct_default.rc = self._full_rc()
+        assert len(recwarn) == 0
+
+    def test_set_rc_over_computed_source_warns(self, ct_default):
+        ct_default._set_rc(self._full_rc(), "meas")  # seed a computed source
+        with pytest.warns(UserWarning, match="changed from 'meas' to 'manual'"):
+            ct_default.rc = self._full_rc(810.0)
+
+    def test_set_rc_over_manual_is_silent(self, ct_default, recwarn):
+        ct_default.rc = self._full_rc()  # first -> manual (silent)
+        ct_default.rc = self._full_rc(810.0)  # manual -> manual (silent)
+        assert len(recwarn) == 0

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2913,3 +2913,90 @@ class TestManualRcSerialization:
         sub = capt._build_yaml_sub_mapping()
         assert "reporting_conditions_values" in sub
         assert "rep_conditions" not in sub.get("overrides", {})
+
+
+class TestRcOwnershipRoundTrip:
+    """to_yaml/from_yaml round-trips of the single test RC across sources."""
+
+    def _capt(self, meas_cd_default, sim_cd_default, **kw):
+        return CapTest.from_params(
+            test_setup="e2848_default",
+            meas=meas_cd_default,
+            sim=sim_cd_default,
+            ac_nameplate=6_000_000,
+            **kw,
+        )
+
+    def _roundtrip(self, capt, tmp_path, clean_meas, clean_sim):
+        capt._meas_path = str(tmp_path / "meas.csv")
+        capt._sim_path = str(tmp_path / "sim.csv")
+        path = tmp_path / "config.yaml"
+        capt.to_yaml(path, merge_into_existing=False)
+        return CapTest.from_yaml(
+            path,
+            meas_loader=MagicMock(return_value=clean_meas),
+            sim_loader=MagicMock(return_value=clean_sim),
+        )
+
+    def test_roundtrip_computed_meas_recomputes_ct_rc(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.meas.filter_irr(200, 800)
+        capt.rep_cond(which="meas")
+        expected_poa = capt.rc["poa"].iloc[0]
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "meas"
+        assert reloaded.rc is not None
+        assert reloaded.rc["poa"].iloc[0] == pytest.approx(expected_poa)
+
+    def test_roundtrip_manual_rc_restores_values(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "manual"
+        assert reloaded.rc["poa"].iloc[0] == pytest.approx(805.0)
+
+    def test_roundtrip_rc_source_sim_replays_sim_first(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        # The OTHER side (meas) carries the rep_irr filter; sim is the source.
+        # This fails under a fixed meas-before-sim load order.
+        capt = self._capt(meas_cd_default, sim_cd_default, rc_source="sim")
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.sim.filter_irr(200, 800)
+        capt.rep_cond(which="sim")  # ct.rc from sim, rc_source='sim'
+        capt.meas.filter_irr(0.8, 1.2, ref_val="rep_irr")  # anchors on sim rep irr
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        assert reloaded.rc_source == "sim"
+        meas_irr = [
+            s for s in reloaded.meas.filters if type(s).__name__ == "Irradiance"
+        ][-1]
+        assert meas_irr.ref_val_resolved == pytest.approx(reloaded.rc["poa"].iloc[0])
+
+    def test_load_is_config_seeded_and_silent(
+        self, tmp_path, meas_cd_default, sim_cd_default, recwarn
+    ):
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.rep_cond(which="sim")  # sim RepCond step (rc_source -> 'sim')
+        capt.rep_cond(which="meas")  # meas RepCond step (rc_source -> 'meas')
+        assert capt.rc_source == "meas"
+        recwarn.clear()
+
+        reloaded = self._roundtrip(capt, tmp_path, clean_meas, clean_sim)
+
+        # Config-seeded: meas drives despite sim also carrying a RepCond step.
+        assert reloaded.rc_source == "meas"
+        # No source-change warning during load.
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -3003,3 +3003,32 @@ class TestRcOwnershipRoundTrip:
         assert reloaded.rc_source == "meas"
         # No source-change warning during load.
         assert not any("rc_source changed" in str(w.message) for w in recwarn)
+
+    def test_corrupted_manual_rc_in_yaml_raises_on_load(
+        self, tmp_path, meas_cd_default, sim_cd_default
+    ):
+        """from_yaml with a corrupted manual RC (missing required RHS variable)
+        must raise ValueError at load time, not silently succeed and fail later
+        at predict/rep_irr."""
+        capt = self._capt(meas_cd_default, sim_cd_default)
+        clean_meas, clean_sim = capt.meas.copy(), capt.sim.copy()
+        capt.rc = pd.DataFrame({"poa": [805.0], "t_amb": [25.0], "w_vel": [2.0]})
+        capt._meas_path = str(tmp_path / "meas.csv")
+        capt._sim_path = str(tmp_path / "sim.csv")
+        path = tmp_path / "config.yaml"
+        capt.to_yaml(path, merge_into_existing=False)
+
+        # Hand-edit: drop w_vel from reporting_conditions_values to simulate
+        # a corrupted or hand-edited YAML file.
+        with open(path) as f:
+            doc = yaml.safe_load(f)
+        del doc["captest"]["reporting_conditions_values"]["w_vel"]
+        with open(path, "w") as f:
+            yaml.safe_dump(doc, f)
+
+        with pytest.raises(ValueError, match="missing required regression"):
+            CapTest.from_yaml(
+                path,
+                meas_loader=MagicMock(return_value=clean_meas),
+                sim_loader=MagicMock(return_value=clean_sim),
+            )

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -1069,12 +1069,6 @@ class TestRepIrrCrossInstance:
         assert step.ref_val_resolved == pytest.approx(500.0)
         assert step.low_effective == pytest.approx(0.8 * 500.0)
 
-    @pytest.mark.xfail(
-        reason="rep_cond->ct.rc auto-sync lands in Plan 3 and the rep_irr YAML "
-        "round-trip in Plan 5; placeholder keeps the deferred end-to-end "
-        "coverage gap visible. Plan 5 removes this marker.",
-        strict=False,
-    )
     def test_meas_rep_cond_then_sim_rep_irr_roundtrips(self, ct_default, tmp_path):
         """End-to-end: meas.rep_cond seeds ct.rc, sim filters around it, and the
         pipeline round-trips through to_yaml. Enabled in Plan 5."""
@@ -2230,8 +2224,11 @@ class TestIntegration:
         # applicable to the sim CapData.
         capt.sim.filter_shade(fshdbm=capt.fshdbm)
         capt.sim.filter_time(start=_SIM_WINDOW[0], end=_SIM_WINDOW[1])
+        # Single test RC from the rc_source side (default 'meas'). Under
+        # last-writer-wins a second rep_cond(which='sim') would flip rc_source
+        # to 'sim' and change captest_results; the canonical workflow uses one
+        # source.
         capt.rep_cond()
-        capt.rep_cond(which="sim")
         capt.meas.fit_regression(summary=False)
         capt.sim.fit_regression(summary=False)
 

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -2849,3 +2849,22 @@ class TestRepCondSync:
         assert ct_default.meas.rc is not None  # member CapData rc is set
         assert ct_default.rc is None  # test rc untouched
         assert ct_default.rc_source == "meas"  # default, unchanged
+
+    def test_ct_rep_cond_default_which_follows_rc_source(self, ct_default, recwarn):
+        ct_default.sim.rep_cond()  # rc_source -> 'sim'
+        ct_default.rep_cond()  # which=None -> should pick 'sim'
+        assert ct_default.rc_source == "sim"
+        # If the default had picked 'meas', this would flip+warn.
+        assert not any("rc_source changed" in str(w.message) for w in recwarn)
+
+    def test_ct_rep_cond_explicit_which_sim(self, ct_default):
+        ct_default.rep_cond("sim")
+        assert ct_default.rc_source == "sim"
+        assert ct_default.rc is not None
+
+    def test_ct_rep_cond_default_which_meas_when_rc_source_manual(self, ct_default):
+        # Seed a manual source, then default rep_cond should fall back to 'meas'.
+        ct_default.rc = pd.DataFrame({"poa": [800.0], "t_amb": [25.0], "w_vel": [2.0]})
+        assert ct_default.rc_source == "manual"
+        ct_default.rep_cond()  # which=None, rc_source='manual' -> 'meas'
+        assert ct_default.rc_source == "meas"


### PR DESCRIPTION
## Summary

Makes `CapTest.rc` the single owner of a capacity test's reporting conditions, replacing the per-`CapData` `rc_source_resolved` reference. The one test RC is sourced from `meas`/`sim` via `rep_cond` (last-writer-wins) or set manually with `ct.rc = df`, and it round-trips through `to_yaml` / `from_yaml`.

## Changes

- **Storage + write point:** add `CapTest.rc` (read-only property over `_rc`) and `_set_rc(df, source, warn=True)` as the single write point; `rc_source` Selector now accepts `"meas"` / `"sim"` / `"manual"` and warns only on a real source change.
- **Resolution:** replace `CapData.rc_source_resolved` (CapData→CapData) with a `CapData._captest` back-reference wired in `CapTest.setup()`. `CapData.rep_irr` resolves from `ct.rc` inside a test, else `self.rc`. `capdata.py` never imports `captest` (opaque runtime call).
- **Manual override:** `ct.rc = df` (DataFrame / Series / dict) is the only public manual path; it validates that every right-hand-side regression variable of the shared `meas`/`sim` formula is covered and records `rc_source="manual"`.
- **Sync:** any `cd.rep_cond()` on a test member updates `ct.rc` last-writer-wins via `_on_capdata_rep_cond`; `ct.rep_cond(which=None)` defaults to the current `rc_source`.
- **Results:** `captest_results` predicts both regressions at `ct.rc` and raises `ValueError` when no test RC is set.
- **Serialization / load:** manual RC is serialized as `reporting_conditions_values` (numpy scalars coerced to native); on load, a manual RC is seeded (and re-validated) before replay, the configured `rc_source` side replays first so cross-side `ref_val="rep_irr"` filters resolve, and the `rep_cond` sync is config-seeded and warning-suppressed via `_loading`.
- Updated `CHANGELOG.md`; design spec and implementation plans added under `docs/superpowers/`.

## Testing

- Full suite green: `just test` → **903 passed**.
- New/updated coverage in `tests/test_captest.py` (`TestTestRc`, `TestManualRc`, `TestRepCondSync`, `TestManualRcSerialization`, `TestRcOwnershipRoundTrip`, `captest_results`) and `tests/test_CapData.py` (`TestRepIrr` + straggler migrations). Developed test-first throughout.

## Notes

- Behavior change (not a break vs. released code — `rc_source_resolved` was never released): `captest_results` now raises `ValueError` when no test RC is set, and `rc_source` accepts `"manual"`.
- The design spec + 5 implementation plans under `docs/superpowers/` are included for review transparency; say the word if you'd prefer them dropped from the PR.
- User-facing `user_guide` / `api_reference` pages for the new `ct.rc` API are not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
