### PR TITLE
fix!: correct the NREL temperature correction and remove single_irr_weighted_temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,17 @@ orchestrator. Config-driven pipelines (`run_pipeline`, `from_yaml`) supersede
 it.
 
 ### Fixed
+- `prtest.perf_ratio_temp_corr_nrel` now *multiplies* the DC nameplate by the
+temperature correction factor `1 + (power_temp_coeff / 100) * (temp_cell - base_temp)`
+instead of dividing by it, matching the weather-corrected performance ratio defined in
+NREL/TP-5200-57991. The division inverted the correction: cell temperatures above
+`base_temp` raised the expected DC in the denominator rather than lowering it, so
+reported PR values were biased low for hot conditions and high for cold ones. **PR
+values computed with this function will change.** As a consequence of the corrected
+(linear) form, `single_irr_weighted_temp=True` now redistributes the expected DC across
+intervals without changing the summed expected DC or the reported `pr` — collapsing the
+per-interval cell temperatures to their irradiance-weighted mean is an algebraic
+identity when each interval is weighted by its POA irradiance.
 - Remote URIs (e.g. `s3://bucket/...`) and path objects now work consistently for
 every path argument to the loaders, not just the `path` argument of `load_data` /
 `DataLoader`. `util.read_json` and `util.read_yaml` read through `UPath` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,18 @@ that argument and let `CapTest` wrap the sim data on setup.
 import it from `captest.filters`.
 
 ### Removed
+- **Breaking:** removed the `single_irr_weighted_temp` parameter of
+`prtest.perf_ratio_temp_corr_nrel`. Passing it now raises `TypeError`; remove the
+argument from calling code, which will produce the same PR it always should have. The
+option collapsed the per-interval cell temperatures to a single irradiance weighted
+mean before temperature correcting, but it cannot change the reported `pr`: the
+correction factor is linear in cell temperature and each interval's contribution to the
+expected DC is weighted by its POA irradiance — the same weight used to average the
+temperature — so `sum_i G_i * (1 + g * (T_i - b))` and `(1 + g * (T_w - b)) * sum_i G_i`
+are identical. The option appeared to change the result only while the correction was
+applied as a division (see the fix below), which is not linear in temperature.
+Contract language calling for a single irradiance weighted cell temperature is already
+satisfied by the per-interval calculation.
 - Removed the legacy module-level `capdata.run_test(cd, steps)` (imperative
 method+args tuples); the name is reused by the new `CapTest.run_test()`
 orchestrator. Config-driven pipelines (`run_pipeline`, `from_yaml`) supersede
@@ -237,11 +249,7 @@ instead of dividing by it, matching the weather-corrected performance ratio defi
 NREL/TP-5200-57991. The division inverted the correction: cell temperatures above
 `base_temp` raised the expected DC in the denominator rather than lowering it, so
 reported PR values were biased low for hot conditions and high for cold ones. **PR
-values computed with this function will change.** As a consequence of the corrected
-(linear) form, `single_irr_weighted_temp=True` now redistributes the expected DC across
-intervals without changing the summed expected DC or the reported `pr` — collapsing the
-per-interval cell temperatures to their irradiance-weighted mean is an algebraic
-identity when each interval is weighted by its POA irradiance.
+values computed with this function will change.**
 - Remote URIs (e.g. `s3://bucket/...`) and path objects now work consistently for
 every path argument to the loaders, not just the `path` argument of `load_data` /
 `DataLoader`. `util.read_json` and `util.read_yaml` read through `UPath` instead of

--- a/src/captest/prtest.py
+++ b/src/captest/prtest.py
@@ -159,7 +159,10 @@ def perf_ratio_temp_corr_nrel(
     single_irr_weighted_temp : bool, default False
         Set to True to calculate a single irradiance weighted temperature to use
         when temperature correcting the power. Some contract language calls for this
-        but it does not follow the calculation defined in the NREL paper.
+        but it does not follow the calculation defined in the NREL paper. Note that
+        the temperature correction is linear in cell temperature and each interval is
+        weighted by its POA irradiance, so this option redistributes the expected DC
+        across intervals without changing the summed expected DC or the reported `pr`.
     temp_amb : Series
         Ambient temperature (degrees C) measurements.
     wind_speed : Series

--- a/src/captest/prtest.py
+++ b/src/captest/prtest.py
@@ -128,7 +128,6 @@ def perf_ratio_temp_corr_nrel(
     power_temp_coeff=None,
     temp_bom=None,
     temp_amb=None,
-    single_irr_weighted_temp=False,
     wind_speed=None,
     base_temp=25,
     module_type="glass_cell_poly",
@@ -156,13 +155,6 @@ def perf_ratio_temp_corr_nrel(
         Measured back of module temperature. The `temp_amb` and `wind_speed` arguments
         are not used if this argument is not None; skips calculating BOM temps from
         ambient temperature, wind speed, and POA irradiance.
-    single_irr_weighted_temp : bool, default False
-        Set to True to calculate a single irradiance weighted temperature to use
-        when temperature correcting the power. Some contract language calls for this
-        but it does not follow the calculation defined in the NREL paper. Note that
-        the temperature correction is linear in cell temperature and each interval is
-        weighted by its POA irradiance, so this option redistributes the expected DC
-        across intervals without changing the summed expected DC or the reported `pr`.
     temp_amb : Series
         Ambient temperature (degrees C) measurements.
     wind_speed : Series
@@ -193,6 +185,26 @@ def perf_ratio_temp_corr_nrel(
 
     Returns
     -------
+    PrResults
+        Instance of class PrResults.
+
+    Notes
+    -----
+    The cell temperature correction is applied per interval. A
+    `single_irr_weighted_temp` option, which collapsed the per-interval cell
+    temperatures to a single irradiance weighted mean before correcting, was removed
+    because it cannot change the reported `pr`. The correction factor is
+    linear in cell temperature and each interval's contribution to the expected DC is
+    weighted by its POA irradiance -- the same weight used to average the temperature
+    -- so the two are algebraically identical once summed::
+
+        sum_i G_i * (1 + g * (T_i - b)) == (1 + g * (T_w - b)) * sum_i G_i
+
+    where ``T_w = sum_i(G_i * T_i) / sum_i(G_i)``. The option appeared to change the
+    result only while the correction was applied as a division, which is not linear in
+    temperature; that was a bug, fixed in the same release. Contract language calling
+    for a single irradiance weighted cell temperature is therefore already satisfied by
+    the per-interval calculation.
     """
     timestep = util.get_common_timestep(poa, units="h", string_output=False)
     timestep_str = util.get_common_timestep(poa, units="h", string_output=True)
@@ -201,8 +213,6 @@ def perf_ratio_temp_corr_nrel(
     if temp_bom is None:
         temp_bom = poa * np.exp(coeffs["a"] + coeffs["b"] * wind_speed) + temp_amb
     temp_cell = temp_bom + (poa / 1000) * coeffs["del_tcnd"]
-    if single_irr_weighted_temp:
-        temp_cell = (poa * temp_cell).sum() / poa.sum()
     dc_nameplate_temp_corr = dc_nameplate * (
         1 + ((power_temp_coeff / 100) * (temp_cell - base_temp))
     )

--- a/src/captest/prtest.py
+++ b/src/captest/prtest.py
@@ -200,7 +200,7 @@ def perf_ratio_temp_corr_nrel(
     temp_cell = temp_bom + (poa / 1000) * coeffs["del_tcnd"]
     if single_irr_weighted_temp:
         temp_cell = (poa * temp_cell).sum() / poa.sum()
-    dc_nameplate_temp_corr = dc_nameplate / (
+    dc_nameplate_temp_corr = dc_nameplate * (
         1 + ((power_temp_coeff / 100) * (temp_cell - base_temp))
     )
     # below is same as the perf_ratio function

--- a/tests/test_prtest.py
+++ b/tests/test_prtest.py
@@ -250,43 +250,55 @@ class TestPerfRatioTempCorrNREL:
         assert perf_ratio.dc_nameplate == dc_nameplate
         assert isinstance(perf_ratio.results_data, pd.DataFrame)
 
-    def test_pr_meas_bom_single_irr_weighted_temp(self):
-        """Test single_irr_weighted_temp=True redistributes expected DC per interval.
+    def test_irr_weighted_cell_temp_matches_per_interval_correction(self):
+        """Verify per-interval correction equals correcting at the weighted mean temp.
 
-        The temperature correction is linear in cell temperature and each interval
-        is weighted by its POA irradiance, so collapsing the per-interval cell
-        temperatures to their irradiance-weighted mean is an algebraic identity for
-        the summed expected DC. Only the per-interval split changes.
+        This is the property that made the removed `single_irr_weighted_temp` option
+        redundant: the correction is linear in cell temperature and each interval is
+        weighted by its POA irradiance, so collapsing the per-interval cell
+        temperatures to their irradiance-weighted mean leaves the summed expected DC,
+        and therefore the reported PR, unchanged.
         """
         ac_energy = pd.Series([80_000, 90_000, 95_000], index=ix)
         poa = pd.Series([850, 900, 1000], index=ix)
         dc_nameplate = 120_000
         temp_bom = pd.Series([30, 32, 34], index=ix)
-        pr_default = pr.perf_ratio_temp_corr_nrel(
+        power_temp_coeff = -0.37
+
+        perf_ratio = pr.perf_ratio_temp_corr_nrel(
             ac_energy,
             dc_nameplate,
             poa,
-            power_temp_coeff=-0.37,
+            power_temp_coeff=power_temp_coeff,
             temp_bom=temp_bom,
         )
-        pr_weighted = pr.perf_ratio_temp_corr_nrel(
-            ac_energy,
-            dc_nameplate,
-            poa,
-            power_temp_coeff=-0.37,
-            temp_bom=temp_bom,
-            single_irr_weighted_temp=True,
+
+        # Correct once at the irradiance-weighted mean cell temperature instead.
+        temp_cell = temp_bom + (poa / 1000) * 3  # del_tcnd of the default module
+        temp_cell_weighted = (poa * temp_cell).sum() / poa.sum()
+        nameplate_weighted = dc_nameplate * (
+            1 + (power_temp_coeff / 100) * (temp_cell_weighted - 25)
         )
-        assert pr_weighted.pr <= 1
-        assert pr_weighted.pr > 0
-        assert isinstance(pr_weighted.results_data, pd.DataFrame)
-        # The expected DC is redistributed across intervals ...
-        assert not np.allclose(
-            pr_weighted.results_data["expected_dc"].values,
-            pr_default.results_data["expected_dc"].values,
-        )
-        # ... but its total, and therefore the reported PR, is unchanged.
-        assert pr_weighted.pr == pytest.approx(pr_default.pr)
+        expected_dc_weighted = nameplate_weighted * poa / 1000
+        pr_weighted = ac_energy.sum() / expected_dc_weighted.sum()
+
+        assert perf_ratio.pr == pytest.approx(pr_weighted)
+
+    def test_single_irr_weighted_temp_argument_removed(self):
+        """Verify the removed `single_irr_weighted_temp` option is rejected."""
+        ac_energy = pd.Series([80_000, 90_000, 95_000], index=ix)
+        poa = pd.Series([850, 900, 1000], index=ix)
+        temp_bom = pd.Series([30, 32, 34], index=ix)
+
+        with pytest.raises(TypeError):
+            pr.perf_ratio_temp_corr_nrel(
+                ac_energy,
+                120_000,
+                poa,
+                power_temp_coeff=-0.37,
+                temp_bom=temp_bom,
+                single_irr_weighted_temp=True,
+            )
 
     def test_pr_meas_bom_and_amb(self):
         """Test a short series of data for a hypothetical system.

--- a/tests/test_prtest.py
+++ b/tests/test_prtest.py
@@ -251,7 +251,13 @@ class TestPerfRatioTempCorrNREL:
         assert isinstance(perf_ratio.results_data, pd.DataFrame)
 
     def test_pr_meas_bom_single_irr_weighted_temp(self):
-        """Test single_irr_weighted_temp=True uses irradiance-weighted cell temp."""
+        """Test single_irr_weighted_temp=True redistributes expected DC per interval.
+
+        The temperature correction is linear in cell temperature and each interval
+        is weighted by its POA irradiance, so collapsing the per-interval cell
+        temperatures to their irradiance-weighted mean is an algebraic identity for
+        the summed expected DC. Only the per-interval split changes.
+        """
         ac_energy = pd.Series([80_000, 90_000, 95_000], index=ix)
         poa = pd.Series([850, 900, 1000], index=ix)
         dc_nameplate = 120_000
@@ -273,9 +279,14 @@ class TestPerfRatioTempCorrNREL:
         )
         assert pr_weighted.pr <= 1
         assert pr_weighted.pr > 0
-        # Using a single weighted temp should produce a different result
-        assert pr_weighted.pr != pytest.approx(pr_default.pr, abs=1e-10)
         assert isinstance(pr_weighted.results_data, pd.DataFrame)
+        # The expected DC is redistributed across intervals ...
+        assert not np.allclose(
+            pr_weighted.results_data["expected_dc"].values,
+            pr_default.results_data["expected_dc"].values,
+        )
+        # ... but its total, and therefore the reported PR, is unchanged.
+        assert pr_weighted.pr == pytest.approx(pr_default.pr)
 
     def test_pr_meas_bom_and_amb(self):
         """Test a short series of data for a hypothetical system.
@@ -309,6 +320,82 @@ class TestPerfRatioTempCorrNREL:
         assert isinstance(perf_ratio.timestep[1], str)
         assert perf_ratio.dc_nameplate == dc_nameplate
         assert isinstance(perf_ratio.results_data, pd.DataFrame)
+
+    def test_expected_dc_derated_when_cells_above_base_temp(self):
+        """Verify hot cells reduce the temperature-corrected nameplate.
+
+        Constant 1000 W/m^2 POA and a 45 C BOM temp give a cell temp of
+        45 + (1000 / 1000) * 3 = 48 C for the default open rack, glass/cell/poly
+        module. With a -0.40 %/C coefficient the correction factor is
+        1 + (-0.0040 * (48 - 25)) = 0.908, so the 100 kW-DC nameplate corrects
+        down to 90.8 kW-DC and each hourly interval expects 90,800 Wh.
+        """
+        ac_energy = pd.Series([80_000, 82_000, 84_000], index=ix)
+        poa = pd.Series([1000, 1000, 1000], index=ix)
+        dc_nameplate = 100_000
+        temp_bom = pd.Series([45, 45, 45], index=ix)
+
+        perf_ratio = pr.perf_ratio_temp_corr_nrel(
+            ac_energy,
+            dc_nameplate,
+            poa,
+            power_temp_coeff=-0.40,
+            temp_bom=temp_bom,
+        )
+
+        np.testing.assert_allclose(
+            perf_ratio.results_data["expected_dc"].values, [90_800.0] * 3
+        )
+        assert perf_ratio.pr == pytest.approx(246_000 / 272_400)
+
+    def test_expected_dc_uprated_when_cells_below_base_temp(self):
+        """Verify cold cells increase the temperature-corrected nameplate.
+
+        Constant 500 W/m^2 POA and a 5 C BOM temp give a cell temp of
+        5 + (500 / 1000) * 3 = 6.5 C. With a -0.40 %/C coefficient the correction
+        factor is 1 + (-0.0040 * (6.5 - 25)) = 1.074, so the 100 kW-DC nameplate
+        corrects up to 107.4 kW-DC and each hourly interval expects 53,700 Wh.
+        """
+        ac_energy = pd.Series([40_000, 41_000, 42_000], index=ix)
+        poa = pd.Series([500, 500, 500], index=ix)
+        dc_nameplate = 100_000
+        temp_bom = pd.Series([5, 5, 5], index=ix)
+
+        perf_ratio = pr.perf_ratio_temp_corr_nrel(
+            ac_energy,
+            dc_nameplate,
+            poa,
+            power_temp_coeff=-0.40,
+            temp_bom=temp_bom,
+        )
+
+        np.testing.assert_allclose(
+            perf_ratio.results_data["expected_dc"].values, [53_700.0] * 3
+        )
+        assert perf_ratio.pr == pytest.approx(123_000 / 161_100)
+
+    def test_hot_cells_raise_pr_above_uncorrected_pr(self):
+        """Verify weather correcting removes the thermal penalty from the PR.
+
+        Cell temperatures above the base temperature lower the expected DC, so
+        the temperature-corrected PR must exceed the uncorrected PR for the same
+        measured energy.
+        """
+        ac_energy = pd.Series([80_000, 82_000, 84_000], index=ix)
+        poa = pd.Series([1000, 1000, 1000], index=ix)
+        dc_nameplate = 100_000
+        temp_bom = pd.Series([45, 45, 45], index=ix)
+
+        pr_corrected = pr.perf_ratio_temp_corr_nrel(
+            ac_energy,
+            dc_nameplate,
+            poa,
+            power_temp_coeff=-0.40,
+            temp_bom=temp_bom,
+        )
+        pr_uncorrected = pr.perf_ratio(ac_energy, dc_nameplate, poa)
+
+        assert pr_corrected.pr > pr_uncorrected.pr
 
 
 class TestPrResults:


### PR DESCRIPTION
## Summary

`prtest.perf_ratio_temp_corr_nrel` divided the DC nameplate by the temperature
correction factor instead of multiplying by it, inverting the correction. Cell
temperatures above `base_temp` *raised* the expected DC in the denominator rather than
lowering it, so reported PR values were biased low in hot conditions and high in cold
ones.

The NREL weather-corrected performance ratio (NREL/TP-5200-57991) defines the
denominator as `P_STC * (G_POA / 1000) * (1 - δ(T_cell_typ_avg - T_cell))`, which is
equivalent to `1 + (power_temp_coeff / 100) * (temp_cell - base_temp)` applied
multiplicatively.

Correcting the arithmetic showed that the `single_irr_weighted_temp` option had no
effect on the reported PR, so it is removed here as well.

**Breaking:** PR values computed with this function will change, and passing
`single_irr_weighted_temp` now raises `TypeError`.

## Changes

- `src/captest/prtest.py` — `dc_nameplate_temp_corr` now multiplies by the correction
  factor rather than dividing by it.
- `src/captest/prtest.py` — removed the `single_irr_weighted_temp` parameter and the
  branch implementing it.
- `src/captest/prtest.py` — added a `Notes` section explaining why the option was
  removed (rendered by the API reference), and filled in the previously empty `Returns`
  section.
- `CHANGELOG.md` — entries under Unreleased / Fixed and Unreleased / Removed.
- `tests/test_prtest.py` — regression coverage (see Testing).

## Why `single_irr_weighted_temp` was removed

The option collapsed the per-interval cell temperatures to a single irradiance weighted
mean before correcting. It cannot change the reported `pr`: the correction is linear in
cell temperature and each interval's contribution to the expected DC is weighted by its
POA irradiance — the same weight used to average the temperature — so

```
Σᵢ Gᵢ(1 + γ(Tᵢ − b))  ==  (1 + γ(T_w − b))·Σᵢ Gᵢ,   T_w = ΣGᵢTᵢ / ΣGᵢ
```

It appeared to change the result only while the correction was a division, which is not
linear in temperature — i.e. its apparent effect was an artifact of the bug. Contract
language calling for a single irradiance weighted cell temperature is already satisfied
by the per-interval calculation. Callers should delete the argument; the result is
unchanged by its removal.

## Testing

The pre-existing tests only asserted `0 < pr <= 1`, which held under both the
multiplicative and the divisive form — that is why the sign error went unnoticed. Added
tests that pin the arithmetic with hand-computed expected values:

- `test_expected_dc_derated_when_cells_above_base_temp` — 1000 W/m², 45 °C BOM → 48 °C
  cell, −0.40 %/°C ⇒ factor 0.908, so 100 kW-DC corrects down to 90.8 kW-DC.
- `test_expected_dc_uprated_when_cells_below_base_temp` — 500 W/m², 5 °C BOM → 6.5 °C
  cell ⇒ factor 1.074, so the nameplate corrects up to 107.4 kW-DC.
- `test_hot_cells_raise_pr_above_uncorrected_pr` — weather correcting must raise the PR
  above the uncorrected `perf_ratio` when cells run hot.
- `test_irr_weighted_cell_temp_matches_per_interval_correction` — verifies the identity
  above against an independently computed weighted-mean correction.
- `test_single_irr_weighted_temp_argument_removed` — guards the breaking change.

The first three fail with the old division and pass with the fix. Full suite: 1224
passed; `just lint`, `just fmt`, and `just docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtK8J234WAzD9cyXsk9FV3