### PR TITLE
feat: add a data prep stage between load and setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- New data prep stage: adjustments applied between load and `setup()` are now
+declared, serialized, and replayed. `CapData` gains `prep`, `prep_convert_units`,
+`prep_scale`, `prep_astype`, `prep_custom`, `prep_to_config`, `run_prep`, and
+`describe_prep`; `CapTest` gains `meas_prep`/`sim_prep`, replayed after every
+load (including `reload`) and written to the yaml config. See the new
+"Preparing Data" user guide page.
+- `CapData.drop_cols` and `CapData.rename_cols` now record a prep step by
+default and accept `record=False` for internal callers.
 - New `CapData.rerun_filters_from(index)` — partial pipeline re-run: truncates
 the chain to the retained prefix and re-runs the tail as live step objects with
 their current param values.
@@ -96,6 +104,8 @@ config's serialized filter pipelines until `run_test` replays and consumes them
 (retained, with recovery guidance attached to the error, when a replay fails).
 
 ### Changed
+- Value-rewriting prep steps raise if run after filters are applied; call
+`reset_filter()` first. Column drops and renames are unaffected.
 - `ReportingIrradiance.plot` now detects a missing reporting irradiance with
 `pd.isna` rather than an identity test against `np.nan`. The identity form only
 held for that exact object, so a NaN `irr_rc` arriving as a `numpy.float64`

--- a/docs/source/api_reference/capdata.rst
+++ b/docs/source/api_reference/capdata.rst
@@ -35,6 +35,9 @@ Data Management
 ---------------
 
 Methods for inspecting, renaming, copying, and exporting data.
+:meth:`~captest.capdata.CapData.drop_cols` and
+:meth:`~captest.capdata.CapData.rename_cols` record a prep step by default;
+see :ref:`data_prep`.
 
 .. autosummary::
    :toctree: generated/
@@ -45,6 +48,29 @@ Methods for inspecting, renaming, copying, and exporting data.
    capdata.CapData.empty
    capdata.CapData.drop_cols
    capdata.CapData.rename_cols
+
+.. _capdata-api-prep:
+
+Data Preparation
+----------------
+
+Thin wrappers that build a step class from :py:mod:`captest.prep` and
+``run()`` it, appending it to the ``CapData.prep`` chain. Prep steps rewrite
+``data`` in place between loading and ``setup()``. ``describe_prep`` returns a
+written summary of what was applied, while ``prep_to_config`` / ``run_prep``
+serialize and replay the chain. See :doc:`prep` for the underlying step
+classes and :ref:`data_prep` for the workflow.
+
+.. autosummary::
+   :toctree: generated/
+
+   capdata.CapData.prep_convert_units
+   capdata.CapData.prep_scale
+   capdata.CapData.prep_astype
+   capdata.CapData.prep_custom
+   capdata.CapData.describe_prep
+   capdata.CapData.prep_to_config
+   capdata.CapData.run_prep
 
 Aggregation
 -----------

--- a/docs/source/api_reference/generated/captest.CapTest.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rst
@@ -56,6 +56,7 @@
       ~CapTest.meas
       ~CapTest.meas_load_kwargs
       ~CapTest.meas_loader
+      ~CapTest.meas_prep
       ~CapTest.min_irr
       ~CapTest.module_type
       ~CapTest.name
@@ -79,6 +80,7 @@
       ~CapTest.sim_days
       ~CapTest.sim_load_kwargs
       ~CapTest.sim_loader
+      ~CapTest.sim_prep
       ~CapTest.spectral_module_type
       ~CapTest.test_setup
       ~CapTest.test_tolerance

--- a/docs/source/api_reference/generated/captest.capdata.CapData.describe_prep.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.describe_prep.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.describe\_prep
+======================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.describe_prep

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep_astype.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep_astype.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep\_astype
+====================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.prep_astype

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep_convert_units.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep_convert_units.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep\_convert\_units
+============================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.prep_convert_units

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep_custom.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep_custom.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep\_custom
+====================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.prep_custom

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep_scale.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep_scale.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep\_scale
+===================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.prep_scale

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep_to_config.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep_to_config.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep\_to\_config
+========================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.prep_to_config

--- a/docs/source/api_reference/generated/captest.capdata.CapData.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.rst
@@ -23,6 +23,7 @@
       ~CapData.custom_param
       ~CapData.data_columns_to_excel
       ~CapData.describe_filters
+      ~CapData.describe_prep
       ~CapData.drop_cols
       ~CapData.empty
       ~CapData.expand_agg_map
@@ -55,6 +56,11 @@
       ~CapData.get_summary
       ~CapData.plot
       ~CapData.predict_capacities
+      ~CapData.prep_astype
+      ~CapData.prep_convert_units
+      ~CapData.prep_custom
+      ~CapData.prep_scale
+      ~CapData.prep_to_config
       ~CapData.print_points_summary
       ~CapData.process_regression_columns
       ~CapData.reg_scatter_matrix
@@ -66,6 +72,7 @@
       ~CapData.reset_filter
       ~CapData.review_column_groups
       ~CapData.run_pipeline
+      ~CapData.run_prep
       ~CapData.scatter
       ~CapData.scatter_filters
       ~CapData.scatter_hv
@@ -87,6 +94,7 @@
       ~CapData.filters
       ~CapData.name
       ~CapData.param
+      ~CapData.prep
       ~CapData.rep_irr
    
    

--- a/docs/source/api_reference/generated/captest.capdata.CapData.run_prep.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.run_prep.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.run\_prep
+=================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.run_prep

--- a/docs/source/api_reference/generated/captest.prep.AsType.rst
+++ b/docs/source/api_reference/generated/captest.prep.AsType.rst
@@ -1,0 +1,39 @@
+﻿captest.prep.AsType
+===================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: AsType
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~AsType.__init__
+      ~AsType.from_config
+      ~AsType.run
+      ~AsType.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~AsType.args_repr
+      ~AsType.columns
+      ~AsType.custom_name
+      ~AsType.dtype
+      ~AsType.explanation
+      ~AsType.group
+      ~AsType.group_regex
+      ~AsType.name
+      ~AsType.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.BasePrepStep.rst
+++ b/docs/source/api_reference/generated/captest.prep.BasePrepStep.rst
@@ -1,0 +1,38 @@
+﻿captest.prep.BasePrepStep
+=========================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: BasePrepStep
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~BasePrepStep.__init__
+      ~BasePrepStep.from_config
+      ~BasePrepStep.run
+      ~BasePrepStep.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~BasePrepStep.args_repr
+      ~BasePrepStep.columns
+      ~BasePrepStep.custom_name
+      ~BasePrepStep.explanation
+      ~BasePrepStep.group
+      ~BasePrepStep.group_regex
+      ~BasePrepStep.name
+      ~BasePrepStep.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.ConvertUnits.rst
+++ b/docs/source/api_reference/generated/captest.prep.ConvertUnits.rst
@@ -1,0 +1,40 @@
+﻿captest.prep.ConvertUnits
+=========================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: ConvertUnits
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ConvertUnits.__init__
+      ~ConvertUnits.from_config
+      ~ConvertUnits.run
+      ~ConvertUnits.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~ConvertUnits.args_repr
+      ~ConvertUnits.columns
+      ~ConvertUnits.custom_name
+      ~ConvertUnits.explanation
+      ~ConvertUnits.from_units
+      ~ConvertUnits.group
+      ~ConvertUnits.group_regex
+      ~ConvertUnits.name
+      ~ConvertUnits.param
+      ~ConvertUnits.to_units
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.Custom.rst
+++ b/docs/source/api_reference/generated/captest.prep.Custom.rst
@@ -1,0 +1,38 @@
+﻿captest.prep.Custom
+===================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: Custom
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Custom.__init__
+      ~Custom.from_config
+      ~Custom.run
+      ~Custom.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Custom.args_repr
+      ~Custom.columns
+      ~Custom.custom_name
+      ~Custom.explanation
+      ~Custom.group
+      ~Custom.group_regex
+      ~Custom.name
+      ~Custom.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.DropColumns.rst
+++ b/docs/source/api_reference/generated/captest.prep.DropColumns.rst
@@ -1,0 +1,38 @@
+﻿captest.prep.DropColumns
+========================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: DropColumns
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~DropColumns.__init__
+      ~DropColumns.from_config
+      ~DropColumns.run
+      ~DropColumns.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~DropColumns.args_repr
+      ~DropColumns.columns
+      ~DropColumns.custom_name
+      ~DropColumns.explanation
+      ~DropColumns.group
+      ~DropColumns.group_regex
+      ~DropColumns.name
+      ~DropColumns.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.RenameColumns.rst
+++ b/docs/source/api_reference/generated/captest.prep.RenameColumns.rst
@@ -1,0 +1,39 @@
+﻿captest.prep.RenameColumns
+==========================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: RenameColumns
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~RenameColumns.__init__
+      ~RenameColumns.from_config
+      ~RenameColumns.run
+      ~RenameColumns.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~RenameColumns.args_repr
+      ~RenameColumns.column_map
+      ~RenameColumns.columns
+      ~RenameColumns.custom_name
+      ~RenameColumns.explanation
+      ~RenameColumns.group
+      ~RenameColumns.group_regex
+      ~RenameColumns.name
+      ~RenameColumns.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.Scale.rst
+++ b/docs/source/api_reference/generated/captest.prep.Scale.rst
@@ -1,0 +1,40 @@
+﻿captest.prep.Scale
+==================
+
+.. currentmodule:: captest.prep
+
+.. autoclass:: Scale
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Scale.__init__
+      ~Scale.from_config
+      ~Scale.run
+      ~Scale.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Scale.args_repr
+      ~Scale.columns
+      ~Scale.custom_name
+      ~Scale.explanation
+      ~Scale.factor
+      ~Scale.group
+      ~Scale.group_regex
+      ~Scale.name
+      ~Scale.offset
+      ~Scale.param
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.conversion_factors.rst
+++ b/docs/source/api_reference/generated/captest.prep.conversion_factors.rst
@@ -1,0 +1,6 @@
+﻿captest.prep.conversion\_factors
+================================
+
+.. currentmodule:: captest.prep
+
+.. autofunction:: conversion_factors

--- a/docs/source/api_reference/generated/captest.prep.prep_step_from_config.rst
+++ b/docs/source/api_reference/generated/captest.prep.prep_step_from_config.rst
@@ -1,0 +1,6 @@
+﻿captest.prep.prep\_step\_from\_config
+=====================================
+
+.. currentmodule:: captest.prep
+
+.. autofunction:: prep_step_from_config

--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -12,6 +12,7 @@ API Reference
    capdata
    captest
    filters
+   prep
    clearsky
    prtest
    calcparams

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -11,7 +11,8 @@ configuration as typed ``param`` parameters and implements ``_execute``,
 rewriting ``CapData.data`` in place and recording itself on
 ``CapData.prep``. The ``prep_*`` methods on
 :py:class:`~captest.capdata.CapData` are thin wrappers that build the matching
-step and ``run()`` it. Steps may also be constructed and run directly:
+step and ``run()`` it. Steps may also be constructed and run directly against
+a :py:class:`~captest.capdata.CapData` instance ``cd``:
 
 .. code-block:: Python
 

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -18,7 +18,9 @@ a :py:class:`~captest.capdata.CapData` instance ``cd``:
 
    from captest.prep import ConvertUnits, Scale
 
-   ConvertUnits(group_regex='^temp', from_units='F', to_units='C').run(cd)
+   ConvertUnits(
+       group_regex='^temp_(amb|bom)$', from_units='F', to_units='C'
+   ).run(cd)
    Scale(columns=['E_Grid'], factor=0.001).run(cd)
 
 See :ref:`data_prep` in the user guide for the workflow.

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -1,0 +1,79 @@
+.. currentmodule:: captest
+
+Prep
+====
+
+The :py:mod:`captest.prep` module holds the data-preparation steps: declared,
+serializable adjustments applied between loading data and
+:py:meth:`~captest.captest.CapTest.setup`. Each step is a
+:py:class:`~captest.prep.BasePrepStep` subclass that declares its
+configuration as typed ``param`` parameters and implements ``_execute``,
+rewriting ``CapData.data`` in place and recording itself on
+``CapData.prep``. The ``prep_*`` methods on
+:py:class:`~captest.capdata.CapData` are thin wrappers that build the matching
+step and ``run()`` it. Steps may also be constructed and run directly:
+
+.. code-block:: Python
+
+   from captest.prep import ConvertUnits, Scale
+
+   ConvertUnits(group_regex='^temp', from_units='F', to_units='C').run(cd)
+   Scale(columns=['E_Grid'], factor=0.001).run(cd)
+
+See :ref:`data_prep` in the user guide for the workflow.
+
+Base Class
+----------
+
+:py:class:`~captest.prep.BasePrepStep` owns the ``run()`` lifecycle, the
+three-way column selector (``columns`` / ``group`` / ``group_regex``), the
+``custom_name`` label, and the guard that refuses a value-rewriting step once
+filters have been applied.
+
+.. autosummary::
+   :toctree: generated/
+
+   prep.BasePrepStep
+
+Prep Steps
+----------
+
+Each step mutates ``CapData.data`` in place. The corresponding
+``CapData.prep_*`` wrapper (or, for the last two,
+:py:meth:`~captest.capdata.CapData.drop_cols` /
+:py:meth:`~captest.capdata.CapData.rename_cols`) builds and runs the step.
+
+.. autosummary::
+   :toctree: generated/
+
+   prep.ConvertUnits
+   prep.Scale
+   prep.AsType
+   prep.DropColumns
+   prep.RenameColumns
+   prep.Custom
+
+Unit Conversions
+----------------
+
+Conversions are affine (``out = value * factor + offset``). Only the forward
+direction of each pair is tabulated in ``UNIT_CONVERSIONS``; inverses are
+derived. ``UNIT_ALIASES`` normalizes unit spellings case-insensitively before
+lookup.
+
+.. autosummary::
+   :toctree: generated/
+
+   prep.conversion_factors
+
+Serialization
+-------------
+
+``PREP_REGISTRY`` maps a step's type name to its class;
+:py:func:`~captest.prep.prep_step_from_config` is the inverse of each step's
+``to_config``.
+
+.. autosummary::
+   :toctree: generated/
+
+   prep.prep_step_from_config

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -384,19 +384,26 @@ Step 1 — load the test
 
     tst = CapTest.from_yaml('./project.yaml')
 
-The measured and modeled data are loaded and
+The measured and modeled data are loaded, any prep steps saved in the file are
+replayed against the freshly loaded data, and
 :py:meth:`~captest.captest.CapTest.setup` runs: scalar settings are propagated
 to ``tst.meas`` / ``tst.sim``, calculated columns (e.g. ``e_total``) are
-created, and the regression columns are resolved and aggregated. The filter
-pipelines saved in the file are stored as pending — they have not touched the
-data.
+created, and the regression columns are resolved and aggregated. Prep runs
+before ``setup`` so the calculated columns are derived from prepped values
+(see :doc:`data_prep`). The filter pipelines saved in the file are stored as
+pending — they have not touched the data.
 
 .. note::
 
     **State after this step.**
 
-    - ``tst.meas.data`` / ``tst.sim.data`` hold the loaded (plus calculated)
-      columns, and ``data_filtered`` equals ``data`` — nothing is filtered.
+    - ``tst.meas.data`` / ``tst.sim.data`` hold the loaded (plus prepped and
+      calculated) columns, and ``data_filtered`` equals ``data`` — nothing is
+      filtered.
+    - ``tst.meas.prep`` / ``tst.sim.prep`` hold the prep steps replayed from
+      the config, and their values are already applied to ``data``. Unlike the
+      filter pipelines, prep is not staged as pending: it runs at load time,
+      and ``run_test`` never re-runs it.
     - The applied filter chains (``tst.meas.filters`` / ``tst.sim.filters``)
       are empty; the config's pipelines are held in
       ``tst.meas_filters_pending`` / ``tst.sim_filters_pending``.
@@ -406,6 +413,23 @@ data.
       ``setup()``, so ``tst.rc`` is set and ``tst.rc_source == 'manual'``.
     - No regressions are fitted (``regression_results`` is ``None`` on both
       sides).
+
+.. note::
+
+    ``setup()`` runs automatically here. Pass ``run_setup=False`` to load the
+    data and stop there instead:
+
+    .. code-block:: Python
+
+        tst = CapTest.from_yaml('./project.yaml', run_setup=False)
+
+    The config's prep steps are still replayed — prep is tied to the load, not
+    to ``setup`` — so this is the point to inspect the loaded data, or add a
+    prep step the config does not have, before the calculated columns are
+    derived from it. Run ``tst.setup()`` when ready, or call
+    :py:meth:`~captest.captest.CapTest.run_test`, whose first stage is the
+    per-side setup. See :ref:`load-only` for the full state after a load-only
+    call.
 
 Step 2 — review the raw data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -421,7 +445,38 @@ Because nothing is filtered yet, the review tools show the full dataset:
     **State after this step.** Unchanged — reviewing does not modify the
     test.
 
-Step 3 — run the measured side
+Step 3 — prepare the data (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the review turns up values in the wrong units or dtype, or a sensor whose
+measurements should be dropped, adjust them now with the prep methods:
+
+.. code-block:: Python
+
+    tst.meas.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    tst.sim.prep_scale(columns=['E_Grid'], factor=0.001)
+
+Prep steps rewrite values in ``data`` in place and are recorded on
+``tst.meas.prep`` / ``tst.sim.prep``, so they are written to the config by
+:py:meth:`~captest.captest.CapTest.to_yaml` and re-applied the next time the
+data is loaded. Any prep the config already declared was applied during
+step 1, between the load and ``setup()`` — there is nothing to repeat here.
+
+This step comes before step 4 because a prep step that rewrites values raises
+once filters have been applied: those filters were evaluated against
+un-prepped values. See :doc:`data_prep` for the selectors, the supported unit
+conversions, the once-per-load rules, and the config format.
+
+.. note::
+
+    **State after this step.**
+
+    - The prepped columns of ``tst.meas.data`` / ``tst.sim.data`` hold
+      converted values, and the applied steps are on ``tst.meas.prep`` /
+      ``tst.sim.prep``.
+    - Nothing is filtered and no regressions are fitted; the pending filter
+      pipelines are still pending.
+
+Step 4 — run the measured side
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: Python
@@ -444,7 +499,7 @@ and fits the measured regression. The modeled side is untouched.
     - ``tst.sim`` still holds unfiltered data with its pipeline pending;
       nothing is fitted on the modeled side.
 
-Step 4 — summarize the measured filtering
+Step 5 — summarize the measured filtering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: Python
@@ -453,7 +508,7 @@ Step 4 — summarize the measured filtering
     print(tst.meas.describe_filters())
     tst.meas.scatter_filters() + tst.meas.timeseries_filters()
 
-Step 5 — adjust the filtering (optional)
+Step 6 — adjust the filtering (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To append a filter, call any ``filter_*`` method — it runs immediately at the
 tail of the applied chain:
@@ -478,7 +533,7 @@ they can be re-run (see :ref:`reporting_conditions`).
     is stale until it is re-fitted (step 7, or another
     ``run_test(side='meas')``).
 
-Step 6 — run and summarize the modeled side
+Step 7 — run and summarize the modeled side
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: Python
@@ -495,7 +550,7 @@ Modeled filters that anchor on the reporting irradiance
     **State after this step.** Both chains are applied, both pending lists
     are consumed, both regressions are fitted, and ``tst.rc`` is set.
 
-Step 7 — results
+Step 8 — results
 ~~~~~~~~~~~~~~~~
 When both fits are current, compare them directly:
 
@@ -692,6 +747,12 @@ before the regression mapping is applied:
     aggregation. Pending pipelines (and, for a manual-RC config, the pending
     reporting-conditions values) are stored for later. A subsequent
     ``tst.setup()`` or ``tst.run_test()`` proceeds normally from this state.
+
+    Prep is the exception: it is tied to the load rather than to ``setup``,
+    so the config's ``meas_prep`` / ``sim_prep`` steps have already run and
+    are recorded on ``tst.meas.prep`` / ``tst.sim.prep``. Any prep you add
+    here is applied immediately too — and must be added before filtering,
+    since a prep step that rewrites values raises once filters are applied.
 
 .. _editing-filter-pipeline:
 

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -452,7 +452,9 @@ measurements should be dropped, adjust them now with the prep methods:
 
 .. code-block:: Python
 
-    tst.meas.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    tst.meas.prep_convert_units(
+        group_regex='^temp_(amb|bom)$', from_units='F', to_units='C'
+    )
     tst.sim.prep_scale(columns=['E_Grid'], factor=0.001)
 
 Prep steps rewrite values in ``data`` in place and are recorded on

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -148,8 +148,8 @@ silent no-op, and the messages name what is available:
 The remaining steps select differently:
 :py:meth:`~captest.capdata.CapData.drop_cols` takes its column names directly,
 :py:meth:`~captest.capdata.CapData.rename_cols` takes them from the keys of
-its ``column_map``, and the selector is optional for
-:py:meth:`~captest.capdata.CapData.prep_custom` (see
+its ``column_map``, and :py:meth:`~captest.capdata.CapData.prep_custom` takes
+no selector at all — the callable decides what it touches (see
 `Custom prep steps`_).
 
 Converting units
@@ -279,8 +279,15 @@ Three consequences follow:
 
   ``reload`` snapshots the outgoing side's applied prep chain into
   ``sim_prep``, loads a fresh un-prepped frame from the stored path, replays
-  the prep, and then runs ``setup`` for that side. To change the prep, edit
-  ``tst.sim_prep`` before reloading.
+  that prep, and then runs ``setup`` for that side. It re-applies **the same
+  steps** — including after ``tst.reload('sim', path=...)`` points the side at
+  a different file, which is the case it exists for. Because the snapshot
+  overwrites ``sim_prep`` with the applied chain, editing ``tst.sim_prep``
+  and then reloading does not change anything. To run a *different* prep,
+  rebuild the test from its paths — with
+  :py:meth:`~captest.captest.CapTest.from_yaml` on an edited config, or
+  ``from_params(..., run_setup=False)`` followed by the ``prep_*`` calls you
+  want.
 
 :py:meth:`~captest.capdata.CapData.run_prep` is transactional across the whole
 batch, not just per step: if any step raises, ``data`` and the prep chain are
@@ -293,8 +300,8 @@ attached to the exception. A partially prepped frame is never left behind.
     :py:class:`~captest.capdata.CapData` rather than a path, a stored
     ``meas_prep`` / ``sim_prep`` config is kept but **not** applied — the
     object may already have been prepped, and prep is not idempotent. A
-    ``UserWarning`` names the skipped steps and the call that applies them:
-    ``tst.meas.run_prep(tst.meas_prep)``.
+    ``UserWarning`` reports how many steps were skipped and names the call
+    that applies them: ``tst.meas.run_prep(tst.meas_prep)``.
 
 Prep comes before filtering
 ---------------------------
@@ -408,10 +415,10 @@ and immediately replays that side's prep, before ``setup``:
     Columns E_Grid were scaled by 0.001 with an offset of 0.0.
 
 The same replay happens for :py:meth:`~captest.captest.CapTest.from_params`
-and :py:meth:`~captest.captest.CapTest.from_mapping` when a side is built from
-a path, and on every :py:meth:`~captest.captest.CapTest.reload` — including
-``run_setup=False`` construction. That is what makes a reload with a new file
-safe: the new data gets the same adjustments the old data had.
+and :py:meth:`~captest.captest.CapTest.from_mapping` whenever a side is built
+from a path, including under ``run_setup=False``, and on every
+:py:meth:`~captest.captest.CapTest.reload`. That is what makes a reload with a
+new file safe: the new data gets the same adjustments the old data had.
 
 A single :py:class:`~captest.capdata.CapData` can be round-tripped on its own
 with :py:meth:`~captest.capdata.CapData.prep_to_config` and
@@ -453,10 +460,15 @@ closure raises when the config is written, not when the step is run.
 
 ``custom_name`` is keyword-only on
 :py:meth:`~captest.capdata.CapData.prep_custom` so it cannot collide with an
-argument destined for ``func``; every other prep method accepts it too, as a
-display label in :py:meth:`~captest.capdata.CapData.describe_prep`.
+argument destined for ``func``. ``prep_convert_units``, ``prep_scale``, and
+``prep_astype`` accept it too, as a display label in
+:py:meth:`~captest.capdata.CapData.describe_prep`;
+:py:meth:`~captest.capdata.CapData.drop_cols` and
+:py:meth:`~captest.capdata.CapData.rename_cols` do not.
 
-The three-way column selector is optional for a custom step. When it is
-omitted, ``func`` decides which columns it touches; when it is given, it is
-resolved and validated exactly as for the other steps, which is a useful way
-to fail early if the columns are missing.
+A custom step takes no column selector. Every argument other than
+``custom_name`` is forwarded to ``func``, so
+``prep_custom(fn, columns=['a'])`` passes ``columns=['a']`` to ``fn`` rather
+than selecting columns, and the serialized step records it as one of ``func``'s
+keyword arguments. ``func`` decides for itself which columns it touches, and
+whatever validation of them matters is ``func``'s to do.

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -2,11 +2,9 @@
 
 Preparing Data
 ==============
-Measured and modeled data almost never arrive in the units and dtypes a
-capacity test needs. Thermocouples report degrees Fahrenheit, anemometers
-report miles per hour, and a PVsyst ``E_Grid`` column is in watts where the
-metered power is in kilowatts. The **prep stage** is where those adjustments
-are made.
+Measured and modeled data are sometimes not in the units and dtypes a capacity test
+needs. Or, a sensor may be oriented incorrectly and its measurements should be dropped
+before aggregation. The **prep stage** is where these types of adjustments can be made.
 
 Prep steps are declared, serialized, and replayed, exactly like filters. The
 difference is what they do: a filter selects rows and leaves the values alone,
@@ -248,8 +246,7 @@ That option exists for **internal callers** inside the library — for example
 :py:meth:`~captest.capdata.CapData.agg_sensors`, which renames the aggregate
 columns it creates and must not put that rename into the user's prep chain,
 because replaying it on the next load would name columns that do not yet
-exist. A test scans the package source to make sure every internal call site
-passes ``record=False`` explicitly. As a user, leave ``record`` alone.
+exist. As a user, leave ``record`` alone.
 
 .. _prep-once-per-load:
 
@@ -438,8 +435,7 @@ with :py:meth:`~captest.capdata.CapData.prep_to_config` and
 Custom prep steps
 -----------------
 :py:meth:`~captest.capdata.CapData.prep_custom` is the escape hatch for
-adjustments the declarative vocabulary does not cover — blanking east-facing
-POA columns before sunrise, say, or any site-specific repair. The callable
+adjustments the declarative vocabulary does not cover. The callable
 receives the :py:class:`~captest.capdata.CapData` as its first argument and
 mutates ``data`` in place; its return value is ignored.
 

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -98,8 +98,8 @@ what was applied:
     Columns met1_mod_temp1, met1_mod_temp2, met2_mod_temp1, met2_mod_temp2, met1_amb_temp, met2_amb_temp were converted from F to C.
     Columns met1_windspeed, met2_windspeed were converted from mph to m/s.
 
-Every step is atomic. If a step raises, ``data`` is restored to its
-pre-step state and nothing is appended to
+Every step is atomic. If a step raises, ``data`` and ``column_groups`` are
+restored to their pre-step state and nothing is appended to
 :py:attr:`~captest.capdata.CapData.prep`, so a failed step is a no-op rather
 than a half-applied change.
 
@@ -264,8 +264,10 @@ Three consequences follow:
 
 - ``prep_convert_units``, ``prep_scale``, and ``prep_astype`` raise a
   ``RuntimeError`` when a step equal to one already applied — same type, same
-  arguments — is run again. Two *different* conversions of the same columns
-  are allowed; it is the exact repeat that is refused.
+  arguments, ``custom_name`` aside — is run again. Two *different* conversions
+  of the same columns are allowed; it is the exact repeat that is refused.
+  The check compares the selector as written, so the same column reached two
+  ways (``columns=["poa_1"]`` and ``group="poa"``) is not caught.
 - :py:meth:`~captest.capdata.CapData.run_prep` refuses to replay a config onto
   a :py:class:`~captest.capdata.CapData` whose prep chain is already
   populated.
@@ -290,9 +292,10 @@ Three consequences follow:
   want.
 
 :py:meth:`~captest.capdata.CapData.run_prep` is transactional across the whole
-batch, not just per step: if any step raises, ``data`` and the prep chain are
-restored to their state before the call and a note naming the failing step is
-attached to the exception. A partially prepped frame is never left behind.
+batch, not just per step: if any step raises, ``data``, ``column_groups``, and
+the prep chain are restored to their state before the call and a note naming
+the failing step is attached to the exception. A partially prepped frame is
+never left behind.
 
 .. note::
 

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -96,6 +96,17 @@ what was applied:
     Columns met1_mod_temp1, met1_mod_temp2, met2_mod_temp1, met2_mod_temp2, met1_amb_temp, met2_amb_temp were converted from F to C.
     Columns met1_windspeed, met2_windspeed were converted from mph to m/s.
 
+A step that touches more than ten columns lists the first and last three with
+the total count, the same way
+:py:meth:`~captest.capdata.CapData.agg_group` truncates its verbose output.
+Error messages that name columns or column groups truncate the same way. The
+truncation is display-only — the step's ``columns_resolved`` attribute always
+holds every resolved column name:
+
+.. code-block:: text
+
+    Columns temp_0, temp_1, temp_2, ..., temp_22, temp_23, temp_24 (25 total) were converted from F to C.
+
 Every step is atomic. If a step raises, ``data`` and ``column_groups`` are
 restored to their pre-step state and nothing is appended to
 :py:attr:`~captest.capdata.CapData.prep`, so a failed step is a no-op rather

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -270,12 +270,15 @@ equivalent reset, because ``data`` is the only copy.
 
 Three consequences follow:
 
-- ``prep_convert_units``, ``prep_scale``, and ``prep_astype`` raise a
-  ``RuntimeError`` when a step equal to one already applied — same type, same
-  arguments, ``custom_name`` aside — is run again. Two *different* conversions
-  of the same columns are allowed; it is the exact repeat that is refused.
-  The check compares the selector as written, so the same column reached two
-  ways (``columns=["poa_1"]`` and ``group="poa"``) is not caught.
+- A step raises a ``RuntimeError`` when an applied step of the same type, with
+  the same settings (``custom_name`` aside), already touched any of the
+  columns it resolves to. The comparison is on the **resolved columns**, not
+  on the selector as written, so the same column reached two ways
+  (``columns=["poa_1"]`` and then ``group="poa"``) is caught, as is a partial
+  re-selection (``columns=["a", "b"]`` and then ``columns=["b", "c"]``). Two
+  *different* conversions of the same column are allowed — an °F-to-°C step
+  followed by °C-to-°F is a deliberate round trip. ``prep_custom`` is exempt:
+  what the callable does is opaque, so a repeat may well be intended.
 - :py:meth:`~captest.capdata.CapData.run_prep` refuses to replay a config onto
   a :py:class:`~captest.capdata.CapData` whose prep chain is already
   populated.

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -1,0 +1,462 @@
+.. _data_prep:
+
+Preparing Data
+==============
+Measured and modeled data almost never arrive in the units and dtypes a
+capacity test needs. Thermocouples report degrees Fahrenheit, anemometers
+report miles per hour, and a PVsyst ``E_Grid`` column is in watts where the
+metered power is in kilowatts. The **prep stage** is where those adjustments
+are made.
+
+Prep steps are declared, serialized, and replayed, exactly like filters. The
+difference is what they do: a filter selects rows and leaves the values alone,
+while a prep step rewrites values (or column identity) in
+:py:attr:`~captest.capdata.CapData.data` in place. Each step that runs is
+appended to the :py:attr:`~captest.capdata.CapData.prep` list, is written to
+the test config by :py:meth:`~captest.captest.CapTest.to_yaml`, and is
+re-applied automatically the next time the data is loaded.
+
+Where prep sits in the lifecycle
+--------------------------------
+The lifecycle of a test is:
+
+**load → prep → setup → filter**
+
+Prep runs after the data is loaded and before
+:py:meth:`~captest.captest.CapTest.setup`. That ordering is deliberate:
+``setup`` resolves regression columns and calculates derived parameters (cell
+temperature, spectral corrections) from the values in ``data``, so the values
+must already be in the units those calculations assume. Filtering comes last,
+because every filter threshold is evaluated against prepped values.
+
+The prep stage is the only place a data adjustment is *recorded*. Editing
+``cd.data`` directly in a notebook still works and always has, but nothing
+captures that it happened: the exported yaml does not show it, and
+:py:meth:`~captest.captest.CapTest.reload` re-invokes the loader and silently
+discards it. A reviewer reading an exported config can see a recorded prep
+step; they cannot see a hand-edit.
+
+Prep is not reported by :py:meth:`~captest.capdata.CapData.get_summary` or
+:py:meth:`~captest.capdata.CapData.describe_filters`. Those report point
+counts, and prep removes no points. Use
+:py:meth:`~captest.capdata.CapData.describe_prep` interactively and the
+``meas_prep`` / ``sim_prep`` block of the config as the durable record.
+
+The prep methods
+----------------
+:py:class:`~captest.capdata.CapData` provides four prep wrappers, each of
+which builds a step from :py:mod:`captest.prep`, runs it against ``data``, and
+appends it to :py:attr:`~captest.capdata.CapData.prep`:
+
+- :py:meth:`~captest.capdata.CapData.prep_convert_units` — convert between
+  units from a supported table.
+- :py:meth:`~captest.capdata.CapData.prep_scale` — apply
+  ``value * factor + offset``.
+- :py:meth:`~captest.capdata.CapData.prep_astype` — cast columns to a dtype.
+- :py:meth:`~captest.capdata.CapData.prep_custom` — run an arbitrary callable.
+
+A typical measured side needs the temperatures and the wind speed converted,
+and a PVsyst side needs its power column rescaled:
+
+.. code-block:: Python
+
+    import captest as ct
+
+    das = ct.load_data('./data/')
+    das.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    das.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
+
+    sim = ct.load_pvsyst('./pvsyst/VC1_HourlyRes_1.CSV')
+    sim.prep_scale(columns=['E_Grid'], factor=0.001)
+
+Within a :py:class:`~captest.captest.CapTest`, load the data without running
+``setup``, prep each side, then call
+:py:meth:`~captest.captest.CapTest.setup`:
+
+.. code-block:: Python
+
+    tst = ct.CapTest.from_params(
+        test_setup='e2848_default',
+        meas_path='./data/',
+        sim_path='./pvsyst/VC1_HourlyRes_1.CSV',
+        run_setup=False,
+    )
+    tst.meas.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    tst.meas.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
+    tst.sim.prep_scale(columns=['E_Grid'], factor=0.001)
+    tst.setup()
+
+:py:meth:`~captest.capdata.CapData.describe_prep` returns a written summary of
+what was applied:
+
+.. code-block:: Python
+
+    print(tst.meas.describe_prep())
+
+.. code-block:: text
+
+    Columns met1_mod_temp1, met1_mod_temp2, met2_mod_temp1, met2_mod_temp2, met1_amb_temp, met2_amb_temp were converted from F to C.
+    Columns met1_windspeed, met2_windspeed were converted from mph to m/s.
+
+Every step is atomic. If a step raises, ``data`` is restored to its
+pre-step state and nothing is appended to
+:py:attr:`~captest.capdata.CapData.prep`, so a failed step is a no-op rather
+than a half-applied change.
+
+.. _prep-selectors:
+
+Selecting columns
+-----------------
+``prep_convert_units``, ``prep_scale``, and ``prep_astype`` take exactly one
+of three column selectors:
+
+``columns``
+    An explicit list of column names, acted on in the order given.
+
+``group``
+    A :py:attr:`~captest.capdata.CapData.column_groups` id, or a list of ids.
+
+``group_regex``
+    A regular expression matched against the ``column_groups`` ids. For
+    example ``'^temp'`` reaches ``temp_amb``, ``temp_bom``, and ``temp_mod``
+    in a single step.
+
+The group selectors expand to column names in ``column_groups`` order, with
+duplicates removed. Passing more than one selector, or none, is an error:
+
+.. code-block:: Python
+
+    das.prep_scale(factor=0.001)
+    # ValueError: Scale requires exactly one of 'columns', 'group', or
+    # 'group_regex'; got none.
+
+Selectors are resolved **at run time**, not when the step is constructed. A
+step that runs after an earlier drop or rename sees the current columns, which
+is what makes a recorded chain replay correctly: a rename recorded before a
+conversion is replayed first, and the conversion resolves against the new
+names.
+
+A selector that resolves to zero columns is always an error rather than a
+silent no-op, and the messages name what is available:
+
+.. code-block:: Python
+
+    das.prep_convert_units(group='temp_ambient', from_units='F', to_units='C')
+    # ValueError: Column group 'temp_ambient' is not in column_groups.
+    # Available ids: [...]. Did you mean 'temp_amb'?
+
+The remaining steps select differently:
+:py:meth:`~captest.capdata.CapData.drop_cols` takes its column names directly,
+:py:meth:`~captest.capdata.CapData.rename_cols` takes them from the keys of
+its ``column_map``, and the selector is optional for
+:py:meth:`~captest.capdata.CapData.prep_custom` (see
+`Custom prep steps`_).
+
+Converting units
+----------------
+:py:meth:`~captest.capdata.CapData.prep_convert_units` applies an affine
+conversion, ``value * factor + offset``, to the selected columns and writes
+the result back to the same column names. The supported pairs are:
+
+.. list-table::
+   :header-rows: 1
+
+   * - From
+     - To
+   * - ``F``
+     - ``C``
+   * - ``K``
+     - ``C``
+   * - ``mph``
+     - ``m/s``
+   * - ``km/h``
+     - ``m/s``
+   * - ``kn``
+     - ``m/s``
+   * - ``ft/s``
+     - ``m/s``
+   * - ``W``
+     - ``kW``
+   * - ``MW``
+     - ``kW``
+   * - ``mbar``
+     - ``Pa``
+   * - ``m``
+     - ``cm``
+   * - ``in``
+     - ``cm``
+
+Only the forward direction is tabulated; the **inverse of every pair is
+derived automatically**, so ``from_units='C', to_units='F'`` works without a
+second table entry. Unit names are normalized case-insensitively through a
+table of aliases, so ``'degF'``, ``'fahrenheit'``, and ``'F'`` are the same
+unit, as are ``'kph'`` and ``'km/h'``, or ``'knots'`` and ``'kn'``.
+
+Requesting a pair that is not supported in either direction raises and lists
+what is:
+
+.. code-block:: Python
+
+    das.prep_convert_units(columns=['irr_poa_1'], from_units='W/m2', to_units='kW/m2')
+    # ValueError: No conversion from 'W/m2' to 'kW/m2'. Inverses of the
+    # supported pairs are derived automatically; supported pairs: [...].
+    # Use Scale(factor=..., offset=...) for anything else.
+
+Anything the table does not cover is expressed directly with
+:py:meth:`~captest.capdata.CapData.prep_scale`, which is the raw-numbers
+escape hatch:
+
+.. code-block:: Python
+
+    sim.prep_scale(columns=['E_Grid'], factor=0.001)
+    das.prep_scale(group='irr_poa', factor=1000)
+
+.. note::
+
+    A unit conversion is an *asserted* transformation, not a checked one.
+    Nothing on :py:class:`~captest.capdata.CapData` tracks the current units
+    of a column, and no unit is inferred from a column name. Converting a
+    column that is already in the target units will silently produce wrong
+    values, which is why an identical repeat of a step is refused (see
+    :ref:`prep-once-per-load`).
+
+Both :py:meth:`~captest.capdata.CapData.prep_convert_units` and
+:py:meth:`~captest.capdata.CapData.prep_scale` require numeric columns and
+raise a ``TypeError`` naming the first offender otherwise. A frame that loaded
+as ``object`` — a PVsyst export with a stray index column is the usual cause —
+is fixed with :py:meth:`~captest.capdata.CapData.prep_astype` first:
+
+.. code-block:: Python
+
+    sim.drop_cols(['index'])
+    sim.prep_astype(columns=['E_Grid'], dtype='float64')
+
+Dropping and renaming columns
+-----------------------------
+:py:meth:`~captest.capdata.CapData.drop_cols` and
+:py:meth:`~captest.capdata.CapData.rename_cols` keep the names and signatures
+they have always had, and now record a prep step by default. There are no
+separate ``prep_drop_columns`` / ``prep_rename_columns`` methods:
+
+.. code-block:: Python
+
+    sim.drop_cols(['index'])
+    das.rename_cols({'met1_poa_pyran': 'irr_poa_met1'})
+
+Both accept ``record=False``, which performs the change without recording it.
+That option exists for **internal callers** inside the library — for example
+:py:meth:`~captest.capdata.CapData.agg_sensors`, which renames the aggregate
+columns it creates and must not put that rename into the user's prep chain,
+because replaying it on the next load would name columns that do not yet
+exist. A test scans the package source to make sure every internal call site
+passes ``record=False`` explicitly. As a user, leave ``record`` alone.
+
+.. _prep-once-per-load:
+
+Prep runs once per load
+-----------------------
+Prep steps mutate ``data``, so they are **not idempotent**: converting °F to
+°C twice is silently wrong rather than loudly broken. Filters do not have this
+problem because replaying a pipeline resets the chain first; prep has no
+equivalent reset, because ``data`` is the only copy.
+
+Three consequences follow:
+
+- ``prep_convert_units``, ``prep_scale``, and ``prep_astype`` raise a
+  ``RuntimeError`` when a step equal to one already applied — same type, same
+  arguments — is run again. Two *different* conversions of the same columns
+  are allowed; it is the exact repeat that is refused.
+- :py:meth:`~captest.capdata.CapData.run_prep` refuses to replay a config onto
+  a :py:class:`~captest.capdata.CapData` whose prep chain is already
+  populated.
+- There is no ``reset_prep()``. Nothing can undo a mutation, so re-prepping
+  means going back to raw data with
+  :py:meth:`~captest.captest.CapTest.reload`:
+
+  .. code-block:: Python
+
+      tst.reload('sim')
+
+  ``reload`` snapshots the outgoing side's applied prep chain into
+  ``sim_prep``, loads a fresh un-prepped frame from the stored path, replays
+  the prep, and then runs ``setup`` for that side. To change the prep, edit
+  ``tst.sim_prep`` before reloading.
+
+:py:meth:`~captest.capdata.CapData.run_prep` is transactional across the whole
+batch, not just per step: if any step raises, ``data`` and the prep chain are
+restored to their state before the call and a note naming the failing step is
+attached to the exception. A partially prepped frame is never left behind.
+
+.. note::
+
+    When a :py:class:`~captest.captest.CapTest` is built from a *pre-built*
+    :py:class:`~captest.capdata.CapData` rather than a path, a stored
+    ``meas_prep`` / ``sim_prep`` config is kept but **not** applied — the
+    object may already have been prepped, and prep is not idempotent. A
+    ``UserWarning`` names the skipped steps and the call that applies them:
+    ``tst.meas.run_prep(tst.meas_prep)``.
+
+Prep comes before filtering
+---------------------------
+A filter that has already run was evaluated against un-prepped values, so
+rewriting those values afterwards produces wrong numbers rather than a crash.
+Prep steps that rewrite values refuse to run once filters are applied:
+
+.. code-block:: Python
+
+    das.filter_irr(200, 950)
+    das.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
+    # RuntimeError: Cannot run ConvertUnits after filtering — 1 filters are
+    # already applied and were evaluated against un-prepped values. Call
+    # cd.reset_filter() first, or reload this side.
+
+The recovery is :py:meth:`~captest.capdata.CapData.reset_filter`, which clears
+the filter chain and leaves the prep chain intact:
+
+.. code-block:: Python
+
+    das.reset_filter()
+    das.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
+
+Column drops and renames are exempt. They change column identity rather than
+values, so :py:meth:`~captest.capdata.CapData.drop_cols` and
+:py:meth:`~captest.capdata.CapData.rename_cols` stay legal after filtering.
+
+Prep before aggregating sensors
+-------------------------------
+:py:meth:`~captest.capdata.CapData.agg_sensors` combines a group of sensors
+into one representative column — typically the mean of several thermocouples
+or pyranometers. Averaging across columns that are in *different* units
+produces a meaningless number, and no error is raised, because nothing tracks
+the units of a column.
+
+This matters in practice because ``agg_sensors`` is often called by hand after
+``setup``, while prep runs before it. Convert units in the prep stage, before
+aggregating:
+
+.. code-block:: Python
+
+    tst.meas.prep_convert_units(group='temp_bom', from_units='F', to_units='C')
+    tst.setup()
+    tst.meas.agg_sensors()
+
+If one met station reports °F and another °C, convert the °F columns
+explicitly by name — a per-column ``columns=[...]`` selector — before the two
+groups are aggregated together.
+
+Prep in the config file
+-----------------------
+:py:meth:`~captest.captest.CapTest.to_yaml` writes the applied prep chain for
+each side under the ``meas_prep`` and ``sim_prep`` keys, alongside the
+``meas_filters`` / ``sim_filters`` pipelines described in
+:ref:`reproducing-a-test`. The keys are omitted entirely when a side has no
+prep.
+
+.. code-block:: yaml
+
+    captest:
+      test_setup: e2848_default
+      meas_path: ./data/
+      sim_path: ./pvsyst/VC1_HourlyRes_1.CSV
+      # ... test settings ...
+      meas_prep:
+      - type: ConvertUnits
+        columns: null
+        custom_name: null
+        from_units: F
+        group: null
+        group_regex: ^temp
+        to_units: C
+      - type: ConvertUnits
+        columns: null
+        custom_name: null
+        from_units: mph
+        group: wind
+        group_regex: null
+        to_units: m/s
+      sim_prep:
+      - type: DropColumns
+        columns:
+        - index
+        custom_name: null
+        group: null
+        group_regex: null
+      - type: Scale
+        columns:
+        - E_Grid
+        custom_name: null
+        factor: 0.001
+        group: null
+        group_regex: null
+        offset: 0.0
+      meas_filters:
+      # ...
+
+Unlike the filter pipelines, which are stored as *pending* and replayed by
+:py:meth:`~captest.captest.CapTest.run_test`, prep is applied **at load**.
+:py:meth:`~captest.captest.CapTest.from_yaml` loads each side from its path
+and immediately replays that side's prep, before ``setup``:
+
+.. code-block:: Python
+
+    tst = ct.CapTest.from_yaml('./project.yaml')
+    print(tst.sim.describe_prep())
+
+.. code-block:: text
+
+    Columns index were dropped.
+    Columns E_Grid were scaled by 0.001 with an offset of 0.0.
+
+The same replay happens for :py:meth:`~captest.captest.CapTest.from_params`
+and :py:meth:`~captest.captest.CapTest.from_mapping` when a side is built from
+a path, and on every :py:meth:`~captest.captest.CapTest.reload` — including
+``run_setup=False`` construction. That is what makes a reload with a new file
+safe: the new data gets the same adjustments the old data had.
+
+A single :py:class:`~captest.capdata.CapData` can be round-tripped on its own
+with :py:meth:`~captest.capdata.CapData.prep_to_config` and
+:py:meth:`~captest.capdata.CapData.run_prep`, which mirror
+:py:meth:`~captest.capdata.CapData.filters_to_config` and
+:py:meth:`~captest.capdata.CapData.run_pipeline`:
+
+.. code-block:: Python
+
+    config = das.prep_to_config()
+    fresh = ct.load_data('./data/')
+    fresh.run_prep(config)
+
+Custom prep steps
+-----------------
+:py:meth:`~captest.capdata.CapData.prep_custom` is the escape hatch for
+adjustments the declarative vocabulary does not cover — blanking east-facing
+POA columns before sunrise, say, or any site-specific repair. The callable
+receives the :py:class:`~captest.capdata.CapData` as its first argument and
+mutates ``data`` in place; its return value is ignored.
+
+.. code-block:: Python
+
+    # in project_prep.py
+    def blank_before_sunrise(cd, columns, hour):
+        mask = cd.data.index.hour < hour
+        cd.data.loc[mask, columns] = float('nan')
+
+.. code-block:: Python
+
+    from project_prep import blank_before_sunrise
+
+    das.prep_custom(blank_before_sunrise, ['met1_poa_east'], 7)
+
+``func`` serializes as a module-qualified name, so it **must be a
+module-level function** that can be imported when the config is replayed — the
+same constraint that applies to a custom filter. A lambda or a locally defined
+closure raises when the config is written, not when the step is run.
+
+``custom_name`` is keyword-only on
+:py:meth:`~captest.capdata.CapData.prep_custom` so it cannot collide with an
+argument destined for ``func``; every other prep method accepts it too, as a
+display label in :py:meth:`~captest.capdata.CapData.describe_prep`.
+
+The three-way column selector is optional for a custom step. When it is
+omitted, ``func`` decides which columns it touches; when it is given, it is
+resolved and validated exactly as for the other steps, which is a useful way
+to fail early if the columns are missing.

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -61,7 +61,9 @@ and a PVsyst side needs its power column rescaled:
     import captest as ct
 
     das = ct.load_data('./data/')
-    das.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    das.prep_convert_units(
+        group_regex='^temp_(amb|bom)$', from_units='F', to_units='C'
+    )
     das.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
 
     sim = ct.load_pvsyst('./pvsyst/VC1_HourlyRes_1.CSV')
@@ -79,7 +81,9 @@ Within a :py:class:`~captest.captest.CapTest`, load the data without running
         sim_path='./pvsyst/VC1_HourlyRes_1.CSV',
         run_setup=False,
     )
-    tst.meas.prep_convert_units(group_regex='^temp', from_units='F', to_units='C')
+    tst.meas.prep_convert_units(
+        group_regex='^temp_(amb|bom)$', from_units='F', to_units='C'
+    )
     tst.meas.prep_convert_units(group='wind', from_units='mph', to_units='m/s')
     tst.sim.prep_scale(columns=['E_Grid'], factor=0.001)
     tst.setup()
@@ -127,8 +131,22 @@ of three column selectors:
 
 ``group_regex``
     A regular expression matched against the ``column_groups`` ids. For
-    example ``'^temp'`` reaches ``temp_amb``, ``temp_bom``, and ``temp_mod``
-    in a single step.
+    example ``'^temp_(amb|bom)$'`` reaches ``temp_amb`` and ``temp_bom`` in a
+    single step.
+
+    Anchor the pattern at both ends and name the groups you mean. A loose
+    ``'^temp'`` also matches ``temp_inv`` and ``temp_inv_pcs`` — inverter
+    temperatures, which are not ambient or back-of-module readings and should
+    not be converted alongside them. It is worse than a wrong answer on a
+    project-level ``column_groups`` reused across loads: those inverter groups
+    routinely name columns that are not in the loaded frame, and the step
+    raises rather than silently converting the wrong thing. Check what a
+    pattern reaches before relying on it:
+
+    .. code-block:: Python
+
+        import re
+        [gid for gid in das.column_groups if re.search('^temp_(amb|bom)$', gid)]
 
 The group selectors expand to column names in ``column_groups`` order, with
 duplicates removed. Passing more than one selector, or none, is an error:
@@ -386,7 +404,7 @@ prep.
         custom_name: null
         from_units: F
         group: null
-        group_regex: ^temp
+        group_regex: ^temp_(amb|bom)$
         to_units: C
       - type: ConvertUnits
         columns: null

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -9,5 +9,6 @@ User Guide
     reporting_conditions
     saving_reproducing
     dataload
+    data_prep
     custom_test_setups
     bifacial

--- a/src/captest/calcparams.py
+++ b/src/captest/calcparams.py
@@ -529,9 +529,17 @@ def precipitable_water_gueymard(data, temp_amb=None, rel_humidity=None, verbose=
 def scale(data, col=None, factor=1.0, verbose=True):
     """Multiply a single column by a scalar factor.
 
-    Generic unit-conversion / rescaling helper usable in
-    ``regression_cols`` calc trees. Primary use in this module is converting
-    PVsyst ``PrecWat`` from meters to centimeters with ``factor=100``.
+    Produces a **single new column named ``scale``** for use inside a
+    ``regression_cols`` calc tree; the primary use in this module is
+    converting PVsyst ``PrecWat`` from meters to centimeters with
+    ``factor=100``. A second ``custom_param`` call overwrites the first, and
+    the result never writes back to the source column.
+
+    This is not a bulk column-rewriting tool. To rescale existing columns in
+    place — a whole group of thermocouples, or ``E_Grid`` from W to kW — use
+    the prep stage: :py:meth:`~captest.capdata.CapData.prep_scale` /
+    :py:meth:`~captest.capdata.CapData.prep_convert_units`, which run before
+    ``setup()`` and serialize into the test config.
 
     Parameters
     ----------

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2341,8 +2341,10 @@ class CapData(param.Parameterized):
         group : str or list of str, optional
             ``column_groups`` id, or list of ids.
         group_regex : str, optional
-            Regex matched against ``column_groups`` ids, e.g. ``"^temp"`` to
-            reach ``temp_amb``, ``temp_bom``, and ``temp_mod`` at once.
+            Regex matched against ``column_groups`` ids, e.g.
+            ``"^temp_(amb|bom)$"`` to reach ``temp_amb`` and ``temp_bom`` at
+            once. Anchor the pattern: a loose ``"^temp"`` also matches
+            inverter-temperature groups such as ``temp_inv``.
         from_units, to_units : str
             Source and target units; see :data:`captest.prep.UNIT_CONVERSIONS`.
         custom_name : str, optional

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2348,15 +2348,13 @@ class CapData(param.Parameterized):
         custom_name : str, optional
             Display label for the recorded step.
         """
-        self._check_duplicate_prep(
-            prep.ConvertUnits(
-                columns=columns,
-                group=group,
-                group_regex=group_regex,
-                from_units=from_units,
-                to_units=to_units,
-                custom_name=custom_name,
-            )
+        prep.ConvertUnits(
+            columns=columns,
+            group=group,
+            group_regex=group_regex,
+            from_units=from_units,
+            to_units=to_units,
+            custom_name=custom_name,
         ).run(self)
 
     def prep_scale(
@@ -2382,15 +2380,13 @@ class CapData(param.Parameterized):
         custom_name : str, optional
             Display label for the recorded step.
         """
-        self._check_duplicate_prep(
-            prep.Scale(
-                columns=columns,
-                group=group,
-                group_regex=group_regex,
-                factor=factor,
-                offset=offset,
-                custom_name=custom_name,
-            )
+        prep.Scale(
+            columns=columns,
+            group=group,
+            group_regex=group_regex,
+            factor=factor,
+            offset=offset,
+            custom_name=custom_name,
         ).run(self)
 
     def prep_astype(
@@ -2413,14 +2409,12 @@ class CapData(param.Parameterized):
         custom_name : str, optional
             Display label for the recorded step.
         """
-        self._check_duplicate_prep(
-            prep.AsType(
-                columns=columns,
-                group=group,
-                group_regex=group_regex,
-                dtype=dtype,
-                custom_name=custom_name,
-            )
+        prep.AsType(
+            columns=columns,
+            group=group,
+            group_regex=group_regex,
+            dtype=dtype,
+            custom_name=custom_name,
         ).run(self)
 
     def prep_custom(self, func, *args, custom_name=None, **kwargs):
@@ -2439,55 +2433,6 @@ class CapData(param.Parameterized):
             collide with arguments destined for ``func``.
         """
         prep.Custom(func, *args, custom_name=custom_name, **kwargs).run(self)
-
-    def _check_duplicate_prep(self, step):
-        """Return ``step``, raising if an equal step is already applied.
-
-        Prep mutates ``data`` and is not idempotent — converting °F to °C
-        twice is silently wrong — so an identical step is refused. Equality is
-        on the serialized config with ``custom_name`` excluded: the label is
-        presentation, so re-running the same scale under a second label is
-        still a double scale.
-
-        The check is deliberately shallow — it compares the selector *as
-        written*, not the columns it resolves to. Two steps that select the
-        same column by different routes (``columns=["poa_1"]`` and
-        ``group="poa"`` when the group holds only ``poa_1``) are therefore not
-        detected and will both apply. Resolution happens at ``run`` time
-        against data an earlier step may have reshaped, so a selector-level
-        comparison is the only one available before the step runs.
-
-        Parameters
-        ----------
-        step : BasePrepStep
-            Step about to be run.
-
-        Returns
-        -------
-        BasePrepStep
-            ``step``, unchanged, so callers can chain into ``run``.
-
-        Raises
-        ------
-        RuntimeError
-            If an equal step is already in ``self.prep``.
-        """
-
-        def comparable(prep_step):
-            return {
-                key: value
-                for key, value in prep_step.to_config().items()
-                if key != "custom_name"
-            }
-
-        config = comparable(step)
-        if any(comparable(applied) == config for applied in self.prep):
-            raise RuntimeError(
-                f"An equal {type(step).__name__} prep step is already applied. "
-                "Prep steps mutate `data` and are not idempotent; re-prep by "
-                "reloading this dataset."
-            )
-        return step
 
     def prep_to_config(self):
         """Serialize the applied prep chain to a list of config dicts.

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -910,6 +910,11 @@ class CapData(param.Parameterized):
         cd_c.column_groups = copy.deepcopy(self.column_groups)
         cd_c.regression_cols = copy.copy(self.regression_cols)
         cd_c.filters = copy.deepcopy(self.filters)
+        # `data` is copied post-prep, so the chain that produced those values
+        # has to come with it: dropping it would let the copy serialize to a
+        # config that reproduces different data, and would let `run_prep` pass
+        # its empty-chain guard and prep the same values twice.
+        cd_c.prep = copy.deepcopy(self.prep)
         cd_c.rc = copy.copy(self.rc)
         cd_c.regression_results = copy.deepcopy(self.regression_results)
         cd_c.regression_formula = copy.copy(self.regression_formula)
@@ -2440,10 +2445,43 @@ class CapData(param.Parameterized):
 
         Prep mutates ``data`` and is not idempotent — converting °F to °C
         twice is silently wrong — so an identical step is refused. Equality is
-        on the serialized config, i.e. same type and same params.
+        on the serialized config with ``custom_name`` excluded: the label is
+        presentation, so re-running the same scale under a second label is
+        still a double scale.
+
+        The check is deliberately shallow — it compares the selector *as
+        written*, not the columns it resolves to. Two steps that select the
+        same column by different routes (``columns=["poa_1"]`` and
+        ``group="poa"`` when the group holds only ``poa_1``) are therefore not
+        detected and will both apply. Resolution happens at ``run`` time
+        against data an earlier step may have reshaped, so a selector-level
+        comparison is the only one available before the step runs.
+
+        Parameters
+        ----------
+        step : BasePrepStep
+            Step about to be run.
+
+        Returns
+        -------
+        BasePrepStep
+            ``step``, unchanged, so callers can chain into ``run``.
+
+        Raises
+        ------
+        RuntimeError
+            If an equal step is already in ``self.prep``.
         """
-        config = step.to_config()
-        if any(applied.to_config() == config for applied in self.prep):
+
+        def comparable(prep_step):
+            return {
+                key: value
+                for key, value in prep_step.to_config().items()
+                if key != "custom_name"
+            }
+
+        config = comparable(step)
+        if any(comparable(applied) == config for applied in self.prep):
             raise RuntimeError(
                 f"An equal {type(step).__name__} prep step is already applied. "
                 "Prep steps mutate `data` and are not idempotent; re-prep by "
@@ -2467,12 +2505,16 @@ class CapData(param.Parameterized):
         :meth:`prep_to_config` or a loaded YAML). Each step is constructed via
         ``prep.prep_step_from_config`` and run against this CapData in order.
 
-        The replay is a transaction across the whole batch: ``data`` is
-        snapshotted before the first step and restored — with every step this
-        call appended discarded — if any step raises, with a note naming the
-        failing step attached to the exception (Python 3.11+). Per-step
-        atomicity alone would leave earlier steps applied, which is a
-        half-prepped frame the caller could neither safely retry nor measure.
+        The replay is a transaction across the whole batch: ``data`` and
+        ``column_groups`` are snapshotted before the first step and both are
+        restored — with every step this call appended discarded — if any step
+        raises, with a note naming the failing step attached to the exception
+        (Python 3.11+). Per-step atomicity alone would leave earlier steps
+        applied, which is a half-prepped frame the caller could neither safely
+        retry nor measure. ``column_groups`` is in the snapshot because
+        ``DropColumns`` and ``RenameColumns`` rewrite it alongside ``data``,
+        and a rollback that misses it leaves group ids pointing at columns
+        that no longer match ``data`` — wrong silently rather than loudly.
 
         Parameters
         ----------
@@ -2493,7 +2535,7 @@ class CapData(param.Parameterized):
                 "mutates `data` and is not idempotent — reload this dataset "
                 "(CapTest.reload(side)) to re-prep from raw data."
             )
-        snapshot = self.data.copy()
+        snapshot = prep.snapshot_prep_state(self)
         prior_prep = self.prep
         step_label = "?"
         try:
@@ -2501,7 +2543,7 @@ class CapData(param.Parameterized):
                 step_label = f"{i} ({step_config.get('type', '?')})"
                 prep.prep_step_from_config(step_config).run(self)
         except Exception as e:
-            self.data = snapshot
+            prep.restore_prep_state(self, snapshot)
             self.prep = prior_prep
             if hasattr(e, "add_note"):
                 e.add_note(f"Raised while running prep step {step_label}.")

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -23,7 +23,7 @@ import param
 from bokeh.models import HoverTool, NumeralTickFormatter
 from patsy import dmatrix
 
-from captest import plotting, util
+from captest import plotting, prep, util
 from captest.filters import (
     AbsDiffPrev,
     Backtracking,
@@ -960,7 +960,7 @@ class CapData(param.Parameterized):
             )
         return float(rc["poa"].iloc[0])
 
-    def drop_cols(self, columns):
+    def drop_cols(self, columns, record=True):
         """
         Drop columns from CapData `data` and `column_groups`.
 
@@ -971,9 +971,17 @@ class CapData(param.Parameterized):
         ----------
         columns : str or list
             Column name or list of column names to drop.
+        record : bool, default True
+            Append a ``DropColumns`` prep step so the drop is serialized to
+            the config and replayed after a reload. **Internal callers must
+            pass ``record=False``** so library-generated column changes do not
+            enter the user's prep chain; a source-scan test enforces this.
         """
         if isinstance(columns, str):
             columns = [columns]
+        if record:
+            prep.DropColumns(columns=list(columns)).run(self)
+            return
         for col in columns:
             print(f"Removing following column: {col}")
             for key, value in self.column_groups.items():
@@ -986,7 +994,7 @@ class CapData(param.Parameterized):
             self.data.drop(col, axis=1, inplace=True)
             print("    Dropped from data attribute")
 
-    def rename_cols(self, column_map):
+    def rename_cols(self, column_map, record=True):
         """
         Rename columns in `data` and `column_groups`.
 
@@ -997,7 +1005,14 @@ class CapData(param.Parameterized):
         ----------
         column_map : dict
             Dictionary mapping old column names to new column names.
+        record : bool, default True
+            Append a ``RenameColumns`` prep step so the rename is serialized
+            to the config and replayed after a reload. **Internal callers must
+            pass ``record=False``**; a source-scan test enforces this.
         """
+        if record:
+            prep.RenameColumns(column_map=dict(column_map)).run(self)
+            return
         self.data.rename(columns=column_map, inplace=True)
         for key, value in self.column_groups.items():
             self.column_groups[key] = [column_map.get(col, col) for col in value]
@@ -1657,7 +1672,7 @@ class CapData(param.Parameterized):
             self.data = pd.concat([agg_result, self.data], axis=1)
             agg_names[group_id] = col_name
         self.filters = []
-        self.rename_cols(rename_map)
+        self.rename_cols(rename_map, record=False)
         self.agg_name_mapper = agg_names
         self.create_column_group_attributes()
         self.create_agg_attributes()

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -50,6 +50,7 @@ from captest.filters import (
     step_from_config,
     wrap_year_end,
 )
+from captest.prep import BasePrepStep
 
 # visualization library imports
 hv_spec = importlib.util.find_spec("holoviews")
@@ -788,6 +789,12 @@ class CapData(param.Parameterized):
         default=[],
         item_type=BaseSummaryStep,
         doc="Ordered pipeline of filter/summary steps applied to the data.",
+    )
+
+    prep = param.List(
+        default=[],
+        item_type=BasePrepStep,
+        doc="Ordered list of data-preparation steps applied to `data`.",
     )
 
     @property

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -2318,6 +2318,208 @@ class CapData(param.Parameterized):
         """
         return [step.to_config() for step in self.filters]
 
+    def prep_convert_units(
+        self,
+        columns=None,
+        group=None,
+        group_regex=None,
+        from_units=None,
+        to_units=None,
+        custom_name=None,
+    ):
+        """Convert the selected columns between units and record the step.
+
+        Parameters
+        ----------
+        columns : list of str, optional
+            Explicit column names. Mutually exclusive with the group selectors.
+        group : str or list of str, optional
+            ``column_groups`` id, or list of ids.
+        group_regex : str, optional
+            Regex matched against ``column_groups`` ids, e.g. ``"^temp"`` to
+            reach ``temp_amb``, ``temp_bom``, and ``temp_mod`` at once.
+        from_units, to_units : str
+            Source and target units; see :data:`captest.prep.UNIT_CONVERSIONS`.
+        custom_name : str, optional
+            Display label for the recorded step.
+        """
+        self._check_duplicate_prep(
+            prep.ConvertUnits(
+                columns=columns,
+                group=group,
+                group_regex=group_regex,
+                from_units=from_units,
+                to_units=to_units,
+                custom_name=custom_name,
+            )
+        ).run(self)
+
+    def prep_scale(
+        self,
+        columns=None,
+        group=None,
+        group_regex=None,
+        factor=1.0,
+        offset=0.0,
+        custom_name=None,
+    ):
+        """Apply ``value * factor + offset`` to the selected columns.
+
+        Parameters
+        ----------
+        columns, group, group_regex : optional
+            Column selector; exactly one is required. See
+            :meth:`prep_convert_units`.
+        factor : float, default 1.0
+            Multiplier.
+        offset : float, default 0.0
+            Added after multiplying.
+        custom_name : str, optional
+            Display label for the recorded step.
+        """
+        self._check_duplicate_prep(
+            prep.Scale(
+                columns=columns,
+                group=group,
+                group_regex=group_regex,
+                factor=factor,
+                offset=offset,
+                custom_name=custom_name,
+            )
+        ).run(self)
+
+    def prep_astype(
+        self,
+        columns=None,
+        group=None,
+        group_regex=None,
+        dtype="float64",
+        custom_name=None,
+    ):
+        """Cast the selected columns to ``dtype``.
+
+        Parameters
+        ----------
+        columns, group, group_regex : optional
+            Column selector; exactly one is required. See
+            :meth:`prep_convert_units`.
+        dtype : str, default "float64"
+            Target dtype name.
+        custom_name : str, optional
+            Display label for the recorded step.
+        """
+        self._check_duplicate_prep(
+            prep.AsType(
+                columns=columns,
+                group=group,
+                group_regex=group_regex,
+                dtype=dtype,
+                custom_name=custom_name,
+            )
+        ).run(self)
+
+    def prep_custom(self, func, *args, custom_name=None, **kwargs):
+        """Apply ``func(self, *args, **kwargs)`` as a recorded prep step.
+
+        Parameters
+        ----------
+        func : callable
+            Takes this CapData as its first argument and mutates ``data`` in
+            place. Must be importable by module-qualified name to serialize —
+            a lambda cannot be exported.
+        *args, **kwargs
+            Forwarded to ``func``.
+        custom_name : str, optional
+            Display label for the recorded step. Keyword-only so it cannot
+            collide with arguments destined for ``func``.
+        """
+        prep.Custom(func, *args, custom_name=custom_name, **kwargs).run(self)
+
+    def _check_duplicate_prep(self, step):
+        """Return ``step``, raising if an equal step is already applied.
+
+        Prep mutates ``data`` and is not idempotent — converting °F to °C
+        twice is silently wrong — so an identical step is refused. Equality is
+        on the serialized config, i.e. same type and same params.
+        """
+        config = step.to_config()
+        if any(applied.to_config() == config for applied in self.prep):
+            raise RuntimeError(
+                f"An equal {type(step).__name__} prep step is already applied. "
+                "Prep steps mutate `data` and are not idempotent; re-prep by "
+                "reloading this dataset."
+            )
+        return step
+
+    def prep_to_config(self):
+        """Serialize the applied prep chain to a list of config dicts.
+
+        Each entry is a step's ``to_config()``. Inverse of :meth:`run_prep`.
+        Used by ``CapTest.to_yaml`` to embed this CapData's prep in the single
+        config file.
+        """
+        return [step.to_config() for step in self.prep]
+
+    def run_prep(self, config):
+        """Rebuild and run each prep step from a list of config dicts.
+
+        ``config`` is a list of ``to_config()`` dicts (e.g. from
+        :meth:`prep_to_config` or a loaded YAML). Each step is constructed via
+        ``prep.prep_step_from_config`` and run against this CapData in order.
+
+        The replay is a transaction across the whole batch: ``data`` is
+        snapshotted before the first step and restored — with every step this
+        call appended discarded — if any step raises, with a note naming the
+        failing step attached to the exception (Python 3.11+). Per-step
+        atomicity alone would leave earlier steps applied, which is a
+        half-prepped frame the caller could neither safely retry nor measure.
+
+        Parameters
+        ----------
+        config : list of dict
+            Prep-step config dicts, in order.
+
+        Raises
+        ------
+        RuntimeError
+            If ``prep`` is already populated. Prep steps mutate ``data`` and
+            are not idempotent, so replay is a once-per-load operation; re-prep
+            by reloading (``CapTest.reload(side)``).
+        """
+        if self.prep:
+            raise RuntimeError(
+                "run_prep requires an un-prepped dataset, but "
+                f"{len(self.prep)} prep steps are already applied. Prep "
+                "mutates `data` and is not idempotent — reload this dataset "
+                "(CapTest.reload(side)) to re-prep from raw data."
+            )
+        snapshot = self.data.copy()
+        prior_prep = self.prep
+        step_label = "?"
+        try:
+            for i, step_config in enumerate(config):
+                step_label = f"{i} ({step_config.get('type', '?')})"
+                prep.prep_step_from_config(step_config).run(self)
+        except Exception as e:
+            self.data = snapshot
+            self.prep = prior_prep
+            if hasattr(e, "add_note"):
+                e.add_note(f"Raised while running prep step {step_label}.")
+            raise
+
+    def describe_prep(self):
+        """Return a written, human-readable summary of the prep applied.
+
+        Joins the ``explanation`` of each step in ``self.prep``, one per line.
+        This is the only summary surface that reports prep: ``get_summary``
+        and ``describe_filters`` stay filter-only, because their rows are
+        point counts and prep removes no points. The serialized
+        ``meas_prep``/``sim_prep`` block in the yaml config is the durable
+        record.
+        """
+        lines = [step.explanation for step in self.prep if step.explanation is not None]
+        return "\n".join(lines)
+
     def _rc_state_snapshot(self):
         """Capture rc/rc_tool and (when test-wired) the CapTest RC state."""
         ct = self._captest

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1207,6 +1207,8 @@ _CAPTEST_YAML_KEYS = frozenset(
         "overrides",
         "meas_filters",
         "sim_filters",
+        "meas_prep",
+        "sim_prep",
         "reporting_conditions_values",
     }
 )
@@ -1350,6 +1352,14 @@ class CapTest(param.Parameterized):
         respectively. Not serialized to yaml.
     meas_load_kwargs, sim_load_kwargs : dict or None
         Plain-dict kwargs splatted into the loaders.
+    meas_prep, sim_prep : list of dict
+        Serialized data-preparation pipelines (``CapData.prep_to_config``
+        dicts) replayed onto the corresponding ``CapData`` immediately after
+        every load — ``from_params``/``from_mapping``/``from_yaml`` when the
+        side is built from a path, and ``reload``. Prep mutates ``data`` and
+        is not idempotent, so ``setup()`` and ``run_test()`` never replay it,
+        and a side supplied as a pre-built ``CapData`` keeps its config but
+        does not apply it (a ``UserWarning`` names the skipped steps).
 
     Attributes
     ----------
@@ -1603,6 +1613,23 @@ class CapTest(param.Parameterized):
         doc="Extra kwargs splatted into sim_loader.",
     )
 
+    # Declared data-preparation pipelines. Serialized to yaml, replayed once
+    # per load (never by setup() or run_test(): prep is not idempotent).
+    meas_prep = param.List(
+        default=[],
+        doc=(
+            "Serialized prep-step configs replayed onto `meas` immediately "
+            "after every load, before setup()."
+        ),
+    )
+    sim_prep = param.List(
+        default=[],
+        doc=(
+            "Serialized prep-step configs replayed onto `sim` immediately "
+            "after every load, before setup()."
+        ),
+    )
+
     # Class-level tuple of param names to copy onto the CapData instances
     # during setup(). Names also listed in _downstream_attrs_meas_only are
     # copied onto meas only; all others are copied onto both meas and sim.
@@ -1843,6 +1870,66 @@ class CapTest(param.Parameterized):
         side = "meas" if cd is self.meas else "sim"
         self._set_rc(cd.rc.copy(), side, warn=True)
 
+    # --- data preparation -------------------------------------------------
+
+    def _replay_prep(self, side):
+        """Replay ``<side>_prep`` onto the freshly-loaded CapData for ``side``.
+
+        Called immediately after a load and before ``setup()``. Prep mutates
+        ``data`` and is not idempotent, so this is the only place a stored
+        prep config is applied — ``setup()`` and ``run_test()`` never run it.
+
+        Parameters
+        ----------
+        side : {'meas', 'sim'}
+            Which side's stored prep config to replay. A no-op when that
+            config is empty or the side's ``CapData`` is unset.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RuntimeError
+            Propagated from ``CapData.run_prep`` if the target ``CapData``
+            already has an applied prep chain.
+        """
+        config = self.meas_prep if side == "meas" else self.sim_prep
+        capdata = getattr(self, side)
+        if not config or capdata is None:
+            return
+        capdata.run_prep(config)
+
+    def _warn_prep_not_applied(self, side):
+        """Warn that a stored prep config was skipped for a pre-built CapData.
+
+        A pre-built ``CapData`` may already have been prepped by the caller,
+        and prep is not idempotent, so the config is kept (it still
+        round-trips through ``to_yaml``) but never applied.
+
+        Parameters
+        ----------
+        side : {'meas', 'sim'}
+            Which side was supplied pre-built. A no-op when that side's
+            stored prep config is empty.
+
+        Returns
+        -------
+        None
+        """
+        config = self.meas_prep if side == "meas" else self.sim_prep
+        if not config:
+            return
+        warnings.warn(
+            f"{len(config)} stored '{side}_prep' steps were not applied — "
+            f"'{side}' was supplied as a pre-built CapData, not loaded from a "
+            "path. Apply them explicitly with: "
+            f"tst.{side}.run_prep(tst.{side}_prep)",
+            # warn -> this helper -> from_params -> the user's call site.
+            stacklevel=3,
+        )
+
     # --- constructors ----------------------------------------------------
 
     @classmethod
@@ -1853,6 +1940,14 @@ class CapTest(param.Parameterized):
         ``sim_path`` in addition to every declared ``param.*``. If both
         ``meas`` and ``meas_path`` are supplied the pre-built instance
         wins and a warning is emitted (same for ``sim`` / ``sim_path``).
+
+        A side built from a path has its declared prep pipeline
+        (``meas_prep`` / ``sim_prep``) replayed onto the loaded ``CapData``
+        immediately, before any ``setup()`` — including when
+        ``run_setup=False``. A side supplied as a pre-built ``CapData``
+        keeps its prep config but does not apply it (prep is not idempotent
+        and the object may already be prepped); a ``UserWarning`` names the
+        skipped steps.
 
         When both ``meas`` and ``sim`` end up populated and ``run_setup``
         is True, ``setup()`` is called automatically. Otherwise the
@@ -1901,11 +1996,14 @@ class CapTest(param.Parameterized):
                 stacklevel=2,
             )
             inst.meas = meas
+            inst._warn_prep_not_applied("meas")
         elif meas is not None:
             inst.meas = meas
+            inst._warn_prep_not_applied("meas")
         elif meas_path is not None:
             load_kwargs = inst.meas_load_kwargs or {}
             inst.meas = _meas_loader()(meas_path, **load_kwargs)
+            inst._replay_prep("meas")
 
         # Wire up sim.
         if sim is not None and sim_path is not None:
@@ -1915,11 +2013,14 @@ class CapTest(param.Parameterized):
                 stacklevel=2,
             )
             inst.sim = sim
+            inst._warn_prep_not_applied("sim")
         elif sim is not None:
             inst.sim = sim
+            inst._warn_prep_not_applied("sim")
         elif sim_path is not None:
             load_kwargs = inst.sim_load_kwargs or {}
             inst.sim = _sim_loader()(sim_path, **load_kwargs)
+            inst._replay_prep("sim")
 
         if run_setup and inst.meas is not None and inst.sim is not None:
             inst.setup()
@@ -1939,6 +2040,8 @@ class CapTest(param.Parameterized):
         pipelines are stored as :attr:`meas_filters_pending` /
         :attr:`sim_filters_pending`, not applied; run them with
         :meth:`run_test` (or per side via ``CapData.run_pipeline``).
+        Serialized ``meas_prep`` / ``sim_prep`` pipelines, by contrast, are
+        applied at load — see :meth:`from_params`.
 
         Parameters
         ----------
@@ -1995,7 +2098,11 @@ class CapTest(param.Parameterized):
         Serialized ``meas_filters`` / ``sim_filters`` pipelines are stored
         as :attr:`meas_filters_pending` / :attr:`sim_filters_pending` —
         nothing is replayed at load. Run them with :meth:`run_test` (or per
-        side via ``CapData.run_pipeline``). Manual reporting-conditions
+        side via ``CapData.run_pipeline``). Serialized ``meas_prep`` /
+        ``sim_prep`` pipelines are the exception: they reach
+        :meth:`from_params` as parameters and are applied to each
+        path-loaded side at load, before any ``setup()``. Manual
+        reporting-conditions
         values (``reporting_conditions_values`` with
         ``rc_source='manual'``) are validated and seeded during the
         construction-time ``setup()``; with ``run_setup=False`` they are
@@ -2194,6 +2301,12 @@ class CapTest(param.Parameterized):
         filters against the fresh data. When the outgoing chain is empty, an
         existing pending config is left untouched.
 
+        The outgoing side's applied prep chain is preserved the same way,
+        into ``<side>_prep``, and — unlike the filters — is replayed
+        immediately onto the freshly loaded data, before the per-side
+        ``setup()``. A reload is the supported way to re-prep, since the
+        loader supplies a fresh un-prepped frame.
+
         Parameters
         ----------
         side : {'meas', 'sim'}
@@ -2234,12 +2347,15 @@ class CapTest(param.Parameterized):
         outgoing = getattr(self, side)
         if outgoing is not None and outgoing.filters:
             setattr(self, f"{side}_filters_pending", outgoing.filters_to_config())
+        if outgoing is not None and outgoing.prep:
+            setattr(self, f"{side}_prep", outgoing.prep_to_config())
         if side == "meas":
             loader = self.meas_loader or _default_meas_loader()
             self.meas = loader(stored_path, **(self.meas_load_kwargs or {}))
         else:
             loader = self.sim_loader or _default_sim_loader()
             self.sim = loader(stored_path, **(self.sim_load_kwargs or {}))
+        self._replay_prep(side)
         self.setup(verbose=verbose, side=side)
         return self
 
@@ -2258,7 +2374,9 @@ class CapTest(param.Parameterized):
         ``meas_filters`` / ``sim_filters`` (lists of filter-step config dicts
         from :meth:`CapData.filters_to_config`, or the side's pending config
         when its chain is empty), each only when non-empty; ``from_yaml``
-        stores them as pending pipelines that :meth:`run_test` replays. When a
+        stores them as pending pipelines that :meth:`run_test` replays. The
+        prep pipelines are written the same way as ``meas_prep`` /
+        ``sim_prep``; ``from_yaml`` applies those at load. When a
         ``RepCond`` step is present in either pipeline, ``overrides.rep_conditions``
         is omitted — the step is then the authoritative reporting-conditions
         source (avoids representing it in two places).
@@ -2358,7 +2476,10 @@ class CapTest(param.Parameterized):
         so the merge/write step stays short. Embeds each side's pipeline as
         ``meas_filters``/``sim_filters``: the applied filter chain when
         non-empty, else the side's pending config (so a load → save without
-        running is lossless), else the key is omitted. Omits
+        running is lossless), else the key is omitted. Embeds each side's
+        prep pipeline as ``meas_prep``/``sim_prep`` under the same three-way
+        rule (applied prep chain, else the stored ``meas_prep``/``sim_prep``
+        config, else the key is omitted). Omits
         ``overrides.rep_conditions`` when a ``RepCond`` step is present in
         either pipeline (the step is then the single source of reporting
         conditions).
@@ -2396,6 +2517,16 @@ class CapTest(param.Parameterized):
             self.sim.filters_to_config()
             if self.sim is not None and self.sim.filters
             else list(self.sim_filters_pending)
+        )
+        meas_prep = (
+            self.meas.prep_to_config()
+            if self.meas is not None and self.meas.prep
+            else copy.deepcopy(self.meas_prep)
+        )
+        sim_prep = (
+            self.sim.prep_to_config()
+            if self.sim is not None and self.sim.prep
+            else copy.deepcopy(self.sim_prep)
         )
         has_rep_cond_step = any(
             d["type"] == "RepCond" for d in (meas_filters + sim_filters)
@@ -2457,6 +2588,11 @@ class CapTest(param.Parameterized):
             sub["meas_filters"] = meas_filters
         if sim_filters:
             sub["sim_filters"] = sim_filters
+
+        if meas_prep:
+            sub["meas_prep"] = meas_prep
+        if sim_prep:
+            sub["sim_prep"] = sim_prep
 
         # Manual reporting conditions are data, not config: serialize their
         # values so from_yaml can restore them (computed RC is recomputed by

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -2102,8 +2102,7 @@ class CapTest(param.Parameterized):
         ``sim_prep`` pipelines are the exception: they reach
         :meth:`from_params` as parameters and are applied to each
         path-loaded side at load, before any ``setup()``. Manual
-        reporting-conditions
-        values (``reporting_conditions_values`` with
+        reporting-conditions values (``reporting_conditions_values`` with
         ``rc_source='manual'``) are validated and seeded during the
         construction-time ``setup()``; with ``run_setup=False`` they are
         stashed and consumed by the next full ``setup()``.
@@ -2305,7 +2304,12 @@ class CapTest(param.Parameterized):
         into ``<side>_prep``, and — unlike the filters — is replayed
         immediately onto the freshly loaded data, before the per-side
         ``setup()``. A reload is the supported way to re-prep, since the
-        loader supplies a fresh un-prepped frame.
+        loader supplies a fresh un-prepped frame. Note that the stash
+        rewrites ``<side>_prep`` in place: a hand-written config of partial
+        step dicts is replaced by the fully-expanded ``to_config()`` form
+        (every step param, defaults included). The two are behaviorally
+        equivalent, but the expanded form is what a later ``to_yaml`` and
+        any read of ``tst.<side>_prep`` will show.
 
         Parameters
         ----------

--- a/src/captest/filters.py
+++ b/src/captest/filters.py
@@ -5,7 +5,6 @@ This module is imported one-way by ``capdata.py``; it never imports
 runtime ``capdata`` argument to ``run``/``_execute``.
 """
 
-import copy
 import difflib
 import importlib.util
 import math
@@ -373,7 +372,7 @@ def backtracking_active(
     )
 
 
-class BaseSummaryStep(param.Parameterized):
+class BaseSummaryStep(util.StrictAttrs, param.Parameterized):
     """Common ancestor for steps that appear in the filtering summary.
 
     Holds the shared lifecycle (`run`), the optional `custom_name` display
@@ -386,12 +385,16 @@ class BaseSummaryStep(param.Parameterized):
     are not stored — they are chain-derived on demand via
     `CapData._ix_before`/`_pts_before`.
 
-    Attribute assignment is restricted (see `__setattr__`): a step accepts its
-    declared `param` parameters, private (leading-underscore) names, and the
-    non-param runtime attributes named in `_runtime_attrs`. A subclass that
+    Attribute assignment is restricted by `util.StrictAttrs`: a step accepts
+    its declared `param` parameters, private (leading-underscore) names, and
+    the non-param runtime attributes named in `_runtime_attrs`. A subclass that
     writes a plain attribute in `_execute` must list it in its own
     `_runtime_attrs`; `__init_subclass__` unions those declarations down the
-    hierarchy, so subclasses declare only what they add.
+    hierarchy, so subclasses declare only what they add. Without the guard, the
+    documented edit-then-replay workflow — adjust a step's params, then
+    `CapData.rerun_filters_from(index)` — would silently do nothing when a
+    param name is mistyped (e.g. `Outliers.contamination`, whose real param is
+    `envelope_kwargs`).
     """
 
     custom_name = param.String(
@@ -407,41 +410,6 @@ class BaseSummaryStep(param.Parameterized):
     # Non-param instance attributes this class is allowed to set. Accumulated
     # across the MRO by __init_subclass__, so a subclass lists only its own.
     _runtime_attrs = frozenset({"ix_after", "pts_after"})
-
-    def __init_subclass__(cls, **kwargs):
-        """Union each subclass's `_runtime_attrs` with those of its bases."""
-        super().__init_subclass__(**kwargs)
-        cls._runtime_attrs = frozenset().union(
-            *(base.__dict__.get("_runtime_attrs", frozenset()) for base in cls.__mro__)
-        )
-
-    def __setattr__(self, name, value):
-        """Reject assignment to names that are neither params nor runtime state.
-
-        `param.Parameterized` accepts arbitrary attribute assignment, which
-        makes the documented edit-then-replay workflow — adjust a step's params,
-        then `CapData.rerun_filters_from(index)` — silently do nothing when the
-        param name is mistyped (e.g. `Outliers.contamination`, whose real param
-        is `envelope_kwargs`). Raising here surfaces the typo at the assignment
-        instead of producing an unchanged re-run.
-
-        Leading-underscore names pass through unchecked; they cover `param`'s
-        own instance internals as well as steps' private state.
-        """
-        if (
-            name.startswith("_")
-            or name in self.param
-            or name in type(self)._runtime_attrs
-        ):
-            super().__setattr__(name, value)
-            return
-        settable = sorted(set(self.param) | type(self)._runtime_attrs)
-        suggestion = difflib.get_close_matches(name, settable, n=1)
-        hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
-        raise AttributeError(
-            f"{type(self).__name__} has no parameter or attribute {name!r}. "
-            f"Settable names: {settable}.{hint}"
-        )
 
     def run(self, capdata):
         """Execute the step, record runtime state, and append self to filters.
@@ -533,21 +501,15 @@ class BaseSummaryStep(param.Parameterized):
         """Serialize this step to a config dict (every param, defaults
         included; the param-system ``name`` is omitted).
 
-        Param values are deep-copied so the returned dict is an independent
-        snapshot — mutating it never reaches back into the step's params.
-        Numpy scalars (e.g. a ``ref_val`` taken from ``cd.rc['poa'].iloc[0]``)
-        are coerced to native Python types via ``util.to_native`` so the dict
-        survives ``yaml.safe_dump``; subclasses whose params hold callables
-        override to encode them.
+        Param values are deep-copied by ``util.params_to_config`` so the
+        returned dict is an independent snapshot — mutating it never reaches
+        back into the step's params. Numpy scalars (e.g. a ``ref_val`` taken
+        from ``cd.rc['poa'].iloc[0]``) are coerced to native Python types so
+        the dict survives ``yaml.safe_dump``; subclasses whose params hold
+        callables override to encode them.
         """
         config = {"type": type(self).__name__}
-        config.update(
-            {
-                k: util.to_native(copy.deepcopy(v))
-                for k, v in self.param.values().items()
-                if k != "name"
-            }
-        )
+        config.update(util.params_to_config(self))
         return config
 
     @classmethod

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -1,0 +1,295 @@
+"""Prep steps: declared, serializable adjustments applied between load and setup.
+
+Each step is a ``param``-configured class that rewrites ``CapData.data`` in
+place and records itself on ``CapData.prep``, so the adjustment round-trips
+through the yaml config and replays after every load.
+
+This module follows ``filters.py``'s import rule: it is imported one-way by
+``capdata.py`` and never imports ``capdata``. A step touches a ``CapData``
+only through the runtime ``capdata`` argument.
+"""
+
+import difflib
+import re
+
+import pandas as pd
+import param
+
+from captest import util
+
+
+class BasePrepStep(util.StrictAttrs, param.Parameterized):
+    """Common ancestor for data-preparation steps.
+
+    Holds the shared lifecycle (``run``), the three-way column selector, and
+    the ``args_repr`` / ``explanation`` rendering used by ``describe_prep``.
+    Subclasses implement ``_execute(capdata, columns)``, which mutates
+    ``capdata.data`` in place and returns nothing.
+
+    Every step is atomic: ``run`` snapshots ``capdata.data`` and restores it
+    if ``_execute`` raises, and appends the step only on success. A failed
+    step is therefore a no-op in both ``data`` and ``prep``.
+
+    Runtime state (``columns_resolved``) is set by ``run`` as a plain
+    attribute and is never serialized. Attribute assignment is restricted by
+    ``util.StrictAttrs``.
+    """
+
+    custom_name = param.String(
+        default=None,
+        allow_None=True,
+        doc="Optional display name in the prep description.",
+    )
+    columns = param.List(
+        default=None,
+        allow_None=True,
+        doc="Explicit column names. Mutually exclusive with group/group_regex.",
+    )
+    group = param.ClassSelector(
+        class_=(str, list),
+        default=None,
+        allow_None=True,
+        doc="column_groups id, or list of ids. Mutually exclusive with the others.",
+    )
+    group_regex = param.String(
+        default=None,
+        allow_None=True,
+        doc="Regex matched against column_groups ids. Mutually exclusive with others.",
+    )
+
+    # Class-intrinsic human-readable template; set by concrete subclasses.
+    _explanation_template = None
+
+    # Steps that rewrite values are refused once filters are applied; steps
+    # that only change column identity (drop, rename) are not.
+    _mutates_values = True
+
+    _runtime_attrs = frozenset({"columns_resolved"})
+
+    def run(self, capdata):
+        """Execute the step against ``capdata`` and record it on ``prep``.
+
+        Parameters
+        ----------
+        capdata : CapData
+            Target dataset. ``data`` is mutated in place.
+
+        Returns
+        -------
+        BasePrepStep
+            ``self``, so callers can keep a handle on the recorded step.
+
+        Raises
+        ------
+        RuntimeError
+            If this step rewrites values and ``capdata.filters`` is non-empty.
+        ValueError
+            If the column selector is not exactly one of ``columns`` /
+            ``group`` / ``group_regex``, or resolves to no columns.
+        """
+        self._check_not_filtered(capdata)
+        cols = self._resolve_columns(capdata)
+        self.columns_resolved = cols
+        snapshot = capdata.data.copy()
+        try:
+            self._execute(capdata, cols)
+        except Exception:
+            # A failed step is a no-op: restore data, record nothing.
+            capdata.data = snapshot
+            raise
+        # Reassign rather than append so param watchers fire.
+        capdata.prep = capdata.prep + [self]
+        return self
+
+    def _check_not_filtered(self, capdata):
+        """Raise when a value-rewriting step runs after filtering.
+
+        A filter applied earlier was evaluated against un-prepped values, so
+        letting prep run now produces wrong numbers rather than a crash.
+        """
+        if not self._mutates_values or not capdata.filters:
+            return
+        raise RuntimeError(
+            f"Cannot run {type(self).__name__} after filtering — "
+            f"{len(capdata.filters)} filters are already applied and were "
+            "evaluated against un-prepped values. Call cd.reset_filter() "
+            "first, or reload this side."
+        )
+
+    def _resolve_columns(self, capdata):
+        """Resolve the selector against ``capdata`` at run time.
+
+        Resolution is deliberately deferred to ``run`` rather than done at
+        construction: earlier steps in the same list may have dropped or
+        renamed columns.
+
+        Returns
+        -------
+        list of str
+            Column names this step acts on, in ``column_groups`` order for the
+            group selectors and in the given order for ``columns``.
+        """
+        chosen = [
+            name
+            for name in ("columns", "group", "group_regex")
+            if getattr(self, name) is not None
+        ]
+        if len(chosen) != 1:
+            raise ValueError(
+                f"{type(self).__name__} requires exactly one of 'columns', "
+                f"'group', or 'group_regex'; got {chosen or 'none'}."
+            )
+        if self.columns is not None:
+            cols = list(self.columns)
+        else:
+            cols = self._columns_from_groups(capdata)
+        missing = [c for c in cols if c not in capdata.data.columns]
+        if missing:
+            raise ValueError(
+                f"{type(self).__name__} selector resolved to columns absent "
+                f"from data: {missing}."
+            )
+        if not cols:
+            raise ValueError(
+                f"{type(self).__name__} selector resolved to zero columns; "
+                "a prep step that does nothing is always a mistake."
+            )
+        return cols
+
+    def _columns_from_groups(self, capdata):
+        """Expand the ``group`` / ``group_regex`` selector to column names."""
+        groups = capdata.column_groups
+        if self.group is not None:
+            ids = [self.group] if isinstance(self.group, str) else list(self.group)
+            for group_id in ids:
+                if group_id not in groups:
+                    suggestion = difflib.get_close_matches(group_id, list(groups), n=1)
+                    hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
+                    raise ValueError(
+                        f"Column group {group_id!r} is not in column_groups. "
+                        f"Available ids: {sorted(groups)}.{hint}"
+                    )
+        else:
+            pattern = re.compile(self.group_regex)
+            ids = [group_id for group_id in groups if pattern.search(group_id)]
+            if not ids:
+                raise ValueError(
+                    f"group_regex {self.group_regex!r} matched no column group. "
+                    f"Available ids: {sorted(groups)}."
+                )
+        cols = []
+        for group_id in ids:
+            for col in groups[group_id]:
+                if col not in cols:
+                    cols.append(col)
+        return cols
+
+    def _execute(self, capdata, columns):
+        """Mutate ``capdata.data`` in place. Implemented by subclasses."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _require_numeric(capdata, columns, step_name):
+        """Raise ``TypeError`` naming the first non-numeric column."""
+        for col in columns:
+            if not pd.api.types.is_numeric_dtype(capdata.data[col]):
+                raise TypeError(
+                    f"{step_name} requires numeric columns; {col!r} has dtype "
+                    f"{capdata.data[col].dtype}."
+                )
+
+    @property
+    def args_repr(self):
+        """Render the step's params for ``describe_prep``."""
+        skip = {"custom_name", "name"}
+        items = [
+            f"{k}={v}"
+            for k, v in util.params_to_config(self).items()
+            if k not in skip and v is not None
+        ]
+        return ", ".join(items) if items else "Default arguments"
+
+    @property
+    def explanation(self):
+        """Human-readable description of the step's effect (read after run)."""
+        if self._explanation_template is None:
+            return None
+        try:
+            values = self._explanation_values()
+        except AttributeError:
+            return None
+        return self._explanation_template.format(**values)
+
+    def _explanation_values(self):
+        """Substitution mapping for ``_explanation_template``."""
+        return {"columns": ", ".join(self.columns_resolved)}
+
+    def to_config(self):
+        """Serialize this step to a yaml-safe config dict."""
+        config = {"type": type(self).__name__}
+        config.update(util.params_to_config(self))
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        """Build an instance from a :meth:`to_config` dict."""
+        config = {k: v for k, v in config.items() if k != "type"}
+        return cls(**config)
+
+
+class Scale(BasePrepStep):
+    """Apply an affine transform ``value * factor + offset`` in place.
+
+    The raw-numbers escape hatch for rescaling that no unit pair covers.
+    Writes back to the same column names, which is the property
+    ``calcparams.custom_param`` structurally cannot provide.
+    """
+
+    factor = param.Number(default=1.0, doc="Multiplier applied to each value.")
+    offset = param.Number(default=0.0, doc="Added after multiplying.")
+
+    _explanation_template = (
+        "Columns {columns} were scaled by {factor} with an offset of {offset}."
+    )
+
+    def _execute(self, capdata, columns):
+        self._require_numeric(capdata, columns, type(self).__name__)
+        capdata.data[columns] = capdata.data[columns] * self.factor + self.offset
+
+    def _explanation_values(self):
+        return {
+            "columns": ", ".join(self.columns_resolved),
+            "factor": self.factor,
+            "offset": self.offset,
+        }
+
+
+PREP_REGISTRY = {
+    "Scale": Scale,
+}
+
+
+def prep_step_from_config(d):
+    """Build a prep step from a ``to_config()`` dict via ``PREP_REGISTRY``.
+
+    Parameters
+    ----------
+    d : dict
+        Config dict with a ``type`` key naming a registered step.
+
+    Returns
+    -------
+    BasePrepStep
+
+    Raises
+    ------
+    ValueError
+        If ``type`` is not a registered prep step.
+    """
+    d = dict(d)
+    cls_name = d.pop("type")
+    if cls_name not in PREP_REGISTRY:
+        suggestion = difflib.get_close_matches(cls_name, PREP_REGISTRY, n=1)
+        hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
+        raise ValueError(f"Unknown prep type {cls_name!r} in prep config.{hint}")
+    return PREP_REGISTRY[cls_name].from_config(d)

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -264,7 +264,134 @@ class Scale(BasePrepStep):
         }
 
 
+UNIT_ALIASES = {
+    "degf": "F",
+    "fahrenheit": "F",
+    "f": "F",
+    "degc": "C",
+    "celsius": "C",
+    "c": "C",
+    "k": "K",
+    "kelvin": "K",
+    "mph": "mph",
+    "mi/h": "mph",
+    "m/s": "m/s",
+    "mps": "m/s",
+    "km/h": "km/h",
+    "kph": "km/h",
+    "kn": "kn",
+    "knots": "kn",
+    "ft/s": "ft/s",
+    "w": "W",
+    "kw": "kW",
+    "mw": "MW",
+    "mbar": "mbar",
+    "pa": "Pa",
+    "m": "m",
+    "cm": "cm",
+    "in": "in",
+    "inches": "in",
+}
+
+# out = value * factor + offset
+UNIT_CONVERSIONS = {
+    ("F", "C"): (5 / 9, -160 / 9),  # (F - 32) * 5/9
+    ("K", "C"): (1.0, -273.15),
+    ("mph", "m/s"): (0.44704, 0.0),
+    ("km/h", "m/s"): (1 / 3.6, 0.0),
+    ("kn", "m/s"): (0.514444, 0.0),
+    ("ft/s", "m/s"): (0.3048, 0.0),
+    ("W", "kW"): (0.001, 0.0),
+    ("MW", "kW"): (1000.0, 0.0),
+    ("mbar", "Pa"): (100.0, 0.0),
+    ("m", "cm"): (100.0, 0.0),
+    ("in", "cm"): (2.54, 0.0),
+}
+
+
+def _normalize_unit(units):
+    """Map a user-supplied unit string to its canonical spelling."""
+    return UNIT_ALIASES.get(str(units).strip().lower(), str(units).strip())
+
+
+def conversion_factors(from_units, to_units):
+    """Return the ``(factor, offset)`` converting ``from_units`` to ``to_units``.
+
+    Conversions are affine: ``out = value * factor + offset``. Only the forward
+    direction is tabulated in :data:`UNIT_CONVERSIONS`; the inverse is derived
+    as ``out = (value - offset) / factor``, so the table cannot drift out of
+    sync with itself. Aliases are normalized case-insensitively before lookup.
+
+    Parameters
+    ----------
+    from_units, to_units : str
+        Unit names or aliases, e.g. ``"degF"`` and ``"C"``.
+
+    Returns
+    -------
+    tuple of float
+        ``(factor, offset)``.
+
+    Raises
+    ------
+    ValueError
+        If the units are identical, or the pair is not supported in either
+        direction.
+    """
+    src = _normalize_unit(from_units)
+    dst = _normalize_unit(to_units)
+    if src == dst:
+        raise ValueError(
+            f"from_units and to_units are identical ({src!r}); a conversion "
+            "that does nothing is always a mistake."
+        )
+    if (src, dst) in UNIT_CONVERSIONS:
+        return UNIT_CONVERSIONS[(src, dst)]
+    if (dst, src) in UNIT_CONVERSIONS:
+        factor, offset = UNIT_CONVERSIONS[(dst, src)]
+        return 1 / factor, -offset / factor
+    supported = sorted(f"{a} -> {b}" for a, b in UNIT_CONVERSIONS)
+    known_units = {u for pair in UNIT_CONVERSIONS for u in pair}
+    suggestion = difflib.get_close_matches(src, known_units, n=1)
+    hint = f" Did you mean {suggestion[0]!r} for from_units?" if suggestion else ""
+    raise ValueError(
+        f"No conversion from {src!r} to {dst!r}. Inverses of the supported "
+        f"pairs are derived automatically; supported pairs: {supported}. Use "
+        f"Scale(factor=..., offset=...) for anything else.{hint}"
+    )
+
+
+class ConvertUnits(BasePrepStep):
+    """Convert the selected columns between units, in place.
+
+    The conversion is affine and applied to the same column names, so a site
+    with twelve thermocouples converts in one step. This is an asserted
+    transformation, not a checked one: nothing tracks or validates a column's
+    current units.
+    """
+
+    from_units = param.String(default=None, allow_None=True, doc="Source units.")
+    to_units = param.String(default=None, allow_None=True, doc="Target units.")
+
+    _explanation_template = (
+        "Columns {columns} were converted from {from_units} to {to_units}."
+    )
+
+    def _execute(self, capdata, columns):
+        self._require_numeric(capdata, columns, type(self).__name__)
+        factor, offset = conversion_factors(self.from_units, self.to_units)
+        capdata.data[columns] = capdata.data[columns] * factor + offset
+
+    def _explanation_values(self):
+        return {
+            "columns": ", ".join(self.columns_resolved),
+            "from_units": self.from_units,
+            "to_units": self.to_units,
+        }
+
+
 PREP_REGISTRY = {
+    "ConvertUnits": ConvertUnits,
     "Scale": Scale,
 }
 

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -63,7 +63,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
     """Common ancestor for data-preparation steps.
 
     Holds the shared lifecycle (``run``), the three-way column selector, and
-    the ``args_repr`` / ``explanation`` rendering used by ``describe_prep``.
+    the ``explanation`` rendering that ``describe_prep`` prints.
     Subclasses implement ``_execute(capdata, columns)``, which mutates
     ``capdata.data`` in place and returns nothing.
 
@@ -106,6 +106,10 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
     # that only change column identity (drop, rename) are not.
     _mutates_values = True
 
+    # Steps subject to the duplicate check. Custom opts out: its effect is
+    # opaque to this class, so re-applying one may well be intended.
+    _duplicate_guarded = True
+
     _runtime_attrs = frozenset({"columns_resolved"})
 
     def run(self, capdata):
@@ -133,6 +137,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         """
         self._check_not_filtered(capdata)
         cols = self._resolve_columns(capdata)
+        self._check_not_duplicate(capdata, cols)
         self.columns_resolved = cols
         snapshot = snapshot_prep_state(capdata)
         try:
@@ -145,6 +150,67 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         # Reassign rather than append so param watchers fire.
         capdata.prep = capdata.prep + [self]
         return self
+
+    def _check_not_duplicate(self, capdata, columns):
+        """Raise when this step would re-apply itself to an already-prepped column.
+
+        Prep mutates ``data`` and is not idempotent — converting °F to °C
+        twice is silently wrong — so a step is refused when an applied step of
+        the same type, with the same non-selector settings, already touched
+        any of the columns this one resolved to.
+
+        The comparison is on **resolved columns**, not on the selector as
+        written, so selecting the same column by different routes
+        (``columns=["poa_1"]`` and ``group="poa"``) is still caught. It is an
+        overlap test rather than an equality test, so a partial re-selection
+        (``columns=["a", "b"]`` then ``columns=["b", "c"]``) is caught too.
+
+        ``custom_name`` is excluded from the settings comparison: the label is
+        presentation, so re-running the same scale under a second label is
+        still a double scale. Differing settings are allowed — an ``F``-to-``C``
+        conversion followed by ``C``-to-``F`` on the same column is a
+        deliberate round trip, not a mistake.
+
+        Parameters
+        ----------
+        capdata : CapData
+            Target dataset, whose ``prep`` list holds the applied steps.
+        columns : list of str
+            Columns this step resolved to.
+
+        Raises
+        ------
+        RuntimeError
+            If an equivalent step already covers any of ``columns``.
+        """
+        if not self._duplicate_guarded:
+            return
+        mine = self._settings_for_duplicate_check()
+        for applied in capdata.prep:
+            if type(applied) is not type(self):
+                continue
+            if applied._settings_for_duplicate_check() != mine:
+                continue
+            overlap = [c for c in columns if c in applied.columns_resolved]
+            if overlap:
+                raise RuntimeError(
+                    f"An equal {type(self).__name__} prep step is already "
+                    f"applied to {util.format_name_list(overlap)}. Prep steps "
+                    "mutate `data` and are not idempotent, so applying the "
+                    "same transformation twice is silently wrong; re-prep by "
+                    "reloading this dataset."
+                )
+
+    def _settings_for_duplicate_check(self):
+        """Return the params that make two steps equivalent.
+
+        Excludes the three selectors (the duplicate check compares resolved
+        columns instead) and the presentation-only ``custom_name``.
+        """
+        ignored = {"columns", "group", "group_regex", "custom_name"}
+        return {
+            k: v for k, v in util.params_to_config(self).items() if k not in ignored
+        }
 
     def _check_not_filtered(self, capdata):
         """Raise when a value-rewriting step runs after filtering.
@@ -245,13 +311,32 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
 
     @property
     def args_repr(self):
-        """Render the step's params for ``describe_prep``."""
+        """Render the step's configured params as a single line.
+
+        Shows the selector and settings **as written**, which is what
+        distinguishes this from ``explanation`` — that renders the columns the
+        selector resolved to, and is what ``describe_prep`` prints. This is a
+        display helper for inspecting a step directly; ``Custom`` overrides it
+        to render its call instead.
+
+        Sequence values are truncated by ``util.format_name_list`` so a
+        selector naming dozens of columns stays readable.
+
+        Returns
+        -------
+        str
+            e.g. ``"columns=a, b, factor=0.001, offset=0.0"``, or
+            ``"Default arguments"`` when every param is None.
+        """
         skip = {"custom_name", "name"}
-        items = [
-            f"{k}={v}"
-            for k, v in util.params_to_config(self).items()
-            if k not in skip and v is not None
-        ]
+        items = []
+        for key, value in util.params_to_config(self).items():
+            if key in skip or value is None:
+                continue
+            rendered = (
+                util.format_name_list(value) if isinstance(value, list) else value
+            )
+            items.append(f"{key}={rendered}")
         return ", ".join(items) if items else "Default arguments"
 
     @property
@@ -549,6 +634,8 @@ class Custom(BasePrepStep):
 
     _explanation_template = "Custom prep {call} was applied."
     _runtime_attrs = frozenset({"func", "args", "kwargs"})
+    # What the callable does is opaque here, so a repeat may be intended.
+    _duplicate_guarded = False
 
     def __init__(self, func, *args, custom_name=None, **kwargs):
         super().__init__(custom_name=custom_name)

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -9,6 +9,7 @@ This module follows ``filters.py``'s import rule: it is imported one-way by
 only through the runtime ``capdata`` argument.
 """
 
+import copy
 import difflib
 import re
 
@@ -16,6 +17,46 @@ import pandas as pd
 import param
 
 from captest import util
+
+
+def snapshot_prep_state(capdata):
+    """Capture the CapData state prep steps mutate, for rollback.
+
+    Steps rewrite ``data``; ``DropColumns`` and ``RenameColumns`` rewrite
+    ``column_groups`` as well. Both have to be captured for a failed step or
+    batch to be a true no-op — restoring ``data`` alone leaves
+    ``column_groups`` naming a column that is not there, or omitting one that
+    is, which no later call errors on and every group selector then reads
+    wrongly.
+
+    ``column_groups`` values are lists that ``drop_cols`` mutates in place, so
+    the copy is deep; a shallow copy would share those lists with the live
+    object and snapshot nothing.
+
+    Parameters
+    ----------
+    capdata : CapData
+        Dataset to snapshot.
+
+    Returns
+    -------
+    tuple
+        Opaque snapshot; pass to :func:`restore_prep_state`.
+    """
+    return capdata.data.copy(), copy.deepcopy(capdata.column_groups)
+
+
+def restore_prep_state(capdata, snapshot):
+    """Restore a :func:`snapshot_prep_state` snapshot onto ``capdata``.
+
+    Parameters
+    ----------
+    capdata : CapData
+        Dataset to roll back, mutated in place.
+    snapshot : tuple
+        Return value of :func:`snapshot_prep_state`.
+    """
+    capdata.data, capdata.column_groups = snapshot
 
 
 class BasePrepStep(util.StrictAttrs, param.Parameterized):
@@ -26,9 +67,10 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
     Subclasses implement ``_execute(capdata, columns)``, which mutates
     ``capdata.data`` in place and returns nothing.
 
-    Every step is atomic: ``run`` snapshots ``capdata.data`` and restores it
-    if ``_execute`` raises, and appends the step only on success. A failed
-    step is therefore a no-op in both ``data`` and ``prep``.
+    Every step is atomic: ``run`` snapshots ``capdata.data`` and
+    ``capdata.column_groups`` and restores both if ``_execute`` raises, and
+    appends the step only on success. A failed step is therefore a no-op in
+    ``data``, ``column_groups``, and ``prep``.
 
     Runtime state (``columns_resolved``) is set by ``run`` as a plain
     attribute and is never serialized. Attribute assignment is restricted by
@@ -72,7 +114,9 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         Parameters
         ----------
         capdata : CapData
-            Target dataset. ``data`` is mutated in place.
+            Target dataset. ``data`` — and, for the column-identity steps,
+            ``column_groups`` — is mutated in place. Both are snapshotted
+            first and restored if ``_execute`` raises.
 
         Returns
         -------
@@ -90,12 +134,13 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         self._check_not_filtered(capdata)
         cols = self._resolve_columns(capdata)
         self.columns_resolved = cols
-        snapshot = capdata.data.copy()
+        snapshot = snapshot_prep_state(capdata)
         try:
             self._execute(capdata, cols)
         except Exception:
-            # A failed step is a no-op: restore data, record nothing.
-            capdata.data = snapshot
+            # A failed step is a no-op: restore data and column_groups,
+            # record nothing.
+            restore_prep_state(capdata, snapshot)
             raise
         # Reassign rather than append so param watchers fire.
         capdata.prep = capdata.prep + [self]
@@ -487,8 +532,13 @@ class Custom(BasePrepStep):
     attributes rather than ``param`` parameters, and ``func`` serializes to a
     module-qualified name — a lambda cannot be exported.
 
-    The three-way column selector is optional here; when omitted,
-    ``columns_resolved`` is an empty list and ``func`` decides what it touches.
+    A custom step takes **no** column selector: ``columns_resolved`` is always
+    an empty list and ``func`` alone decides what it touches. The wrapper
+    :meth:`CapData.prep_custom` forwards a ``columns=`` keyword on to ``func``
+    rather than treating it as a selector, and :meth:`to_config` omits the
+    selector keys, so a selector set by attribute assignment would not
+    serialize and would silently be lost on replay. Pass the columns ``func``
+    should act on as one of its own arguments instead.
     """
 
     _explanation_template = "Custom prep {call} was applied."
@@ -501,7 +551,13 @@ class Custom(BasePrepStep):
         self.kwargs = kwargs
 
     def _resolve_columns(self, capdata):
-        """Resolve the selector when given; otherwise return no columns."""
+        """Return no columns, since a custom step has no selector.
+
+        The inherited selector parameters exist on the class but are not part
+        of Custom's contract and do not serialize; the resolve branch below
+        only keeps a selector set by direct attribute assignment from
+        crashing on the base class's "exactly one of" check.
+        """
         given = [
             name
             for name in ("columns", "group", "group_regex")

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -192,7 +192,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         if missing:
             raise ValueError(
                 f"{type(self).__name__} selector resolved to columns absent "
-                f"from data: {missing}."
+                f"from data: {util.format_name_list(missing)}."
             )
         if not cols:
             raise ValueError(
@@ -212,7 +212,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
                     hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
                     raise ValueError(
                         f"Column group {group_id!r} is not in column_groups. "
-                        f"Available ids: {sorted(groups)}.{hint}"
+                        f"Available ids: {util.format_name_list(sorted(groups))}.{hint}"
                     )
         else:
             pattern = re.compile(self.group_regex)
@@ -220,7 +220,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
             if not ids:
                 raise ValueError(
                     f"group_regex {self.group_regex!r} matched no column group. "
-                    f"Available ids: {sorted(groups)}."
+                    f"Available ids: {util.format_name_list(sorted(groups))}."
                 )
         cols = []
         for group_id in ids:
@@ -267,7 +267,7 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
 
     def _explanation_values(self):
         """Substitution mapping for ``_explanation_template``."""
-        return {"columns": ", ".join(self.columns_resolved)}
+        return {"columns": util.format_name_list(self.columns_resolved)}
 
     def to_config(self):
         """Serialize this step to a yaml-safe config dict."""
@@ -303,7 +303,7 @@ class Scale(BasePrepStep):
 
     def _explanation_values(self):
         return {
-            "columns": ", ".join(self.columns_resolved),
+            "columns": util.format_name_list(self.columns_resolved),
             "factor": self.factor,
             "offset": self.offset,
         }
@@ -443,7 +443,7 @@ class ConvertUnits(BasePrepStep):
 
     def _explanation_values(self):
         return {
-            "columns": ", ".join(self.columns_resolved),
+            "columns": util.format_name_list(self.columns_resolved),
             "from_units": self.from_units,
             "to_units": self.to_units,
         }
@@ -464,7 +464,10 @@ class AsType(BasePrepStep):
         capdata.data[columns] = capdata.data[columns].astype(self.dtype)
 
     def _explanation_values(self):
-        return {"columns": ", ".join(self.columns_resolved), "dtype": self.dtype}
+        return {
+            "columns": util.format_name_list(self.columns_resolved),
+            "dtype": self.dtype,
+        }
 
 
 class DropColumns(BasePrepStep):
@@ -513,7 +516,10 @@ class RenameColumns(BasePrepStep):
         cols = list(self.column_map)
         missing = [c for c in cols if c not in capdata.data.columns]
         if missing:
-            raise ValueError(f"RenameColumns keys are absent from data: {missing}.")
+            raise ValueError(
+                f"RenameColumns keys are absent from data: "
+                f"{util.format_name_list(missing)}."
+            )
         return cols
 
     def _execute(self, capdata, columns):

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -335,9 +335,14 @@ def conversion_factors(from_units, to_units):
     Raises
     ------
     ValueError
-        If the units are identical, or the pair is not supported in either
-        direction.
+        If either unit is omitted (``None``), the units are identical, or the
+        pair is not supported in either direction.
     """
+    if from_units is None or to_units is None:
+        raise ValueError(
+            "from_units and to_units are both required; got "
+            f"from_units={from_units!r}, to_units={to_units!r}."
+        )
     src = _normalize_unit(from_units)
     dst = _normalize_unit(to_units)
     if src == dst:
@@ -390,9 +395,152 @@ class ConvertUnits(BasePrepStep):
         }
 
 
+class AsType(BasePrepStep):
+    """Cast the selected columns to a dtype, in place.
+
+    Covers the PVsyst frames that load as ``object`` because of a stray index
+    column and need ``astype(float)`` before any numeric filtering.
+    """
+
+    dtype = param.String(default="float64", doc="Target numpy/pandas dtype name.")
+
+    _explanation_template = "Columns {columns} were cast to {dtype}."
+
+    def _execute(self, capdata, columns):
+        capdata.data[columns] = capdata.data[columns].astype(self.dtype)
+
+    def _explanation_values(self):
+        return {"columns": ", ".join(self.columns_resolved), "dtype": self.dtype}
+
+
+class DropColumns(BasePrepStep):
+    """Drop the selected columns from ``data`` and ``column_groups``.
+
+    Delegates to :meth:`CapData.drop_cols`; the step exists so the action is
+    recorded and replayed, not to reimplement it. Changes column identity
+    rather than values, so it stays legal after filters are applied.
+    """
+
+    _explanation_template = "Columns {columns} were dropped."
+    _mutates_values = False
+
+    def _execute(self, capdata, columns):
+        capdata.drop_cols(columns, record=False)
+
+
+class RenameColumns(BasePrepStep):
+    """Rename columns in ``data`` and ``column_groups``.
+
+    Takes its columns from ``column_map`` rather than the three-way selector;
+    passing a selector is an error. Delegates to :meth:`CapData.rename_cols`.
+    """
+
+    column_map = param.Dict(
+        default=None, allow_None=True, doc="Mapping of old column name to new."
+    )
+
+    _explanation_template = "Columns {columns} were renamed."
+    _mutates_values = False
+
+    def _resolve_columns(self, capdata):
+        """Return the map's keys; reject the inherited selectors."""
+        selectors = [
+            name
+            for name in ("columns", "group", "group_regex")
+            if getattr(self, name) is not None
+        ]
+        if selectors:
+            raise ValueError(
+                "RenameColumns takes its columns from 'column_map'; remove "
+                f"{selectors}."
+            )
+        if not self.column_map:
+            raise ValueError("RenameColumns requires a non-empty 'column_map'.")
+        cols = list(self.column_map)
+        missing = [c for c in cols if c not in capdata.data.columns]
+        if missing:
+            raise ValueError(f"RenameColumns keys are absent from data: {missing}.")
+        return cols
+
+    def _execute(self, capdata, columns):
+        capdata.rename_cols(self.column_map, record=False)
+
+
+class Custom(BasePrepStep):
+    """Apply an arbitrary callable to the ``CapData`` as a prep step.
+
+    ``func`` is called as ``func(capdata, *args, **kwargs)`` and mutates
+    ``capdata.data`` in place; its return value is ignored. This is the escape
+    hatch for adjustments the declarative vocabulary does not cover, such as
+    blanking east-facing POA columns before sunrise.
+
+    Like ``filters.Custom``, ``func``/``args``/``kwargs`` are plain instance
+    attributes rather than ``param`` parameters, and ``func`` serializes to a
+    module-qualified name — a lambda cannot be exported.
+
+    The three-way column selector is optional here; when omitted,
+    ``columns_resolved`` is an empty list and ``func`` decides what it touches.
+    """
+
+    _explanation_template = "Custom prep {call} was applied."
+    _runtime_attrs = frozenset({"func", "args", "kwargs"})
+
+    def __init__(self, func, *args, custom_name=None, **kwargs):
+        super().__init__(custom_name=custom_name)
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def _resolve_columns(self, capdata):
+        """Resolve the selector when given; otherwise return no columns."""
+        given = [
+            name
+            for name in ("columns", "group", "group_regex")
+            if getattr(self, name) is not None
+        ]
+        if not given:
+            return []
+        return super()._resolve_columns(capdata)
+
+    def _execute(self, capdata, columns):
+        self.func(capdata, *self.args, **self.kwargs)
+
+    @property
+    def args_repr(self):
+        """Render ``func_name(arg, ..., k=v, ...)``."""
+        name = getattr(self.func, "__name__", repr(self.func))
+        arg_parts = [repr(a) for a in self.args]
+        kwarg_parts = [f"{k}={v!r}" for k, v in self.kwargs.items()]
+        return f"{name}({', '.join(arg_parts + kwarg_parts)})"
+
+    def _explanation_values(self):
+        return {"call": self.args_repr}
+
+    def to_config(self):
+        return {
+            "type": "Custom",
+            "func": util.callable_to_qualname(self.func),
+            "args": list(self.args),
+            "kwargs": dict(self.kwargs),
+            "custom_name": self.custom_name,
+        }
+
+    @classmethod
+    def from_config(cls, config):
+        config = dict(config)
+        func = util.callable_from_qualname(config["func"])
+        args = config.get("args") or []
+        kwargs = config.get("kwargs") or {}
+        return cls(func, *args, custom_name=config.get("custom_name"), **kwargs)
+
+
 PREP_REGISTRY = {
     "ConvertUnits": ConvertUnits,
     "Scale": Scale,
+    "AsType": AsType,
+    "DropColumns": DropColumns,
+    "RenameColumns": RenameColumns,
+    "Custom": Custom,
 }
 
 

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -357,8 +357,17 @@ def conversion_factors(from_units, to_units):
         return 1 / factor, -offset / factor
     supported = sorted(f"{a} -> {b}" for a, b in UNIT_CONVERSIONS)
     known_units = {u for pair in UNIT_CONVERSIONS for u in pair}
-    suggestion = difflib.get_close_matches(src, known_units, n=1)
-    hint = f" Did you mean {suggestion[0]!r} for from_units?" if suggestion else ""
+    # Only suggest for the unit that is actually unknown; when both units are
+    # valid the pair is simply unsupported, so echoing a correct argument back
+    # would misdirect.
+    suggestions = []
+    for label, unit in (("from_units", src), ("to_units", dst)):
+        if unit in known_units:
+            continue
+        match = difflib.get_close_matches(unit, known_units, n=1)
+        if match:
+            suggestions.append(f"{match[0]!r} for {label}")
+    hint = f" Did you mean {' or '.join(suggestions)}?" if suggestions else ""
     raise ValueError(
         f"No conversion from {src!r} to {dst!r}. Inverses of the supported "
         f"pairs are derived automatically; supported pairs: {supported}. Use "

--- a/src/captest/util.py
+++ b/src/captest/util.py
@@ -834,3 +834,36 @@ def params_to_config(obj):
         for k, v in obj.param.values().items()
         if k != "name"
     }
+
+
+def format_name_list(names, cutoff=10, edge=3):
+    """Render a sequence of names as a string, truncating long sequences.
+
+    Mirrors the truncation ``CapData.agg_group`` applies to its verbose
+    output: sequences longer than ``cutoff`` are shown as the first and last
+    ``edge`` names with an ellipsis between them, followed by the full count.
+    A site with dozens of thermocouples otherwise turns one prep explanation
+    or error message into an unreadable wall of column names.
+
+    Parameters
+    ----------
+    names : sequence of str
+        Column names or group ids to render.
+    cutoff : int, default 10
+        Maximum number of names to list in full. A sequence at or below this
+        length is joined unchanged.
+    edge : int, default 3
+        Number of names shown at each end when the sequence is truncated.
+
+    Returns
+    -------
+    str
+        Comma-separated names, e.g. ``"a, b, c"`` or
+        ``"a, b, c, ..., x, y, z (26 total)"``.
+    """
+    names = [str(name) for name in names]
+    if len(names) <= cutoff:
+        return ", ".join(names)
+    head = ", ".join(names[:edge])
+    tail = ", ".join(names[-edge:])
+    return f"{head}, ..., {tail} ({len(names)} total)"

--- a/src/captest/util.py
+++ b/src/captest/util.py
@@ -1,3 +1,5 @@
+import copy
+import difflib
 import importlib
 import json
 import re
@@ -750,3 +752,85 @@ def parse_regression_formula(formula: str) -> tuple[list[str], list[str]]:
     rhs_list = [n for n in rhs_list if n != "Intercept"]
 
     return lhs_list, rhs_list
+
+
+class StrictAttrs:
+    """Reject assignment to names that are neither params nor runtime state.
+
+    Mixin for ``param.Parameterized`` subclasses. ``param`` accepts arbitrary
+    attribute assignment, which makes an edit-then-replay workflow silently do
+    nothing when a param name is mistyped. Raising at the assignment surfaces
+    the typo instead of producing an unchanged re-run.
+
+    A subclass that writes a plain (non-param) attribute must name it in its
+    own ``_runtime_attrs``; ``__init_subclass__`` unions those declarations
+    down the hierarchy, so each subclass declares only what it adds.
+    Leading-underscore names pass through unchecked; they cover ``param``'s
+    own instance internals as well as subclasses' private state.
+
+    Notes
+    -----
+    Must be combined with ``param.Parameterized`` (``self.param`` is
+    required)::
+
+        class Step(StrictAttrs, param.Parameterized):
+            ...
+    """
+
+    _runtime_attrs = frozenset()
+
+    def __init_subclass__(cls, **kwargs):
+        """Union each subclass's ``_runtime_attrs`` with those of its bases."""
+        super().__init_subclass__(**kwargs)
+        cls._runtime_attrs = frozenset().union(
+            *(base.__dict__.get("_runtime_attrs", frozenset()) for base in cls.__mro__)
+        )
+
+    def __setattr__(self, name, value):
+        """Allow params, runtime attrs, and private names; reject the rest.
+
+        Raises
+        ------
+        AttributeError
+            If ``name`` is neither a declared param, a name in
+            ``_runtime_attrs``, nor leading-underscore. The message lists the
+            settable names and suggests the closest match.
+        """
+        if (
+            name.startswith("_")
+            or name in self.param
+            or name in type(self)._runtime_attrs
+        ):
+            super().__setattr__(name, value)
+            return
+        settable = sorted(set(self.param) | type(self)._runtime_attrs)
+        suggestion = difflib.get_close_matches(name, settable, n=1)
+        hint = f" Did you mean {suggestion[0]!r}?" if suggestion else ""
+        raise AttributeError(
+            f"{type(self).__name__} has no parameter or attribute {name!r}. "
+            f"Settable names: {settable}.{hint}"
+        )
+
+
+def params_to_config(obj):
+    """Serialize a ``param.Parameterized``'s values to a yaml-safe dict.
+
+    Every param value except the param-system ``name`` is deep-copied and
+    passed through :func:`to_native`, so the result is an independent snapshot
+    that survives ``yaml.safe_dump``.
+
+    Parameters
+    ----------
+    obj : param.Parameterized
+        Object whose param values are serialized.
+
+    Returns
+    -------
+    dict
+        Mapping of param name to native-python value.
+    """
+    return {
+        k: to_native(copy.deepcopy(v))
+        for k, v in obj.param.values().items()
+        if k != "name"
+    }

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import json
 import os
+import sys
 import unittest
 
 import holoviews as hv
@@ -3865,11 +3866,13 @@ class TestPrepSurface:
         assert {k: list(v) for k, v in cd.column_groups.items()} == before_groups
         assert cd.prep == []
 
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="add_note")
     def test_run_prep_failure_note_names_the_step(self, cd):
         config = [{"type": "Scale", "columns": ["not_a_column"], "factor": 1.0}]
         with pytest.raises(ValueError) as excinfo:
             cd.run_prep(config)
-        assert any("Scale" in note for note in excinfo.value.__notes__)
+        notes = getattr(excinfo.value, "__notes__", [])
+        assert any("Scale" in note for note in notes)
 
     def test_reset_filter_leaves_prep_intact(self, cd):
         cd.prep_scale(columns=["power_1"], factor=0.001)

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -25,6 +25,7 @@ from captest import (
     filters,
     io,
     load_pvsyst,
+    prep,
 )
 
 data = np.arange(0, 1300, 54.167)
@@ -3745,6 +3746,109 @@ class TestPipelineConfig:
         reloaded = yaml.safe_load(dumped)
         irr_steps = [d for d in reloaded if d["type"] == "Irradiance"]
         assert irr_steps[-1]["ref_val"] == pytest.approx(float(ref_val))
+
+
+class TestPrepSurface:
+    """CapData's prep wrappers, replay, and description."""
+
+    @pytest.fixture
+    def cd(self):
+        index = pd.date_range("1/1/2021 12:00", freq="5min", periods=4)
+        out = pvc.CapData("test")
+        out.data = pd.DataFrame(
+            {
+                "temp_amb_1": [32.0, 41.0, 50.0, 212.0],
+                "power_1": [1000.0, 2000.0, 3000.0, 4000.0],
+            },
+            index=index,
+        )
+        out.column_groups = cg.ColumnGroups(
+            {"temp_amb": ["temp_amb_1"], "real_pwr": ["power_1"]}
+        )
+        return out
+
+    def test_prep_convert_units_wrapper(self, cd):
+        cd.prep_convert_units(group="temp_amb", from_units="F", to_units="C")
+        assert cd.data["temp_amb_1"].iloc[0] == pytest.approx(0.0)
+        assert isinstance(cd.prep[0], prep.ConvertUnits)
+
+    def test_prep_scale_wrapper(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        assert cd.data["power_1"].tolist() == [1.0, 2.0, 3.0, 4.0]
+
+    def test_prep_astype_wrapper(self, cd):
+        cd.data["power_1"] = ["1", "2", "3", "4"]
+        cd.prep_astype(columns=["power_1"], dtype="float64")
+        assert cd.data["power_1"].dtype == np.dtype("float64")
+
+    def test_prep_custom_wrapper(self, cd):
+        def zero_power(capdata):
+            capdata.data["power_1"] = 0.0
+
+        cd.prep_custom(zero_power)
+        assert (cd.data["power_1"] == 0.0).all()
+
+    def test_duplicate_step_raises(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        with pytest.raises(RuntimeError, match="already applied"):
+            cd.prep_scale(columns=["power_1"], factor=0.001)
+
+    def test_different_params_is_not_a_duplicate(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        cd.prep_scale(columns=["power_1"], factor=2.0)
+        assert len(cd.prep) == 2
+
+    def test_prep_to_config_round_trips(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        config = cd.prep_to_config()
+        assert config[0]["type"] == "Scale"
+        fresh = pvc.CapData("fresh")
+        fresh.data = cd.data * 1000
+        fresh.column_groups = cd.column_groups
+        fresh.run_prep(config)
+        assert fresh.data["power_1"].tolist() == [1.0, 2.0, 3.0, 4.0]
+
+    def test_run_prep_on_populated_chain_raises(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        with pytest.raises(RuntimeError, match="reload"):
+            cd.run_prep([{"type": "Scale", "columns": ["power_1"], "factor": 0.001}])
+
+    def test_run_prep_batch_is_transactional(self, cd):
+        before = cd.data.copy()
+        config = [
+            {"type": "Scale", "columns": ["power_1"], "factor": 0.001},
+            {
+                "type": "ConvertUnits",
+                "columns": ["temp_amb_1"],
+                "from_units": "F",
+                "to_units": "C",
+            },
+            {"type": "Scale", "columns": ["not_a_column"], "factor": 1.0},
+        ]
+        with pytest.raises(ValueError):
+            cd.run_prep(config)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert cd.prep == []
+
+    def test_run_prep_failure_note_names_the_step(self, cd):
+        config = [{"type": "Scale", "columns": ["not_a_column"], "factor": 1.0}]
+        with pytest.raises(ValueError) as excinfo:
+            cd.run_prep(config)
+        assert any("Scale" in note for note in excinfo.value.__notes__)
+
+    def test_reset_filter_leaves_prep_intact(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        cd.reset_filter()
+        assert len(cd.prep) == 1
+
+    def test_describe_prep(self, cd):
+        cd.prep_convert_units(group="temp_amb", from_units="F", to_units="C")
+        assert "temp_amb_1" in cd.describe_prep()
+        assert "F" in cd.describe_prep()
+
+    def test_describe_filters_does_not_mention_prep(self, cd):
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        assert cd.describe_filters() == ""
 
 
 class TestPrepRecordingOnDropAndRename:

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -3747,5 +3747,77 @@ class TestPipelineConfig:
         assert irr_steps[-1]["ref_val"] == pytest.approx(float(ref_val))
 
 
+class TestPrepRecordingOnDropAndRename:
+    """drop_cols / rename_cols record by default; internal callers opt out."""
+
+    @pytest.fixture
+    def cd(self):
+        index = pd.date_range("1/1/2021 12:00", freq="5min", periods=4)
+        out = pvc.CapData("test")
+        out.data = pd.DataFrame(
+            {"a": [1.0, 2.0, 3.0, 4.0], "b": [5.0, 6.0, 7.0, 8.0]}, index=index
+        )
+        out.column_groups = cg.ColumnGroups({"grp": ["a", "b"]})
+        return out
+
+    def test_drop_cols_records_by_default(self, cd):
+        cd.drop_cols(["a"])
+        assert [type(s).__name__ for s in cd.prep] == ["DropColumns"]
+        assert cd.prep[0].columns == ["a"]
+
+    def test_drop_cols_record_false_records_nothing(self, cd):
+        cd.drop_cols(["a"], record=False)
+        assert cd.prep == []
+        assert "a" not in cd.data.columns
+
+    def test_rename_cols_records_by_default(self, cd):
+        cd.rename_cols({"a": "c"})
+        assert [type(s).__name__ for s in cd.prep] == ["RenameColumns"]
+
+    def test_rename_cols_record_false_records_nothing(self, cd):
+        cd.rename_cols({"a": "c"}, record=False)
+        assert cd.prep == []
+        assert "c" in cd.data.columns
+
+
+class TestNoInternalCallerRecordsPrep:
+    """Source scan: internal drop_cols/rename_cols calls must pass record=False."""
+
+    def test_agg_sensors_leaves_prep_empty(self, meas):
+        meas.agg_sensors()
+        assert meas.prep == []
+
+    def test_every_internal_call_site_opts_out(self):
+        import ast
+        import pathlib
+
+        import captest
+
+        src_dir = pathlib.Path(captest.__file__).parent
+        offenders = []
+        for path in sorted(src_dir.glob("*.py")):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not isinstance(func, ast.Attribute):
+                    continue
+                if func.attr not in ("drop_cols", "rename_cols"):
+                    continue
+                opts_out = any(
+                    kw.arg == "record"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is False
+                    for kw in node.keywords
+                )
+                if not opts_out:
+                    offenders.append(f"{path.name}:{node.lineno}")
+        assert offenders == [], (
+            "internal drop_cols/rename_cols calls must pass record=False so "
+            f"they do not record a prep step: {offenders}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -3793,6 +3793,13 @@ class TestPrepSurface:
         with pytest.raises(RuntimeError, match="already applied"):
             cd.prep_scale(columns=["power_1"], factor=0.001)
 
+    def test_custom_name_does_not_defeat_the_duplicate_guard(self, cd):
+        """The label is presentation; a relabelled repeat is still a repeat."""
+        cd.prep_scale(columns=["power_1"], factor=0.001, custom_name="first")
+        with pytest.raises(RuntimeError, match="already applied"):
+            cd.prep_scale(columns=["power_1"], factor=0.001, custom_name="second")
+        assert len(cd.prep) == 1
+
     def test_different_params_is_not_a_duplicate(self, cd):
         cd.prep_scale(columns=["power_1"], factor=0.001)
         cd.prep_scale(columns=["power_1"], factor=2.0)
@@ -3830,6 +3837,34 @@ class TestPrepSurface:
         pd.testing.assert_frame_equal(cd.data, before)
         assert cd.prep == []
 
+    def test_batch_rollback_restores_column_groups_after_drop(self, cd):
+        """DropColumns edits column_groups too, so rollback must undo both."""
+        before = cd.data.copy()
+        before_groups = {k: list(v) for k, v in cd.column_groups.items()}
+        config = [
+            {"type": "DropColumns", "columns": ["power_1"]},
+            {"type": "Scale", "columns": ["not_a_column"], "factor": 1.0},
+        ]
+        with pytest.raises(ValueError):
+            cd.run_prep(config)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert {k: list(v) for k, v in cd.column_groups.items()} == before_groups
+        assert cd.prep == []
+
+    def test_batch_rollback_restores_column_groups_after_rename(self, cd):
+        """A rolled-back rename must not leave groups naming absent columns."""
+        before = cd.data.copy()
+        before_groups = {k: list(v) for k, v in cd.column_groups.items()}
+        config = [
+            {"type": "RenameColumns", "column_map": {"power_1": "POWER"}},
+            {"type": "Scale", "columns": ["not_a_column"], "factor": 1.0},
+        ]
+        with pytest.raises(ValueError):
+            cd.run_prep(config)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert {k: list(v) for k, v in cd.column_groups.items()} == before_groups
+        assert cd.prep == []
+
     def test_run_prep_failure_note_names_the_step(self, cd):
         config = [{"type": "Scale", "columns": ["not_a_column"], "factor": 1.0}]
         with pytest.raises(ValueError) as excinfo:
@@ -3849,6 +3884,18 @@ class TestPrepSurface:
     def test_describe_filters_does_not_mention_prep(self, cd):
         cd.prep_scale(columns=["power_1"], factor=0.001)
         assert cd.describe_filters() == ""
+
+    def test_copy_carries_the_prep_chain(self, cd):
+        """`copy` takes prepped values, so it must take the chain with them."""
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        dupe = cd.copy()
+        assert dupe.prep_to_config() == cd.prep_to_config()
+        assert dupe.data["power_1"].tolist() == [1.0, 2.0, 3.0, 4.0]
+        # The chain is deep-copied, so the two objects do not share steps.
+        assert dupe.prep[0] is not cd.prep[0]
+        # And the copy is still guarded against a second, doubling prep.
+        with pytest.raises(RuntimeError, match="un-prepped"):
+            dupe.run_prep(cd.prep_to_config())
 
 
 class TestPrepRecordingOnDropAndRename:

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -3921,3 +3921,80 @@ class TestCapTestPrep:
         sub = tst.to_mapping()
         assert "sim_prep" not in sub
         assert "meas_prep" not in sub
+
+    def test_prep_replays_on_both_sides_under_default_run_setup(
+        self, meas_cd_default, sim_cd_default
+    ):
+        """Default ``run_setup=True`` load path preps both sides exactly once."""
+        meas_raw_max = meas_cd_default.data["meter_power"].max()
+        sim_raw_max = sim_cd_default.data["E_Grid"].max()
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            meas_path="meas.csv",
+            sim_path="sim.CSV",
+            meas_loader=lambda p, **k: meas_cd_default,
+            sim_loader=lambda p, **k: sim_cd_default,
+            meas_prep=[{"type": "Scale", "columns": ["meter_power"], "factor": 0.001}],
+            sim_prep=self.scale_config,
+            ac_nameplate=6_000_000,
+        )
+        assert tst._resolved_setup is not None  # setup() ran
+        assert len(tst.meas.prep) == 1 and len(tst.sim.prep) == 1
+        assert tst.meas.data["meter_power"].max() == pytest.approx(meas_raw_max * 0.001)
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(sim_raw_max * 0.001)
+
+    def test_meas_prep_replays_on_meas_side(self, meas_cd_default):
+        """``meas_prep`` drives the meas side, and leaves ``sim_prep`` empty."""
+        raw_max = meas_cd_default.data["meter_power"].max()
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            meas_path="meas.csv",
+            meas_loader=lambda p, **k: meas_cd_default,
+            meas_prep=[{"type": "Scale", "columns": ["meter_power"], "factor": 0.001}],
+            run_setup=False,
+        )
+        assert len(tst.meas.prep) == 1
+        assert tst.meas.data["meter_power"].max() == pytest.approx(raw_max * 0.001)
+        assert tst.sim_prep == []
+
+    def test_prebuilt_meas_warns_naming_the_meas_side(self, meas_cd_default):
+        """The pre-built warning names the side it was raised for."""
+        with pytest.warns(UserWarning, match="'meas_prep' steps were not applied"):
+            tst = CapTest.from_params(
+                test_setup="e2848_default",
+                meas=meas_cd_default,
+                meas_prep=[
+                    {"type": "Scale", "columns": ["meter_power"], "factor": 0.001}
+                ],
+                run_setup=False,
+            )
+        assert tst.meas.prep == []
+
+    def test_run_test_does_not_rerun_prep(self, meas_cd_default, sim_cd_default):
+        """A second ``run_test`` leaves prepped values untouched (no double-prep)."""
+        sim_raw_max = sim_cd_default.data["E_Grid"].max()
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            meas_path="meas.csv",
+            sim_path="sim.CSV",
+            meas_loader=lambda p, **k: meas_cd_default,
+            sim_loader=lambda p, **k: sim_cd_default,
+            sim_prep=self.scale_config,
+            ac_nameplate=6_000_000,
+            test_tolerance="- 4",
+        )
+        tst.meas.filter_irr(tst.min_irr, tst.max_irr)
+        tst.sim.filter_irr(tst.min_irr, tst.max_irr)
+        tst.sim.filter_shade(fshdbm=tst.fshdbm)
+        tst.sim.filter_time(start=_SIM_WINDOW[0], end=_SIM_WINDOW[1])
+        tst.rep_cond()
+        tst.meas.fit_regression(summary=False)
+        tst.sim.fit_regression(summary=False)
+
+        tst.run_test()
+        after_first = tst.sim.data["E_Grid"].copy()
+        tst.run_test()
+
+        pd.testing.assert_series_equal(tst.sim.data["E_Grid"], after_first)
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(sim_raw_max * 0.001)
+        assert len(tst.sim.prep) == 1

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -3858,6 +3858,75 @@ class TestCapTestPrep:
         assert len(tst.sim.prep) == 1
         assert tst.sim.data["E_Grid"].max() == pytest.approx(_E_GRID_RAW_MAX / 1000)
 
+    def _reloaded_onto_other_file(self, pvsyst_file, other_pvsyst_file, sim_prep):
+        """Build the issue-2.2 scenario and reload it onto the second file.
+
+        The sim pipeline filters power against a kW nameplate, so it only
+        keeps rows if ``E_Grid`` has been scaled from W to kW by prep.
+
+        Parameters
+        ----------
+        pvsyst_file, other_pvsyst_file : str
+            Paths to the first and second PVsyst example CSVs.
+        sim_prep : list of dict
+            Prep config for the sim side; empty models the pre-feature
+            behavior where the adjustment was hand-written and lost.
+
+        Returns
+        -------
+        CapTest
+            Reloaded onto ``other_pvsyst_file``, filters pending.
+        """
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            sim_path=pvsyst_file,
+            sim_prep=sim_prep,
+            ac_nameplate=6000.0,  # kW, matching the scaled E_Grid column
+            run_setup=False,
+        )
+        tst.sim.filter_irr(200, 800)
+        tst.sim.filter_power(tst.ac_nameplate, percent=0.05)
+        tst.reload("sim", path=other_pvsyst_file, verbose=False)
+        return tst
+
+    def test_reload_then_run_test_reaches_a_fitted_regression(
+        self, pvsyst_file, other_pvsyst_file
+    ):
+        """End-to-end regression test for the feature's motivating failure.
+
+        Integration issue 2.2: the W -> kW division of ``E_Grid`` was a
+        hand-written notebook statement, so ``reload`` discarded it, the
+        kW-scaled power filter emptied the frame, and the run died inside
+        ``fit_regression``. With prep declared, the same sequence has to run
+        all the way to a fitted regression on real reloaded data.
+        """
+        tst = self._reloaded_onto_other_file(
+            pvsyst_file, other_pvsyst_file, self.scale_config
+        )
+        assert len(tst.sim.prep) == 1  # replayed against the freshly loaded file
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(_E_GRID_RAW_MAX / 1000)
+
+        tst.run_test(side="sim")
+
+        assert tst.sim.regression_results is not None
+        assert tst.sim.regression_results.nobs > 0
+        assert not tst.sim.data_filtered.empty
+        assert "poa" in tst.sim.regression_results.params.index
+
+    def test_without_prep_the_same_reload_still_dies_in_the_regression(
+        self, pvsyst_file, other_pvsyst_file
+    ):
+        """Pins the failure prep fixes, so the test above cannot go vacuous.
+
+        Same pipeline with no ``sim_prep``: ``E_Grid`` comes back in W, the
+        power filter removes every row, and ``fit_regression`` raises the
+        zero-size reduction error quoted in the design spec.
+        """
+        tst = self._reloaded_onto_other_file(pvsyst_file, other_pvsyst_file, [])
+        assert tst.sim.prep == []
+        with pytest.raises(ValueError, match="zero-size array"):
+            tst.run_test(side="sim")
+
     def test_reload_stashes_applied_prep_chain(self, pvsyst_file, other_pvsyst_file):
         """Prep applied by hand survives a reload, mirroring the filter chain."""
         tst = CapTest.from_params(

--- a/tests/test_captest.py
+++ b/tests/test_captest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -49,6 +50,22 @@ _DEFAULT_FIXTURE_PRESETS = [
         "bifi_power_tc_etotal_rear_shade_meas",
     }
 ]
+
+# Maximum of the ``E_Grid`` column (W) in the shipped PVsyst example files,
+# used by the prep tests to prove a Scale step actually ran.
+_E_GRID_RAW_MAX = 5898420.0
+
+
+@pytest.fixture
+def pvsyst_file():
+    """Absolute path to the shipped PVsyst example CSV."""
+    return str(Path("./tests/data/pvsyst_example_HourlyRes_2.CSV").resolve())
+
+
+@pytest.fixture
+def other_pvsyst_file():
+    """Absolute path to a second PVsyst example CSV (excel-style dates)."""
+    return str(Path("./tests/data/pvsyst_example_HourlyRes_2_xls_dates.csv").resolve())
 
 
 class TestTestSetupsRegistry:
@@ -3801,3 +3818,106 @@ class TestManualRcStaging:
         ct2.setup()
         assert ct2.rc_source == "manual" and ct2.rc is not None
         assert ct2._pending_manual_rc is None
+
+
+class TestCapTestPrep:
+    """``meas_prep`` / ``sim_prep``: replay at load and config round-trip."""
+
+    scale_config = [{"type": "Scale", "columns": ["E_Grid"], "factor": 0.001}]
+
+    def test_prep_replays_after_load(self, pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            sim_path=pvsyst_file,
+            sim_prep=self.scale_config,
+            run_setup=False,
+        )
+        assert len(tst.sim.prep) == 1
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(_E_GRID_RAW_MAX / 1000)
+
+    def test_prep_not_rerun_by_setup(self, pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            sim_path=pvsyst_file,
+            sim_prep=self.scale_config,
+            run_setup=False,
+        )
+        after_load = tst.sim.data["E_Grid"].copy()
+        tst.setup(side="sim", verbose=False)
+        pd.testing.assert_series_equal(tst.sim.data["E_Grid"], after_load)
+        assert len(tst.sim.prep) == 1
+
+    def test_reload_replays_prep(self, pvsyst_file, other_pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            sim_path=pvsyst_file,
+            sim_prep=self.scale_config,
+            run_setup=False,
+        )
+        tst.reload("sim", path=other_pvsyst_file, verbose=False)
+        assert len(tst.sim.prep) == 1
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(_E_GRID_RAW_MAX / 1000)
+
+    def test_reload_stashes_applied_prep_chain(self, pvsyst_file, other_pvsyst_file):
+        """Prep applied by hand survives a reload, mirroring the filter chain."""
+        tst = CapTest.from_params(
+            test_setup="e2848_default", sim_path=pvsyst_file, run_setup=False
+        )
+        tst.sim.prep_scale(columns=["E_Grid"], factor=0.001)
+        tst.reload("sim", path=other_pvsyst_file, verbose=False)
+        assert [d["type"] for d in tst.sim_prep] == ["Scale"]
+        assert len(tst.sim.prep) == 1
+        assert tst.sim.data["E_Grid"].max() == pytest.approx(_E_GRID_RAW_MAX / 1000)
+
+    def test_prebuilt_capdata_warns_and_does_not_apply(self, pvsyst):
+        with pytest.warns(UserWarning, match="not applied"):
+            tst = CapTest.from_params(
+                test_setup="e2848_default",
+                sim=pvsyst,
+                sim_prep=self.scale_config,
+                run_setup=False,
+            )
+        assert tst.sim.prep == []
+        assert tst.sim_prep  # config kept
+
+    def test_prebuilt_prep_config_still_round_trips(self, pvsyst):
+        with pytest.warns(UserWarning):
+            tst = CapTest.from_params(
+                test_setup="e2848_default",
+                sim=pvsyst,
+                sim_prep=self.scale_config,
+                run_setup=False,
+            )
+        assert tst.to_mapping()["sim_prep"][0]["type"] == "Scale"
+
+    def test_to_yaml_from_yaml_round_trip(self, tmp_path, pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default",
+            sim_path=pvsyst_file,
+            sim_prep=self.scale_config,
+            run_setup=False,
+        )
+        path = tmp_path / "config.yaml"
+        tst.to_yaml(path)
+        reloaded = CapTest.from_yaml(path, run_setup=False)
+        assert reloaded.sim_prep == tst.to_mapping()["sim_prep"]
+        assert reloaded.sim.prep_to_config() == tst.sim.prep_to_config()
+        assert len(reloaded.sim.prep) == 1
+        assert reloaded.sim.data["E_Grid"].max() == pytest.approx(
+            _E_GRID_RAW_MAX / 1000
+        )
+
+    def test_applied_chain_wins_over_stored_config(self, pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default", sim_path=pvsyst_file, run_setup=False
+        )
+        tst.sim.prep_scale(columns=["E_Grid"], factor=0.001)
+        assert tst.to_mapping()["sim_prep"][0]["factor"] == 0.001
+
+    def test_prep_key_omitted_when_empty(self, pvsyst_file):
+        tst = CapTest.from_params(
+            test_setup="e2848_default", sim_path=pvsyst_file, run_setup=False
+        )
+        sub = tst.to_mapping()
+        assert "sim_prep" not in sub
+        assert "meas_prep" not in sub

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -191,6 +191,16 @@ class TestConvertUnits:
                 columns=["wind_1"], from_units="furlongs", to_units="m/s"
             ).run(cd)
 
+    def test_unsupported_pair_hint_targets_the_wrong_unit(self, cd):
+        """A valid from_units must not be echoed back; the typo'd to_units is."""
+        with pytest.raises(ValueError) as exc:
+            prep.ConvertUnits(columns=["wind_1"], from_units="mph", to_units="m/z").run(
+                cd
+            )
+        message = str(exc.value)
+        assert "for from_units" not in message
+        assert "'m/s' for to_units" in message
+
     def test_identical_units_raise(self, cd):
         with pytest.raises(ValueError, match="identical"):
             prep.ConvertUnits(columns=["wind_1"], from_units="C", to_units="C").run(cd)

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -150,3 +150,68 @@ class TestRegistry:
     def test_unknown_type_raises_with_close_match(self):
         with pytest.raises(ValueError, match="Did you mean 'Scale'"):
             prep.prep_step_from_config({"type": "Scaled"})
+
+
+class TestConvertUnits:
+    def test_fahrenheit_to_celsius_is_affine(self, cd):
+        prep.ConvertUnits(columns=["temp_amb_1"], from_units="F", to_units="C").run(cd)
+        assert cd.data["temp_amb_1"].tolist() == pytest.approx([0.0, 5.0, 10.0, 100.0])
+
+    def test_scale_alone_cannot_express_it(self, cd):
+        """32 F is 0 C, not 17.8 — the case that disproves calcparams.scale."""
+        prep.Scale(columns=["temp_amb_1"], factor=5 / 9).run(cd)
+        assert cd.data["temp_amb_1"].iloc[0] == pytest.approx(17.78, abs=0.01)
+
+    def test_mph_to_meters_per_second(self, cd):
+        prep.ConvertUnits(group="wind", from_units="mph", to_units="m/s").run(cd)
+        assert cd.data["wind_1"].iloc[0] == pytest.approx(4.4704)
+
+    def test_group_regex_converts_every_temperature_group(self, cd):
+        prep.ConvertUnits(group_regex="^temp", from_units="F", to_units="C").run(cd)
+        assert cd.data["temp_amb_1"].iloc[0] == pytest.approx(0.0)
+        assert cd.data["temp_bom_1"].iloc[0] == pytest.approx(25.0)
+
+    def test_round_trip_within_tolerance(self, cd):
+        original = cd.data["temp_amb_1"].tolist()
+        prep.ConvertUnits(columns=["temp_amb_1"], from_units="F", to_units="C").run(cd)
+        cd.prep = []
+        prep.ConvertUnits(columns=["temp_amb_1"], from_units="C", to_units="F").run(cd)
+        assert cd.data["temp_amb_1"].tolist() == pytest.approx(original)
+
+    def test_aliases_are_case_insensitive(self, cd):
+        prep.ConvertUnits(
+            columns=["temp_amb_1"], from_units="degF", to_units="Celsius"
+        ).run(cd)
+        assert cd.data["temp_amb_1"].iloc[0] == pytest.approx(0.0)
+
+    def test_unknown_pair_raises_listing_supported(self, cd):
+        with pytest.raises(ValueError, match="supported"):
+            prep.ConvertUnits(
+                columns=["wind_1"], from_units="furlongs", to_units="m/s"
+            ).run(cd)
+
+    def test_identical_units_raise(self, cd):
+        with pytest.raises(ValueError, match="identical"):
+            prep.ConvertUnits(columns=["wind_1"], from_units="C", to_units="C").run(cd)
+
+    def test_config_round_trip(self):
+        step = prep.ConvertUnits(group_regex="^temp", from_units="F", to_units="C")
+        rebuilt = prep.prep_step_from_config(step.to_config())
+        assert isinstance(rebuilt, prep.ConvertUnits)
+        assert rebuilt.group_regex == "^temp"
+        assert rebuilt.from_units == "F"
+
+    def test_explanation_names_the_units(self, cd):
+        step = prep.ConvertUnits(group="wind", from_units="mph", to_units="m/s")
+        step.run(cd)
+        assert "mph" in step.explanation and "m/s" in step.explanation
+
+    def test_inverse_is_derived_not_tabulated(self):
+        forward = prep.conversion_factors("F", "C")
+        inverse = prep.conversion_factors("C", "F")
+        value = 68.0
+        celsius = value * forward[0] + forward[1]
+        assert celsius * inverse[0] + inverse[1] == pytest.approx(value)
+
+    def test_registered(self):
+        assert prep.PREP_REGISTRY["ConvertUnits"] is prep.ConvertUnits

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -121,6 +121,21 @@ class TestAtomicFailure:
         assert cd.prep == []
         pd.testing.assert_frame_equal(cd.data, before_bad)
 
+    def test_failed_step_restores_column_groups_too(self, cd):
+        """A step that reaches column_groups before failing rolls both back."""
+
+        def drop_then_fail(capdata):
+            capdata.drop_cols(["power_1"], record=False)
+            raise RuntimeError("boom")
+
+        before = cd.data.copy()
+        before_groups = {k: list(v) for k, v in cd.column_groups.items()}
+        with pytest.raises(RuntimeError, match="boom"):
+            prep.Custom(drop_then_fail).run(cd)
+        assert cd.prep == []
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert {k: list(v) for k, v in cd.column_groups.items()} == before_groups
+
 
 class TestOrderingGuard:
     def test_value_mutating_step_after_filtering_raises(self, cd):

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -102,6 +102,22 @@ class TestSelectors:
         with pytest.raises(ValueError, match="Did you mean 'wind'"):
             prep.Scale(group="wnd", factor=1.0).run(cd)
 
+    def test_anchored_group_regex_excludes_inverter_temps(self, cd):
+        """The documented '^temp_(amb|bom)$' must not reach temp_inv groups."""
+        cd.data["temp_inv_1"] = [1.0, 2.0, 3.0, 4.0]
+        cd.column_groups["temp_inv"] = ["temp_inv_1"]
+        step = prep.Scale(group_regex="^temp_(amb|bom)$", factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["temp_amb_1", "temp_bom_1"]
+
+    def test_unanchored_group_regex_over_matches(self, cd):
+        """Why the docs anchor it: '^temp' also picks up inverter temps."""
+        cd.data["temp_inv_1"] = [1.0, 2.0, 3.0, 4.0]
+        cd.column_groups["temp_inv"] = ["temp_inv_1"]
+        step = prep.Scale(group_regex="^temp", factor=1.0)
+        step.run(cd)
+        assert "temp_inv_1" in step.columns_resolved
+
     def test_group_regex_matching_nothing_raises(self, cd):
         with pytest.raises(ValueError, match="nomatch"):
             prep.Scale(group_regex="nomatch", factor=1.0).run(cd)

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -4,8 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from captest import capdata as pvc
-from captest import prep
+from captest import capdata as pvc, prep
 from captest.columngroups import ColumnGroups
 
 

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -421,3 +421,72 @@ class TestLongColumnListTruncation:
         step = prep.ConvertUnits(group="temp_amb", from_units="F", to_units="C")
         step.run(cd_many_columns)
         assert len(step.columns_resolved) == 25
+
+
+class TestDuplicateGuardOnResolvedColumns:
+    """The duplicate guard compares resolved columns, not the selector."""
+
+    def test_same_column_via_different_selectors_raises(self, cd):
+        """columns=[...] then group=... reaching the same column is a double scale."""
+        cd.prep_scale(columns=["wind_1"], factor=2.0)
+        with pytest.raises(RuntimeError, match="already applied"):
+            cd.prep_scale(group="wind", factor=2.0)
+        assert cd.data["wind_1"].tolist() == [20.0, 40.0, 60.0, 80.0]
+
+    def test_group_then_explicit_column_raises(self, cd):
+        cd.prep_scale(group="wind", factor=2.0)
+        with pytest.raises(RuntimeError, match="already applied"):
+            cd.prep_scale(columns=["wind_1"], factor=2.0)
+
+    def test_partial_overlap_raises(self, cd):
+        """A second step re-covering only one earlier column still double-scales it."""
+        cd.prep_scale(columns=["wind_1", "power_1"], factor=2.0)
+        with pytest.raises(RuntimeError, match="power_1"):
+            cd.prep_scale(columns=["power_1", "temp_amb_1"], factor=2.0)
+
+    def test_disjoint_columns_allowed(self, cd):
+        cd.prep_scale(columns=["wind_1"], factor=2.0)
+        cd.prep_scale(columns=["power_1"], factor=2.0)
+        assert len(cd.prep) == 2
+
+    def test_different_settings_on_same_column_allowed(self, cd):
+        """F->C then C->F on one column is a deliberate round trip."""
+        cd.prep_convert_units(columns=["temp_amb_1"], from_units="F", to_units="C")
+        cd.prep_convert_units(columns=["temp_amb_1"], from_units="C", to_units="F")
+        assert len(cd.prep) == 2
+        assert cd.data["temp_amb_1"].tolist() == pytest.approx(
+            [32.0, 41.0, 50.0, 212.0]
+        )
+
+    def test_custom_name_does_not_defeat_the_guard(self, cd):
+        cd.prep_scale(columns=["wind_1"], factor=2.0, custom_name="first")
+        with pytest.raises(RuntimeError, match="already applied"):
+            cd.prep_scale(columns=["wind_1"], factor=2.0, custom_name="second")
+
+    def test_different_step_types_allowed_on_same_column(self, cd):
+        """AsType over everything then ConvertUnits on one column is the real flow."""
+        cd.prep_astype(columns=["power_1"], dtype="float64")
+        cd.prep_scale(columns=["power_1"], factor=0.001)
+        assert len(cd.prep) == 2
+
+    def test_guard_applies_to_direct_step_run(self, cd):
+        """The check lives in run(), so it covers steps built directly."""
+        prep.Scale(columns=["wind_1"], factor=2.0).run(cd)
+        with pytest.raises(RuntimeError, match="already applied"):
+            prep.Scale(group="wind", factor=2.0).run(cd)
+
+    def test_custom_steps_are_exempt(self, cd):
+        def touch(capdata):
+            capdata.data["power_1"] = capdata.data["power_1"] + 1
+
+        cd.prep_custom(touch)
+        cd.prep_custom(touch)
+        assert len(cd.prep) == 2
+
+    def test_rejected_step_leaves_data_untouched(self, cd):
+        cd.prep_scale(columns=["wind_1"], factor=2.0)
+        before = cd.data.copy()
+        with pytest.raises(RuntimeError):
+            cd.prep_scale(group="wind", factor=2.0)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert len(cd.prep) == 1

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -349,3 +349,75 @@ class TestRegistryCoverage:
         cls = prep.PREP_REGISTRY[name]
         assert issubclass(cls, prep.BasePrepStep)
         assert cls.__name__ == name
+
+
+@pytest.fixture
+def cd_many_columns():
+    """CapData with a 25-column temperature group and 25 column groups."""
+    index = pd.date_range("1/1/2021 12:00", freq="5min", periods=4)
+    data = pd.DataFrame(
+        {f"temp_{i}": [32.0, 41.0, 50.0, 212.0] for i in range(25)}, index=index
+    )
+    out = pvc.CapData("test")
+    out.data = data
+    groups = {"temp_amb": [f"temp_{i}" for i in range(25)]}
+    groups.update({f"spare_{i}": [] for i in range(25)})
+    out.column_groups = ColumnGroups(groups)
+    return out
+
+
+class TestLongColumnListTruncation:
+    """Explanations and errors truncate long column lists (cf. agg_group)."""
+
+    def test_explanation_truncates(self, cd_many_columns):
+        step = prep.ConvertUnits(group="temp_amb", from_units="F", to_units="C")
+        step.run(cd_many_columns)
+        explanation = step.explanation
+        assert "temp_0, temp_1, temp_2, ..., temp_22, temp_23, temp_24" in explanation
+        assert "(25 total)" in explanation
+        assert "temp_10" not in explanation
+
+    def test_describe_prep_truncates(self, cd_many_columns):
+        cd_many_columns.prep_convert_units(
+            group="temp_amb", from_units="F", to_units="C"
+        )
+        described = cd_many_columns.describe_prep()
+        assert "(25 total)" in described
+        assert "temp_10" not in described
+
+    def test_short_column_list_is_not_truncated(self, cd):
+        step = prep.ConvertUnits(group="temp_amb", from_units="F", to_units="C")
+        step.run(cd)
+        assert "temp_amb_1" in step.explanation
+        assert "total)" not in step.explanation
+
+    def test_missing_columns_error_truncates(self, cd_many_columns):
+        missing = [f"nope_{i}" for i in range(25)]
+        with pytest.raises(ValueError) as exc:
+            prep.Scale(columns=missing, factor=1.0).run(cd_many_columns)
+        message = str(exc.value)
+        assert "(25 total)" in message
+        assert "nope_10" not in message
+
+    def test_unknown_group_error_truncates_available_ids(self, cd_many_columns):
+        with pytest.raises(ValueError) as exc:
+            prep.Scale(group="not_a_group", factor=1.0).run(cd_many_columns)
+        message = str(exc.value)
+        assert "(26 total)" in message
+        # Ids are sorted lexicographically, so spare_5 falls in the elided
+        # middle while spare_10 sorts up next to spare_1 and is still shown.
+        assert "spare_5" not in message
+
+    def test_rename_missing_keys_error_truncates(self, cd_many_columns):
+        column_map = {f"nope_{i}": f"new_{i}" for i in range(25)}
+        with pytest.raises(ValueError) as exc:
+            prep.RenameColumns(column_map=column_map).run(cd_many_columns)
+        message = str(exc.value)
+        assert "(25 total)" in message
+        assert "nope_10" not in message
+
+    def test_columns_resolved_keeps_every_name(self, cd_many_columns):
+        """Truncation is display-only; the step still holds the full list."""
+        step = prep.ConvertUnits(group="temp_amb", from_units="F", to_units="C")
+        step.run(cd_many_columns)
+        assert len(step.columns_resolved) == 25

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -1,0 +1,152 @@
+"""Tests for the prep step classes in captest.prep."""
+
+import pandas as pd
+import pytest
+
+from captest import capdata as pvc
+from captest import prep
+from captest.columngroups import ColumnGroups
+
+
+@pytest.fixture
+def cd():
+    """CapData with two temperature columns, wind, and power."""
+    index = pd.date_range("1/1/2021 12:00", freq="5min", periods=4)
+    data = pd.DataFrame(
+        {
+            "temp_amb_1": [32.0, 41.0, 50.0, 212.0],
+            "temp_bom_1": [77.0, 86.0, 95.0, 104.0],
+            "wind_1": [10.0, 20.0, 30.0, 40.0],
+            "power_1": [1000.0, 2000.0, 3000.0, 4000.0],
+        },
+        index=index,
+    )
+    out = pvc.CapData("test")
+    out.data = data
+    out.column_groups = ColumnGroups(
+        {
+            "temp_amb": ["temp_amb_1"],
+            "temp_bom": ["temp_bom_1"],
+            "wind": ["wind_1"],
+            "real_pwr": ["power_1"],
+        }
+    )
+    return out
+
+
+class TestScale:
+    def test_scales_named_columns_in_place(self, cd):
+        prep.Scale(columns=["power_1"], factor=0.001).run(cd)
+        assert cd.data["power_1"].tolist() == [1.0, 2.0, 3.0, 4.0]
+
+    def test_offset_applied_after_factor(self, cd):
+        prep.Scale(columns=["wind_1"], factor=2.0, offset=1.0).run(cd)
+        assert cd.data["wind_1"].tolist() == [21.0, 41.0, 61.0, 81.0]
+
+    def test_appends_step_to_prep(self, cd):
+        step = prep.Scale(columns=["power_1"], factor=0.001)
+        step.run(cd)
+        assert cd.prep == [step]
+        assert step.columns_resolved == ["power_1"]
+
+    def test_leaves_other_columns_untouched(self, cd):
+        prep.Scale(columns=["power_1"], factor=0.001).run(cd)
+        assert cd.data["wind_1"].tolist() == [10.0, 20.0, 30.0, 40.0]
+
+    def test_config_round_trip(self, cd):
+        step = prep.Scale(columns=["power_1"], factor=0.001, custom_name="W to kW")
+        config = step.to_config()
+        assert config["type"] == "Scale"
+        rebuilt = prep.prep_step_from_config(config)
+        assert isinstance(rebuilt, prep.Scale)
+        assert rebuilt.columns == ["power_1"]
+        assert rebuilt.factor == 0.001
+        assert rebuilt.custom_name == "W to kW"
+
+    def test_args_repr_and_explanation(self, cd):
+        step = prep.Scale(columns=["power_1"], factor=0.001)
+        step.run(cd)
+        assert "factor=0.001" in step.args_repr
+        assert "power_1" in step.explanation
+
+    def test_non_numeric_column_raises_type_error(self, cd):
+        cd.data["power_1"] = ["a", "b", "c", "d"]
+        with pytest.raises(TypeError, match="power_1"):
+            prep.Scale(columns=["power_1"], factor=0.001).run(cd)
+
+
+class TestSelectors:
+    def test_group_selector(self, cd):
+        prep.Scale(group="wind", factor=2.0).run(cd)
+        assert cd.data["wind_1"].tolist() == [20.0, 40.0, 60.0, 80.0]
+
+    def test_list_valued_group_selector(self, cd):
+        step = prep.Scale(group=["temp_amb", "temp_bom"], factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["temp_amb_1", "temp_bom_1"]
+
+    def test_group_regex_spans_several_ids(self, cd):
+        step = prep.Scale(group_regex="^temp", factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["temp_amb_1", "temp_bom_1"]
+
+    def test_two_selectors_raises(self, cd):
+        with pytest.raises(ValueError, match="exactly one"):
+            prep.Scale(columns=["wind_1"], group="wind", factor=1.0).run(cd)
+
+    def test_no_selector_raises(self, cd):
+        with pytest.raises(ValueError, match="exactly one"):
+            prep.Scale(factor=1.0).run(cd)
+
+    def test_unknown_group_raises_with_close_match(self, cd):
+        with pytest.raises(ValueError, match="Did you mean 'wind'"):
+            prep.Scale(group="wnd", factor=1.0).run(cd)
+
+    def test_group_regex_matching_nothing_raises(self, cd):
+        with pytest.raises(ValueError, match="nomatch"):
+            prep.Scale(group_regex="nomatch", factor=1.0).run(cd)
+
+    def test_column_missing_from_data_raises(self, cd):
+        with pytest.raises(ValueError, match="absent"):
+            prep.Scale(columns=["not_a_column"], factor=1.0).run(cd)
+
+
+class TestAtomicFailure:
+    def test_failed_step_restores_data_and_records_nothing(self, cd):
+        cd.data["power_1"] = ["a", "b", "c", "d"]
+        before_bad = cd.data.copy()
+        with pytest.raises(TypeError):
+            prep.Scale(columns=["power_1", "wind_1"], factor=0.001).run(cd)
+        assert cd.prep == []
+        pd.testing.assert_frame_equal(cd.data, before_bad)
+
+
+class TestOrderingGuard:
+    def test_value_mutating_step_after_filtering_raises(self, cd):
+        cd.data["poa"] = [500.0, 600.0, 700.0, 800.0]
+        cd.filter_custom(pd.DataFrame.head, 3)
+        with pytest.raises(RuntimeError, match="reset_filter"):
+            prep.Scale(columns=["power_1"], factor=0.001).run(cd)
+
+    def test_succeeds_after_reset_filter(self, cd):
+        cd.data["poa"] = [500.0, 600.0, 700.0, 800.0]
+        cd.filter_custom(pd.DataFrame.head, 3)
+        cd.reset_filter()
+        prep.Scale(columns=["power_1"], factor=0.001).run(cd)
+        assert cd.data["power_1"].tolist() == [1.0, 2.0, 3.0, 4.0]
+
+
+class TestStrictAttrsOnPrepSteps:
+    def test_mistyped_param_raises(self):
+        step = prep.Scale(columns=["a"], factor=1.0)
+        with pytest.raises(AttributeError, match="Did you mean 'factor'"):
+            step.factr = 2.0
+
+
+class TestRegistry:
+    def test_scale_is_registered(self):
+        assert prep.PREP_REGISTRY["Scale"] is prep.Scale
+
+    def test_unknown_type_raises_with_close_match(self):
+        with pytest.raises(ValueError, match="Did you mean 'Scale'"):
+            prep.prep_step_from_config({"type": "Scaled"})

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -1,5 +1,6 @@
 """Tests for the prep step classes in captest.prep."""
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -194,6 +195,10 @@ class TestConvertUnits:
         with pytest.raises(ValueError, match="identical"):
             prep.ConvertUnits(columns=["wind_1"], from_units="C", to_units="C").run(cd)
 
+    def test_missing_units_raise_clear_message(self, cd):
+        with pytest.raises(ValueError, match="both required"):
+            prep.ConvertUnits(columns=["wind_1"], to_units="m/s").run(cd)
+
     def test_config_round_trip(self):
         step = prep.ConvertUnits(group_regex="^temp", from_units="F", to_units="C")
         rebuilt = prep.prep_step_from_config(step.to_config())
@@ -215,3 +220,108 @@ class TestConvertUnits:
 
     def test_registered(self):
         assert prep.PREP_REGISTRY["ConvertUnits"] is prep.ConvertUnits
+
+
+class TestAsType:
+    def test_casts_selected_columns(self, cd):
+        cd.data["power_1"] = ["1000", "2000", "3000", "4000"]
+        prep.AsType(columns=["power_1"], dtype="float64").run(cd)
+        assert cd.data["power_1"].dtype == np.dtype("float64")
+
+    def test_config_round_trip(self):
+        step = prep.AsType(columns=["a"], dtype="float64")
+        rebuilt = prep.prep_step_from_config(step.to_config())
+        assert rebuilt.dtype == "float64"
+
+    def test_uncastable_value_raises_and_restores(self, cd):
+        cd.data["power_1"] = ["1000", "not_a_number", "3000", "4000"]
+        before = cd.data.copy()
+        with pytest.raises(ValueError):
+            prep.AsType(columns=["power_1"], dtype="float64").run(cd)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert cd.prep == []
+
+
+class TestDropColumns:
+    def test_drops_from_data_and_column_groups(self, cd):
+        prep.DropColumns(columns=["wind_1"]).run(cd)
+        assert "wind_1" not in cd.data.columns
+        assert cd.column_groups["wind"] == []
+
+    def test_permitted_after_filtering(self, cd):
+        cd.data["poa"] = [500.0, 600.0, 700.0, 800.0]
+        cd.filter_custom(pd.DataFrame.head, 3)
+        prep.DropColumns(columns=["wind_1"]).run(cd)
+        assert "wind_1" not in cd.data.columns
+
+    def test_does_not_mutate_values(self):
+        assert prep.DropColumns._mutates_values is False
+
+
+class TestRenameColumns:
+    def test_renames_in_data_and_column_groups(self, cd):
+        prep.RenameColumns(column_map={"wind_1": "wind_speed"}).run(cd)
+        assert "wind_speed" in cd.data.columns
+        assert cd.column_groups["wind"] == ["wind_speed"]
+
+    def test_selector_is_rejected(self, cd):
+        with pytest.raises(ValueError, match="column_map"):
+            prep.RenameColumns(columns=["wind_1"], column_map={"wind_1": "x"}).run(cd)
+
+    def test_unknown_key_raises(self, cd):
+        with pytest.raises(ValueError, match="absent"):
+            prep.RenameColumns(column_map={"nope": "x"}).run(cd)
+
+    def test_config_round_trip(self):
+        step = prep.RenameColumns(column_map={"a": "b"})
+        rebuilt = prep.prep_step_from_config(step.to_config())
+        assert rebuilt.column_map == {"a": "b"}
+
+
+def blank_before(capdata, columns, hour):
+    """Module-level prep function used by the Custom tests."""
+    mask = capdata.data.index.hour < hour
+    capdata.data.loc[mask, columns] = np.nan
+
+
+class TestCustomPrep:
+    def test_calls_func_with_capdata(self, cd):
+        prep.Custom(blank_before, ["power_1"], 13).run(cd)
+        assert cd.data["power_1"].isna().all()
+
+    def test_no_selector_required(self, cd):
+        step = prep.Custom(blank_before, ["power_1"], 13)
+        step.run(cd)
+        assert step.columns_resolved == []
+
+    def test_config_round_trip(self, cd):
+        step = prep.Custom(blank_before, ["power_1"], 13)
+        config = step.to_config()
+        assert config["func"] == "tests.test_prep_classes:blank_before"
+        rebuilt = prep.prep_step_from_config(config)
+        assert rebuilt.func is blank_before
+        assert rebuilt.args == (["power_1"], 13)
+
+    def test_lambda_raises_at_serialization(self, cd):
+        step = prep.Custom(lambda capdata: None)
+        with pytest.raises(ValueError):
+            step.to_config()
+
+    def test_failure_restores_data(self, cd):
+        def boom(capdata):
+            capdata.data["power_1"] = 0.0
+            raise RuntimeError("boom")
+
+        before = cd.data.copy()
+        with pytest.raises(RuntimeError, match="boom"):
+            prep.Custom(boom).run(cd)
+        pd.testing.assert_frame_equal(cd.data, before)
+        assert cd.prep == []
+
+
+class TestRegistryCoverage:
+    @pytest.mark.parametrize("name", list(prep.PREP_REGISTRY))
+    def test_every_step_round_trips_its_defaults(self, name):
+        cls = prep.PREP_REGISTRY[name]
+        assert issubclass(cls, prep.BasePrepStep)
+        assert cls.__name__ == name

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -580,3 +580,31 @@ class TestParamsToConfig:
         config = util.params_to_config(step)
         config["columns"].append("b")
         assert step.columns == ["a"]
+
+
+class TestFormatNameList:
+    """util.format_name_list truncates long name sequences for display."""
+
+    def test_short_sequence_is_joined_unchanged(self):
+        assert util.format_name_list(["a", "b", "c"]) == "a, b, c"
+
+    def test_sequence_at_cutoff_is_not_truncated(self):
+        names = [f"col_{i}" for i in range(10)]
+        assert util.format_name_list(names) == ", ".join(names)
+        assert "total" not in util.format_name_list(names)
+
+    def test_sequence_above_cutoff_truncates_with_count(self):
+        names = [f"col_{i}" for i in range(25)]
+        result = util.format_name_list(names)
+        assert result == "col_0, col_1, col_2, ..., col_22, col_23, col_24 (25 total)"
+
+    def test_edge_and_cutoff_are_configurable(self):
+        names = [f"col_{i}" for i in range(6)]
+        result = util.format_name_list(names, cutoff=4, edge=1)
+        assert result == "col_0, ..., col_5 (6 total)"
+
+    def test_empty_sequence(self):
+        assert util.format_name_list([]) == ""
+
+    def test_non_string_names_are_coerced(self):
+        assert util.format_name_list([1, 2]) == "1, 2"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@ import json
 
 import numpy as np
 import pandas as pd
+import param
 import pytest
 from upath import UPath
 
@@ -517,3 +518,65 @@ class TestReadJsonYamlPathTypes:
         p.write_text("key: [unclosed")
         assert util.read_yaml(str(p)) is None
         assert capsys.readouterr().out != ""
+
+
+class TestStrictAttrs:
+    """util.StrictAttrs is the shared strict-__setattr__ guard."""
+
+    def _cls(self):
+        class Step(util.StrictAttrs, param.Parameterized):
+            _runtime_attrs = frozenset({"resolved"})
+            threshold = param.Number(default=1.0)
+
+        return Step
+
+    def test_param_assignment_allowed(self):
+        step = self._cls()(threshold=2.0)
+        step.threshold = 3.0
+        assert step.threshold == 3.0
+
+    def test_runtime_attr_assignment_allowed(self):
+        step = self._cls()()
+        step.resolved = ["a"]
+        assert step.resolved == ["a"]
+
+    def test_private_attribute_allowed(self):
+        step = self._cls()()
+        step._scratch = 1
+        assert step._scratch == 1
+
+    def test_unknown_attribute_raises_with_close_match(self):
+        step = self._cls()()
+        with pytest.raises(AttributeError, match="Did you mean 'threshold'"):
+            step.threshhold = 2.0
+
+    def test_runtime_attrs_union_down_the_mro(self):
+        base = self._cls()
+
+        class Child(base):
+            _runtime_attrs = frozenset({"extra"})
+
+        assert {"resolved", "extra"} <= Child._runtime_attrs
+
+
+class TestParamsToConfig:
+    """util.params_to_config serializes param values yaml-safely."""
+
+    def test_omits_name_and_coerces_numpy(self):
+        class Step(param.Parameterized):
+            factor = param.Number(default=1.0)
+
+        step = Step(factor=np.float64(0.001))
+        config = util.params_to_config(step)
+        assert "name" not in config
+        assert config == {"factor": 0.001}
+        assert isinstance(config["factor"], float)
+
+    def test_returns_independent_snapshot(self):
+        class Step(param.Parameterized):
+            columns = param.List(default=None, allow_None=True)
+
+        step = Step(columns=["a"])
+        config = util.params_to_config(step)
+        config["columns"].append("b")
+        assert step.columns == ["a"]


### PR DESCRIPTION
## Summary

Adjustments to loaded data — unit conversions, rescaling, dtype casts, column drops and renames — currently have to be hand-written between the loader call and `setup()`. They work, but they are invisible to the config and lost by every path that re-loads: `to_yaml` does not record them, so `from_yaml(path).run_test()` is not a faithful reproduction, and `reload(side, path=...)` re-invokes the loader and discards them.

This makes those adjustments a declared, serializable, replayable stage of the lifecycle: **load → prep → setup → filter**.

## Changes

**New `captest.prep` module** (internal, imported one-way by `capdata.py` — it never imports `capdata`, mirroring `filters.py`):

- `BasePrepStep` with a three-way column selector — `columns`, `group`, or `group_regex` (exactly one required), resolved at *run* time so an earlier drop or rename is respected. `group_regex="^temp"` reaches `temp_amb`, `temp_bom`, and `temp_mod` in one step.
- Steps: `ConvertUnits`, `Scale`, `AsType`, `DropColumns`, `RenameColumns`, `Custom`, plus `PREP_REGISTRY` / `prep_step_from_config`.
- An affine unit table (`out = value * factor + offset`). Only forward pairs are tabulated; inverses are derived at lookup, so the table cannot drift out of sync with itself. This is what `calcparams.scale` structurally cannot do: it is a pure multiply (so `(F - 32) * 5/9` is inexpressible) writing to a single new column named `scale`.

**`CapData`:**

- `prep`, `prep_convert_units`, `prep_scale`, `prep_astype`, `prep_custom`, `prep_to_config`, `run_prep`, `describe_prep`.
- `drop_cols` / `rename_cols` now record a prep step, with `record=False` for internal callers (`agg_sensors` uses it). An AST source-scan test enforces that every internal call site opts out.

**`CapTest`:**

- `meas_prep` / `sim_prep`, replayed immediately after every load and before `setup()` — in `from_params` (so also `from_mapping` / `from_yaml`) and in `reload`. `setup()` and `run_test()` never replay; re-running would double-convert.
- Written to the single YAML config under the same three-way rule already used for `meas_filters` / `sim_filters` (applied chain → stored config → omit).

**Safety, since prep mutates data non-idempotently:**

- Every step is atomic and `run_prep` is transactional across the whole batch — `data` *and* `column_groups` are snapshotted and restored on failure, so a failed prep is a no-op.
- Value-rewriting steps refuse to run once filters are applied (those filters were evaluated against un-prepped values); the message points at `reset_filter()`. `DropColumns` / `RenameColumns` are exempt — they change column identity, not values.
- `run_prep` refuses a populated chain, and a duplicate step raises.
- A side supplied as a pre-built `CapData` keeps its stored prep config but does not apply it, and warns — the object may already be prepped by the caller.

**Refactor:** `StrictAttrs` (the strict-`__setattr__` guard) and `params_to_config` moved to `util` so `BaseSummaryStep` and `BasePrepStep` share one implementation.

## Testing

`just test` — **1195 passed**, `just lint` and `just fmt` clean.

- `tests/test_prep_classes.py` (new, 57 tests): per-step behavior, `to_config`/`from_config` round trips, registry membership, selector resolution including run-time resolution after a `DropColumns`, atomic-failure rollback, the ordering guard, and the affine cases that disprove `scale` (32 °F → 0 °C, 212 °F → 100 °C).
- `tests/test_CapData.py`: the wrapper surface, batch-rollback of `data` *and* `column_groups` for both drop and rename, `copy()` carrying `prep`, the duplicate guard, `reset_filter()` leaving `prep` intact, and the source-scan test.
- `tests/test_captest.py`: replay at each load point on both sides and under both `run_setup` values, `setup()`/`run_test()` not re-running prep, the pre-built warning, and yaml round trips.
- End-to-end regression test for the motivating failure: a `sim_prep` that scales the power column, reloaded onto a second PVsyst file, driven through `run_test(side="sim")` to a fitted regression — the scenario that previously died with `ValueError: zero-size array to reduction operation maximum`. A negative control asserts the same run without prep still raises it, so the test cannot go vacuous.

## Notes

- **Behavior change:** `drop_cols` / `rename_cols` now append a prep step by default. Callers who want the old silent behavior pass `record=False`.
- The duplicate-step guard compares serialized params, so it does not catch `columns=["a"]` versus `group="ga"` resolving to the same column. That gap is documented in the docstring and the user guide rather than implied away.
- No `reset_prep()`: it cannot undo a mutation. Re-prepping means reloading.
- `calcparams.scale`'s docstring was corrected — it oversold itself as a "generic unit-conversion / rescaling helper".
- Docs: new "Preparing Data" user-guide page and `captest.prep` API reference.
