### PR TITLE
docs: correct merge-pr skill paths and require an authored squash commit message

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -9,13 +9,29 @@ A workflow for safely merging pvcaptest PRs and keeping the fork and local upstr
 
 ## Repository layout
 
-- Fork (working directory): `~/python/pvcaptest_bt-`
+- Fork (working directory): `~/python/pvcaptest-fork`
   - `origin` → `git@github.com:bt-/pvcaptest.git`
   - `upstream` → `git@github.com:pvcaptest/pvcaptest.git`
 - Local upstream clone: `~/python/pvcaptest/`
   - `origin` → `git@github.com:pvcaptest/pvcaptest.git`
 
-All `git` commands use the `g` shell alias.
+Use `git -C <path>` in commands. The `g` alias exists only in the user's interactive
+shell and is not available to non-interactive tool calls.
+
+## Where the PR lives
+
+Feature branches are pushed to the **fork** (`bt-/pvcaptest`) but the PR is opened
+**against upstream master** (`pvcaptest/pvcaptest:master`). This cross-repo shape
+determines every `gh` invocation:
+
+- **All `gh pr ...` commands target `--repo pvcaptest/pvcaptest`** — that is where the
+  PR object lives. Querying `--repo bt-/pvcaptest` will not find it.
+- The **head branch** lives on `bt-/pvcaptest`, so branch deletion happens against
+  `origin`, not upstream.
+- Merge permissions are on upstream. Some upstream API endpoints are restricted:
+  `gh run view --log-failed` returns `HTTP 403: Must have admin rights` even when
+  `gh pr checks` works fine. Use `gh pr checks` / `gh run view` (no `--log`) for
+  status, and reproduce failures locally rather than chasing CI logs.
 
 ---
 
@@ -34,23 +50,37 @@ If this fails, stop. Tell the user to install the GitHub CLI (`gh`) before proce
 ### 1b. Check for uncommitted work
 
 ```bash
-g -C ~/python/pvcaptest_bt- status --porcelain
+git -C ~/python/pvcaptest-fork status --porcelain
 ```
 
-If any output appears (staged or unstaged changes), stop. List the dirty files and tell the user to commit or stash them first — merging with a dirty tree risks losing work.
+- **Modified or staged tracked files** (`M`/`A`/`D` lines) → stop. List them and tell
+  the user to commit or stash first — merging with a dirty tree risks losing work.
+- **Untracked files** (`??` lines) → not a blocker, but check whether any belong in the
+  PR before merging, since the branch is deleted afterward. Local-only scratch
+  (`docs/superpowers/plans/*.md`, `docs/superpowers/specs/*.md`, scratch notebooks)
+  is expected to stay untracked — see the "no specs/plans on remotes" convention.
+  If an untracked file looks like it belongs to the feature, ask before proceeding.
+
+Also confirm the branch is fully pushed, or the merge will land stale code:
+
+```bash
+git -C ~/python/pvcaptest-fork rev-list --left-right --count origin/{branch}...HEAD
+```
+
+Anything other than `0	0` means push (or pull) before merging.
 
 ### 1c. Check that CI is passing
 
 Fetch the status of all checks on the PR:
 
 ```bash
-gh pr checks {pr_number} --repo bt-/pvcaptest
+gh pr checks {pr_number} --repo pvcaptest/pvcaptest
 ```
 
 If the PR number isn't known yet, get it first:
 
 ```bash
-gh pr view --json number,headRefName,title --repo bt-/pvcaptest
+gh pr view {pr_number} --repo pvcaptest/pvcaptest --json number,headRefName,title,state,mergeable
 ```
 
 Evaluate the output of `gh pr checks`:
@@ -63,7 +93,8 @@ Evaluate the output of `gh pr checks`:
 Get the list of files changed on the current branch relative to upstream/master:
 
 ```bash
-g -C ~/python/pvcaptest_bt- diff upstream/master...HEAD --name-only
+git -C ~/python/pvcaptest-fork fetch upstream master
+git -C ~/python/pvcaptest-fork diff upstream/master...HEAD --name-only
 ```
 
 Parse the output:
@@ -80,66 +111,141 @@ Parse the output:
 Determine the PR number and feature branch name if not already known:
 
 ```bash
-g -C ~/python/pvcaptest_bt- branch --show-current
-gh pr view --json number,headRefName,title --repo bt-/pvcaptest
+git -C ~/python/pvcaptest-fork branch --show-current
+gh pr view {pr_number} --repo pvcaptest/pvcaptest --json number,headRefName,title,body
 ```
 
 Confirm with the user if anything is ambiguous.
 
 ---
 
-## Step 3: Merge the PR
+## Step 3: Compose the squash commit message
+
+**Always author the squash commit message explicitly.** Never accept GitHub's default:
+it concatenates every commit on the branch, so a 26-commit branch produces an unreadable
+wall of text with the same `Co-Authored-By` trailer repeated once per commit.
+
+Gather source material first:
 
 ```bash
-gh pr merge {pr_number} -s -d
+git -C ~/python/pvcaptest-fork log upstream/master..HEAD --oneline
+gh pr view {pr_number} --repo pvcaptest/pvcaptest --json body -q .body
+```
+
+Then write the message to these rules:
+
+- **First line contains the PR number and the head branch name**, after a conventional
+  commit prefix. Format: `{type}: {concise description} (#{pr_number}, {branch_name})`
+  - Example: `feat: CapTest run_test orchestrator and staged config lifecycle (#165, captest-lifecycle)`
+- **Body is concise bullets** summarizing what actually landed, grouped by theme rather
+  than one bullet per commit. Condense aggressively — a 26-commit branch should read as
+  roughly 10 bullets. Prefer the PR body's "Changes" section, tightened, over the raw
+  commit list. Backtick API names (`CapTest.run_test`, `rerun_filters_from`).
+- **No duplicate author attributions.** At most one `Co-Authored-By` trailer and one
+  `Claude-Session` line, at the very end of the body — never one per squashed commit.
+- **Close with what a reader needs**: breaking-change status (e.g. "Breaking changes are
+  pre-v1 and recorded in CHANGELOG") and the test result summary, one line each.
+
+Write the body to a scratch file so quoting and newlines survive the shell:
+
+```bash
+# write body to $SCRATCH/merge-body.txt, then pass with --body-file
+```
+
+---
+
+## Step 4: Merge the PR
+
+```bash
+gh pr merge {pr_number} --repo pvcaptest/pvcaptest -s -d \
+  --subject "{first line from Step 3}" \
+  --body-file "{path to body file}"
 ```
 
 - `-s` squash-merges all commits on the branch into a single commit on upstream/master
-- `-d` deletes the source branch from the remote after merge
+- `-d` requests deletion of the source branch after merge
+- `--subject` / `--body-file` supply the Step 3 message instead of the default
+
+A successful merge prints **nothing**. Do not read the silence as failure — verify:
+
+```bash
+gh pr view {pr_number} --repo pvcaptest/pvcaptest --json state,mergedAt,mergeCommit \
+  -q '.state, .mergedAt, .mergeCommit.oid'
+```
 
 If the merge fails, report the error and stop.
 
 ---
 
-## Step 4: Delete the remote feature branch from the fork
-
-`gh pr merge -d` should have already removed the branch, but run this as a safety step:
-
-```bash
-g -C ~/python/pvcaptest_bt- push origin -d {branch_name}
-```
-
-If this errors with "remote ref does not exist", that's fine — it just means `gh` already cleaned it up.
-
----
-
 ## Step 5: Sync local master with upstream and push to fork
 
-After the PR is merged into upstream, the local master branch needs to be updated:
+Do this **before** deleting the local branch — the branch cannot be deleted while checked out.
 
 ```bash
-g -C ~/python/pvcaptest_bt- checkout master
-g -C ~/python/pvcaptest_bt- pull upstream master
-g -C ~/python/pvcaptest_bt- push origin master
+git -C ~/python/pvcaptest-fork checkout master
+git -C ~/python/pvcaptest-fork pull upstream master
+git -C ~/python/pvcaptest-fork push origin master
 ```
 
 This pulls the squash-merge commit from upstream and pushes it to the fork so `bt-/pvcaptest:master` stays in sync.
 
 ---
 
-## Step 6: Update the local upstream clone
+## Step 6: Delete the feature branch
+
+Because the head branch is on a fork, `gh pr merge -d` frequently does **not** remove it.
+Always run the explicit deletes and confirm.
+
+Remote (on the fork):
 
 ```bash
-g -C ~/python/pvcaptest pull origin master
+git -C ~/python/pvcaptest-fork push origin -d {branch_name}
+```
+
+An error of "remote ref does not exist" is fine — it means `gh` already cleaned up.
+
+Local — squash merges leave the branch commits as non-ancestors of master, so `git branch -d`
+refuses with "not fully merged" and `-D` is required. **Verify nothing is lost first:**
+
+```bash
+git -C ~/python/pvcaptest-fork diff {branch_name} master --stat   # must be empty
+git -C ~/python/pvcaptest-fork branch -D {branch_name}
+```
+
+Empty diff = the squash captured every change. If it is **not** empty, stop and report —
+something on the branch did not make it into the squash commit.
+
+If deleting the branch prints `error: could not lock config file .git/config`, the ref was
+still deleted but a stale stanza remains. Clean it up:
+
+```bash
+git -C ~/python/pvcaptest-fork config --remove-section branch.{branch_name}
+```
+
+---
+
+## Step 7: Update the local upstream clone
+
+```bash
+git -C ~/python/pvcaptest pull origin master
 ```
 
 This keeps `~/python/pvcaptest/` current with the squash-merge commit.
 
 ---
 
-## Summary
+## Step 8: Verify and report
 
-When all steps complete, confirm to the user:
-- Which PR was merged (number + title)
-- That the feature branch is deleted (local + both remotes)
-- That `master` is synced across the fork origin and local upstream clone
+Confirm all four copies of master agree:
+
+```bash
+git -C ~/python/pvcaptest-fork rev-parse master origin/master upstream/master
+git -C ~/python/pvcaptest rev-parse master
+```
+
+Then confirm to the user:
+- Which PR was merged (number + title) and the squash commit SHA
+- The squash commit subject line, so they can see the message convention was applied
+- That the feature branch is deleted (local + fork remote)
+- That `master` is synced across the fork origin, upstream, and the local upstream clone
+- Anything intentionally left alone (untracked scratch files, unrelated local branches)


### PR DESCRIPTION
## Summary

The `merge-pr` skill described a repository layout that no longer exists, so every command in it failed as written. This corrects the layout and adds a required step for authoring the squash commit message, so merges stop producing the concatenated, trailer-repeating message GitHub generates by default.

## Changes

- **Fork path** corrected from `~/python/pvcaptest_bt-` (nonexistent) to `~/python/pvcaptest-fork`.
- **`g` → `git -C`**: the `g` alias exists only in the interactive shell and is unavailable to non-interactive tool calls, so every git command in the skill failed.
- **New "Where the PR lives" section**: feature branches push to the fork (`bt-/pvcaptest`) but the PR object lives on `pvcaptest/pvcaptest`, so all `gh pr ...` calls now use `--repo pvcaptest/pvcaptest`. Previously they targeted `bt-/pvcaptest` and found nothing. Also records that upstream `gh run view --log-failed` returns `HTTP 403: Must have admin rights` even when `gh pr checks` works, so CI failures should be reproduced locally.
- **New Step 3, "Compose the squash commit message"** — the substantive addition. Requires an explicitly authored message: first line `{type}: {description} (#{pr_number}, {branch_name})`, body as concise theme-grouped bullets rather than one per commit, and at most one `Co-Authored-By` / `Claude-Session` pair at the end. States why: GitHub's default squash message concatenates every branch commit and repeats the trailer once per commit.
- **Step ordering fixed**: sync `master` before deleting the local branch, which cannot be deleted while checked out.
- **Branch deletion corrected**: `gh pr merge -d` frequently does not delete a fork head branch, so the explicit delete is now required rather than a "safety step"; local deletion needs `-D` after a squash merge, gated on `git diff {branch} master --stat` being empty so nothing is discarded silently.
- **Operational notes added**: a successful `gh pr merge` prints nothing (don't misread the silence); untracked `docs/superpowers/` scratch is expected rather than a blocker; how to clear a stale `branch.{name}` config stanza after a `.git/config` lock error.

## Testing

Documentation-only change to `.agents/skills/merge-pr/SKILL.md`; no source or test files touched. Full suite run for confirmation: 1079 passed. `just lint` and `just fmt` clean (no files changed).

Every correction here was derived from executing the workflow end to end while merging #165 — each item is a step that failed or misled in that run.

## Notes

The `create-pr` skill hardcodes `Co-Authored-By: Oz <oz-agent@warp.dev>`, which does not match this repo's recent history. Left unchanged here to keep this PR scoped; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6Cw8ag28jCa4Uwmtxzpem
