### PR TITLE
docs: refine the CapTest and CapData guides for v0.17.0

### DIFF
--- a/docs/source/api_reference/capdata.rst
+++ b/docs/source/api_reference/capdata.rst
@@ -44,6 +44,7 @@ see :ref:`data_prep`.
 
    capdata.CapData.get_reg_cols
    capdata.CapData.review_column_groups
+   capdata.CapData.create_column_group_attributes
    capdata.CapData.copy
    capdata.CapData.empty
    capdata.CapData.drop_cols
@@ -131,7 +132,7 @@ Reporting Conditions
 
 Methods for computing ASTM E2848 reporting conditions. ``rep_irr`` is the
 reporting POA irradiance used to anchor ``filter_irr(ref_val='rep_irr')``; within
-a :py:class:`~captest.captest.CapTest` it resolves from the single test RC. See
+a :py:class:`~captest.CapTest` it resolves from the single test RC. See
 :ref:`reporting_conditions` in the user guide.
 
 .. autosummary::

--- a/docs/source/api_reference/capdata.rst
+++ b/docs/source/api_reference/capdata.rst
@@ -12,6 +12,30 @@ history, and regression results.
 
    capdata.CapData
 
+.. _capdata-api-attributes:
+
+Attributes
+----------
+
+The state a :py:class:`~captest.capdata.CapData` carries.
+:py:attr:`~captest.capdata.CapData.data` is the only frame that is stored:
+:py:attr:`~captest.capdata.CapData.data_filtered` is read-only, derived from
+``data`` and the applied :py:attr:`~captest.capdata.CapData.filters` chain.
+
+.. autosummary::
+   :toctree: generated/
+
+   capdata.CapData.data_filtered
+   capdata.CapData.filters
+   capdata.CapData.prep
+   capdata.CapData.name
+
+The instance attributes — :py:attr:`~captest.capdata.CapData.data`,
+``column_groups``, ``regression_cols``, ``regression_formula``,
+``regression_results``, ``rc``, ``loc``, ``floc``, ``data_loader``, and
+``tolerance`` — are documented in the
+:py:class:`~captest.capdata.CapData` class reference above.
+
 Setup
 -----
 
@@ -55,7 +79,7 @@ see :ref:`data_prep`.
 Data Preparation
 ----------------
 
-Thin wrappers that build a step class from :py:mod:`captest.prep` and
+Thin wrappers that build a step class from :doc:`prep` and
 ``run()`` it, appending it to the ``CapData.prep`` chain. Prep steps rewrite
 ``data`` in place between loading and ``setup()``. ``describe_prep`` returns a
 written summary of what was applied, while ``prep_to_config`` / ``run_prep``
@@ -91,7 +115,7 @@ Methods for aggregating sensor readings into single representative columns.
 Filtering
 ---------
 
-Thin wrappers that build a step class from :py:mod:`captest.filters` and
+Thin wrappers that build a step class from :doc:`filters` and
 ``run()`` it, appending it to the ``CapData.filters`` chain (the single source
 of truth from which ``data_filtered`` is derived). Each accepts an optional
 ``custom_name`` label. ``describe_filters`` returns a written summary of the

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -138,7 +138,8 @@ The built-in presets are:
    Standard ASTM E2848 regression form with total effective irradiance replacing
    front-side POA as the independent variable. Rear shading and IAM losses are
    handled in the modeled (PVsyst) data (``rpoa_pvsyst = GlobBak + BackShd``)
-   while the measured rear sensor is used as-measured (``rear_shade = 0``).
+   while the measured rear sensor is used as-measured, so ``rear_shade`` should
+   be left at its default ``0``.
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
    modified bifacial approach. See :ref:`choosing-test-setup` in the CapTest
    user guide for the per-side formulas.
@@ -167,7 +168,7 @@ The built-in presets are:
    calculate cell temperature via the Sandia PV Array Performance Model. Rear
    shading and IAM losses are handled in the modeled (PVsyst) data
    (``rpoa_pvsyst = GlobBak + BackShd``) while the measured rear sensor is used
-   as-measured (``rear_shade = 0``).
+   as-measured, so ``rear_shade`` should be left at its default ``0``.
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi`, following the NREL
    modified bifacial approach.
 
@@ -191,7 +192,8 @@ The built-in presets are:
    humidity and atmospheric pressure on the measured side and precipitable
    water from the PVsyst output. Rear shading and IAM losses are handled in
    the modeled (PVsyst) data (``rpoa_pvsyst = GlobBak + BackShd``) while the
-   measured rear sensor is used as-measured (``rear_shade = 0``).
+   measured rear sensor is used as-measured, so ``rear_shade`` should be left
+   at its default ``0``.
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi` with the spectral
    correction applied to :math:`E_{POA}`.
 
@@ -202,3 +204,13 @@ The built-in presets are:
    unshaded ``GlobBak``.
    :math:`E_{Total} = E_{POA} + E_{Rear} \cdot \varphi \cdot (1 - s)` on the
    measured side, where :math:`s` is the ``rear_shade`` fraction.
+
+.. warning::
+
+   :py:attr:`~captest.captest.CapTest.rear_shade` belongs with the
+   ``*_rear_shade_meas`` presets. The measured ``reg_cols_meas`` mapping is the
+   same in both variants, and no preset overrides the value, so a non-zero
+   ``rear_shade`` is applied to the measured ``e_total`` whichever preset is
+   selected. Paired with a ``*_rear_shade_sim`` preset — where the shading is
+   already carried by ``rpoa_pvsyst`` on the modeled side — that
+   double-counts the loss.

--- a/docs/source/api_reference/captest.rst
+++ b/docs/source/api_reference/captest.rst
@@ -3,7 +3,7 @@
 CapTest
 =======
 
-:py:class:`~captest.captest.CapTest` organizes a pair of
+:py:class:`~captest.CapTest` organizes a pair of
 :py:class:`~captest.capdata.CapData` objects (measured and simulated) along
 with test configuration, and provides methods for computing reporting
 conditions, running the ASTM E2848 capacity test, and evaluating pass/fail.
@@ -16,7 +16,7 @@ conditions, running the ASTM E2848 capacity test, and evaluating pass/fail.
 Constructors
 ------------
 
-Alternative constructors for building a :py:class:`~captest.captest.CapTest`
+Alternative constructors for building a :py:class:`~captest.CapTest`
 from parameters, YAML files, or mapping objects.
 
 .. autosummary::
@@ -46,9 +46,9 @@ Reporting Conditions
 --------------------
 
 A capacity test has a single set of reporting conditions, owned by the test as
-:py:attr:`~captest.captest.CapTest.rc` and tracked by
-:py:attr:`~captest.captest.CapTest.rc_source` (``'meas'`` / ``'sim'`` /
-``'manual'``). Compute them with :py:meth:`~captest.captest.CapTest.rep_cond`
+:py:attr:`~captest.CapTest.rc` and tracked by
+:py:attr:`~captest.CapTest.rc_source` (``'meas'`` / ``'sim'`` /
+``'manual'``). Compute them with :py:meth:`~captest.CapTest.rep_cond`
 or assign them directly via the ``rc`` setter. See :ref:`reporting_conditions`
 in the user guide for the full model.
 
@@ -56,17 +56,32 @@ in the user guide for the full model.
    :toctree: generated/
 
    CapTest.rc
+   CapTest.rc_source
    CapTest.rep_cond
    CapTest.rep_irr_filter_low
    CapTest.rep_irr_filter_high
+
+Test Settings
+-------------
+
+Parameters referenced from the prose elsewhere in the documentation. The full
+list, with defaults, is in the :py:class:`~captest.CapTest` parameter table
+above; see :ref:`captest-settings-reference` in the user guide for what each one
+is used for.
+
+.. autosummary::
+   :toctree: generated/
+
+   CapTest.rear_shade
+   CapTest.auto_wrap_sim
 
 Results
 -------
 
 Methods for running the capacity test and evaluating pass/fail.
-:py:meth:`~captest.captest.CapTest.run_test` runs the whole test — setup,
+:py:meth:`~captest.CapTest.run_test` runs the whole test — setup,
 filter-pipeline replay, regressions, and results — in one call.
-:py:meth:`~captest.captest.CapTest.captest_results` returns a
+:py:meth:`~captest.CapTest.captest_results` returns a
 :py:class:`~captest.captest.CapTestResults` object; ``str(results)``
 reproduces the printed report and ``results.styled_pvalues()`` the styled
 p-value table.
@@ -94,7 +109,7 @@ Visualization
 Module-level Functions
 ----------------------
 
-Standalone functions used alongside :py:class:`~captest.captest.CapTest`.
+Standalone functions used alongside :py:class:`~captest.CapTest`.
 
 .. autosummary::
    :toctree: generated/
@@ -114,7 +129,7 @@ Predefined Test Setups
 fully-validated test-setup entries. Each entry bundles a regression formula,
 column mappings for measured and modeled data, default reporting conditions,
 and a scatter-plot callable. Pass the preset name as ``test_setup`` when
-constructing a :py:class:`~captest.captest.CapTest`.
+constructing a :py:class:`~captest.CapTest`.
 
 .. data:: captest.TEST_SETUPS
 
@@ -207,7 +222,7 @@ The built-in presets are:
 
 .. warning::
 
-   :py:attr:`~captest.captest.CapTest.rear_shade` belongs with the
+   :py:attr:`~captest.CapTest.rear_shade` belongs with the
    ``*_rear_shade_meas`` presets. The measured ``reg_cols_meas`` mapping is the
    same in both variants, and no preset overrides the value, so a non-zero
    ``rear_shade`` is applied to the measured ``e_total`` whichever preset is

--- a/docs/source/api_reference/clearsky.rst
+++ b/docs/source/api_reference/clearsky.rst
@@ -3,7 +3,7 @@
 Clear-sky Modeling
 ==================
 
-The :py:mod:`captest.clearsky` module provides the pvlib-based clear-sky GHI/POA
+The ``captest.clearsky`` module provides the pvlib-based clear-sky GHI/POA
 modeling used by :py:func:`~captest.io.load_data` when site metadata is supplied.
 This is distinct from clear-sky *filtering*, which is the
 :py:class:`~captest.filters.Clearsky` step (it calls

--- a/docs/source/api_reference/filters.rst
+++ b/docs/source/api_reference/filters.rst
@@ -3,7 +3,7 @@
 Filters
 =======
 
-The :py:mod:`captest.filters` module holds all the filters. Each
+The ``captest.filters`` module holds all the filters. Each
 filter is a first-class object: a :py:class:`~captest.filters.BaseSummaryStep`
 subclass that declares its configuration as typed ``param`` parameters and
 implements ``_execute``. The filter methods on :py:class:`~captest.capdata.CapData` 

--- a/docs/source/api_reference/generated/captest.CapTest.auto_wrap_sim.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.auto_wrap_sim.rst
@@ -1,0 +1,6 @@
+﻿captest.CapTest.auto\_wrap\_sim
+===============================
+
+.. currentmodule:: captest
+
+.. autoattribute:: CapTest.auto_wrap_sim

--- a/docs/source/api_reference/generated/captest.CapTest.rc_source.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rc_source.rst
@@ -1,0 +1,6 @@
+﻿captest.CapTest.rc\_source
+==========================
+
+.. currentmodule:: captest
+
+.. autoattribute:: CapTest.rc_source

--- a/docs/source/api_reference/generated/captest.CapTest.rear_shade.rst
+++ b/docs/source/api_reference/generated/captest.CapTest.rear_shade.rst
@@ -1,0 +1,6 @@
+﻿captest.CapTest.rear\_shade
+===========================
+
+.. currentmodule:: captest
+
+.. autoattribute:: CapTest.rear_shade

--- a/docs/source/api_reference/generated/captest.capdata.CapData.create_column_group_attributes.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.create_column_group_attributes.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.create\_column\_group\_attributes
+=========================================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.create_column_group_attributes

--- a/docs/source/api_reference/generated/captest.capdata.CapData.data_filtered.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.data_filtered.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.data\_filtered
+======================================
+
+.. currentmodule:: captest.capdata
+
+.. autoproperty:: CapData.data_filtered

--- a/docs/source/api_reference/generated/captest.capdata.CapData.filters.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.filters.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.filters
+===============================
+
+.. currentmodule:: captest.capdata
+
+.. autoattribute:: CapData.filters

--- a/docs/source/api_reference/generated/captest.capdata.CapData.name.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.name.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.name
+============================
+
+.. currentmodule:: captest.capdata
+
+.. autoattribute:: CapData.name

--- a/docs/source/api_reference/generated/captest.capdata.CapData.prep.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.prep.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.prep
+============================
+
+.. currentmodule:: captest.capdata
+
+.. autoattribute:: CapData.prep

--- a/docs/source/api_reference/generated/captest.plotting.find_default_groups.rst
+++ b/docs/source/api_reference/generated/captest.plotting.find_default_groups.rst
@@ -1,0 +1,6 @@
+﻿captest.plotting.find\_default\_groups
+======================================
+
+.. currentmodule:: captest.plotting
+
+.. autofunction:: find_default_groups

--- a/docs/source/api_reference/generated/captest.plotting.parse_combine.rst
+++ b/docs/source/api_reference/generated/captest.plotting.parse_combine.rst
@@ -1,0 +1,6 @@
+﻿captest.plotting.parse\_combine
+===============================
+
+.. currentmodule:: captest.plotting
+
+.. autofunction:: parse_combine

--- a/docs/source/api_reference/plotting.rst
+++ b/docs/source/api_reference/plotting.rst
@@ -14,6 +14,8 @@ Dashboards and Multi-panel Plots
 
    plotting.plot
    plotting.scatter_dboard
+   plotting.find_default_groups
+   plotting.parse_combine
 
 Scatter Plots
 -------------

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -3,7 +3,7 @@
 Prep
 ====
 
-The :py:mod:`captest.prep` module holds the data-preparation steps: declared,
+The ``captest.prep`` module holds the data-preparation steps: declared,
 serializable adjustments applied between loading data and
 :py:meth:`~captest.CapTest.setup`. Each step is a
 :py:class:`~captest.prep.BasePrepStep` subclass that declares its

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -5,7 +5,7 @@ Prep
 
 The :py:mod:`captest.prep` module holds the data-preparation steps: declared,
 serializable adjustments applied between loading data and
-:py:meth:`~captest.captest.CapTest.setup`. Each step is a
+:py:meth:`~captest.CapTest.setup`. Each step is a
 :py:class:`~captest.prep.BasePrepStep` subclass that declares its
 configuration as typed ``param`` parameters and implements ``_execute``,
 rewriting ``CapData.data`` in place and recording itself on

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -383,8 +383,171 @@ setup and the temperature-corrected power setup.
 
 .. code-block:: Python
 
-    ct_etotal = CapTest.from_yaml('./project.yaml', key='captest_bifi_etotal')
-    ct_power_tc = CapTest.from_yaml('./project.yaml', key='captest_bifi_power_tc')
+    tst_etotal = CapTest.from_yaml('./project.yaml', key='captest_bifi_etotal')
+    tst_power_tc = CapTest.from_yaml('./project.yaml', key='captest_bifi_power_tc')
+
+.. _captest-settings-reference:
+
+Test settings reference
+"""""""""""""""""""""""
+The keys below may appear directly under a test's mapping in the yaml file, and
+each is also accepted as a keyword argument to
+:py:meth:`~captest.captest.CapTest.from_params`. An unrecognized key raises a
+``ValueError`` at load — naming the closest known key, when there is one — so a
+typo is reported rather than silently ignored.
+:py:meth:`~captest.captest.CapTest.to_yaml` writes every scalar setting on each
+save, so a saved config lists them all whether or not the project changed them
+from the defaults.
+
+**Regression setup and data.** These select the regression equation, point at
+the data, and carry the serialized pipelines.
+
+.. list-table::
+   :widths: 26 74
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``test_setup``
+     - Named preset from :data:`~captest.captest.TEST_SETUPS`, or ``custom``.
+       Default ``e2848_default``. See :ref:`choosing-test-setup`.
+   * - ``meas_path``, ``sim_path``
+     - Paths to the measured and modeled data, resolved relative to the yaml
+       file location.
+   * - ``meas_load_kwargs``, ``sim_load_kwargs``
+     - Keyword arguments splatted into each side's loader. See
+       :ref:`loader-kwargs`.
+   * - ``reg_fml``, ``reg_cols_meas``, ``reg_cols_sim``, ``rep_conditions``
+     - Replace the preset's regression formula, column mappings, and
+       reporting-condition aggregations. Accepted at this level or nested under
+       ``overrides``; required at ``test_setup: custom``. See
+       :ref:`custom_test_setups`.
+   * - ``rc_source``
+     - Which side owns the test reporting conditions — ``meas`` (default),
+       ``sim``, or ``manual``. See :doc:`reporting_conditions`.
+   * - ``reporting_conditions_values``
+     - Explicit reporting-condition values. Written and re-validated on load
+       when ``rc_source: manual``.
+   * - ``meas_prep``, ``sim_prep``
+     - Serialized data-preparation pipelines, replayed immediately after every
+       load. See :doc:`data_prep`.
+   * - ``meas_filters``, ``sim_filters``
+     - Serialized filter pipelines. Stored pending at load and replayed by
+       :py:meth:`~captest.captest.CapTest.run_test`.
+
+**Results and pass/fail.** The only two settings that feed the reported
+result.
+
+.. list-table::
+   :widths: 26 74
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``ac_nameplate``
+     - Nameplate AC power in W. Default ``null``; required for the pass/fail
+       calculation.
+   * - ``test_tolerance``
+     - Tolerance string such as ``"- 4"`` or ``"+/- 3"``. Default ``"- 4"``.
+       Also copied onto both ``CapData`` objects as ``tolerance`` during
+       ``setup()``.
+
+**Calculation scalars.** ``setup()`` copies each of these onto ``tst.meas``
+and ``tst.sim`` so the calculated columns (``e_total``,
+``power_temp_correct``, ``poa_spec_corrected``, ...) pick them up
+automatically. ``rear_shade`` is the exception: it goes to the measured side
+only, because the modeled side handles rear shading through its
+``reg_cols_sim`` definition.
+
+.. list-table::
+   :widths: 26 74
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``bifaciality``
+     - Bifaciality factor :math:`\varphi`. Default ``0.0``.
+   * - ``bifacial_frac``
+     - Fraction of array nameplate power that is bifacial. Default ``1.0``.
+   * - ``rear_shade``
+     - Fraction of rear irradiance lost to shading, applied on the measured
+       side by ``calcparams.e_total``. Default ``0.0``.
+   * - ``power_temp_coeff``
+     - Power temperature coefficient, percent per °C. Default ``-0.32``.
+   * - ``base_temp``
+     - Base temperature for the temperature correction, °C. Default ``25``.
+   * - ``module_type``
+     - Module construction for the Sandia temperature model:
+       ``glass_cell_poly`` (default), ``glass_cell_glass``, or
+       ``poly_tf_steel``.
+   * - ``racking``
+     - Mounting for the Sandia temperature model: ``open_rack`` (default),
+       ``close_roof_mount``, or ``insulated_back``.
+   * - ``spectral_module_type``
+     - Module type for the First Solar spectral correction. Default ``cdte``.
+       Distinct from ``module_type``; see :ref:`spec_corrected_poa`.
+   * - ``airmass_model``
+     - Relative airmass model. Default ``kastenyoung1989``.
+   * - ``altitude_override``
+     - Altitude in m used when building the pvlib ``Location``. Default ``0``
+       (sea level, per the First Solar reference); set to ``null`` to use the
+       site's own altitude.
+
+**Test-requirement values.** These record what the test procedure or contract
+requires. They are stored on the instance for you to reference when building
+the filter pipeline — nothing in pvcaptest reads them on its own.
+
+.. list-table::
+   :widths: 26 74
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``min_irr``, ``max_irr``
+     - POA irradiance filter bounds in W/m^2. Defaults ``400`` and ``1400``.
+       Pass them yourself: ``tst.meas.filter_irr(tst.min_irr, tst.max_irr)``.
+   * - ``rep_irr_filter``
+     - Fractional reporting-irradiance band. Default ``0.2``. Read the derived
+       :py:attr:`~captest.captest.CapTest.rep_irr_filter_low` /
+       :py:attr:`~captest.captest.CapTest.rep_irr_filter_high` properties
+       (``0.8`` / ``1.2``) rather than this value directly.
+   * - ``clipping_irr``
+     - POA irradiance above which the plant is expected to clip, W/m^2.
+       Default ``1000``.
+   * - ``fshdbm``
+     - Shade-filter threshold as a fraction. Default ``1.0``. Note that
+       :py:meth:`~captest.capdata.CapData.filter_shade` takes its own
+       ``fshdbm`` argument — this key does not feed it.
+   * - ``shade_filter_start``, ``shade_filter_end``
+     - ``"HH:MM"`` bounds for between-time shade filtering. Default ``null``.
+   * - ``sim_days``
+     - Days of simulated data used for the test. Default ``30``.
+   * - ``hrs_req``
+     - Hours of data required for a complete test. Default ``12.5``.
+   * - ``irrad_stability``, ``irrad_stability_threshold``
+     - Irradiance stability strategy — ``std`` (default),
+       ``filter_clearsky``, or ``contract`` — and its threshold (``30``).
+   * - ``inv_ac_nameplate``
+     - Per-inverter AC nameplate rating in kW. Plant metadata and a prefill
+       source for per-inverter clipping filters; never a hidden input to
+       results, since serialized filter steps record their resolved
+       thresholds.
+
+.. note::
+
+    Because the values in the last table are carriers rather than inputs, a
+    config that lists ``min_irr: 400`` has not filtered anything — the
+    ``meas_filters`` / ``sim_filters`` pipelines are the record of what was
+    actually applied, and each step stores the resolved values it ran with.
+    Reading the settings and the pipelines together is what makes a config
+    reviewable.
+
+.. note::
+
+    Two constructor arguments are deliberately absent from the yaml surface:
+    ``meas_loader`` / ``sim_loader``, which are callables, and
+    ``auto_wrap_sim``. Set them when calling
+    :py:meth:`~captest.captest.CapTest.from_params`.
 
 .. _what-setup-does:
 

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -2,7 +2,7 @@
 
 CapTest Workflow
 ================
-:py:class:`~captest.captest.CapTest` is a convenient way to keep the measured
+:py:class:`~captest.CapTest` is a convenient way to keep the measured
 data, modeled data, test settings, and comparison plots together for one
 capacity test.
 
@@ -49,9 +49,9 @@ directly. That workflow is mostly unchanged and may be helpful while learning pv
   tolerance, bifaciality, and filter settings.
 - You plan to save the test setup in a yaml file and re-run it later.
 - You want comparison methods such as
-  :py:meth:`~captest.captest.CapTest.captest_results`,
-  :py:meth:`~captest.captest.CapTest.overlay_scatters`, and
-  :py:meth:`~captest.captest.CapTest.residual_plot` to use the same measured
+  :py:meth:`~captest.CapTest.captest_results`,
+  :py:meth:`~captest.CapTest.overlay_scatters`, and
+  :py:meth:`~captest.CapTest.residual_plot` to use the same measured
   and modeled data automatically.
 
 .. _choosing-test-setup:
@@ -78,7 +78,7 @@ the regression for a capacity test. Each setup defines:
   compute reporting conditions (e.g. 60th-percentile POA, mean ambient temperature
   and wind speed).
 - **Scatter plot function** — the plotting callable matched to the regression
-  formula, used by :py:meth:`~captest.captest.CapTest.scatter_plots`.
+  formula, used by :py:meth:`~captest.CapTest.scatter_plots`.
 
 See :ref:`custom_test_setups` for additional details and example.
 
@@ -227,7 +227,7 @@ in the API reference for their descriptions.
 
 Creating a CapTest
 ------------------
-A :py:class:`~captest.captest.CapTest` can be created from from file paths, data
+A :py:class:`~captest.CapTest` can be created from from file paths, data
 that has already been loaded, or from a yaml file. Using ``from_params`` will create
 a CapTest object given file paths and is the option recommended for typical usage of
 pvcaptest to interactivley run a test in a Jupyter notebook.
@@ -265,7 +265,7 @@ passed with ``meas_load_kwargs`` and ``sim_load_kwargs``.
 From loaded data
 ~~~~~~~~~~~~~~~~
 If you have already loaded the measured and modeled data, pass the two
-``CapData`` objects to :py:meth:`~captest.captest.CapTest.from_params`.
+``CapData`` objects to :py:meth:`~captest.CapTest.from_params`.
 
 .. code-block:: Python
 
@@ -296,7 +296,7 @@ User Guide still apply.
 From yaml
 ~~~~~~~~~
 For repeatable project work, the capacity-test setup can be stored in a yaml
-file and loaded with :py:meth:`~captest.captest.CapTest.from_yaml`.
+file and loaded with :py:meth:`~captest.CapTest.from_yaml`.
 
 .. code-block:: yaml
 
@@ -320,11 +320,11 @@ file and loaded with :py:meth:`~captest.captest.CapTest.from_yaml`.
     tst = CapTest.from_yaml('./project.yaml')
 
 ``from_yaml`` loads the measured and modeled data and runs
-:py:meth:`~captest.captest.CapTest.setup`. Filter pipelines saved in the file
+:py:meth:`~captest.CapTest.setup`. Filter pipelines saved in the file
 (``meas_filters`` / ``sim_filters``) are **not** applied at load — they are
 stored on the instance as ``tst.meas_filters_pending`` and
 ``tst.sim_filters_pending`` and run later by
-:py:meth:`~captest.captest.CapTest.run_test`. The
+:py:meth:`~captest.CapTest.run_test`. The
 :ref:`captest-typical-workflow` section walks through the resulting states
 step by step. Pass ``run_setup=False`` to skip ``setup()`` as well and load
 the data only (see :ref:`load-only`).
@@ -340,8 +340,8 @@ Loader options
 loader for that side — :py:func:`~captest.io.load_data` for the measured data
 and :py:func:`~captest.io.load_pvsyst` for the modeled data. They are the yaml
 equivalent of the arguments of the same name on
-:py:meth:`~captest.captest.CapTest.from_params`, and they are also used by
-:py:meth:`~captest.captest.CapTest.reload`, so a side re-loaded later is loaded
+:py:meth:`~captest.CapTest.from_params`, and they are also used by
+:py:meth:`~captest.CapTest.reload`, so a side re-loaded later is loaded
 the same way.
 
 Two measured-side options are worth setting on most projects:
@@ -411,10 +411,10 @@ Test settings reference
 """""""""""""""""""""""
 The keys below may appear directly under a test's mapping in the yaml file, and
 each is also accepted as a keyword argument to
-:py:meth:`~captest.captest.CapTest.from_params`. An unrecognized key raises a
+:py:meth:`~captest.CapTest.from_params`. An unrecognized key raises a
 ``ValueError`` at load — naming the closest known key, when there is one — so a
 typo is reported rather than silently ignored.
-:py:meth:`~captest.captest.CapTest.to_yaml` writes every scalar setting on each
+:py:meth:`~captest.CapTest.to_yaml` writes every scalar setting on each
 save, so a saved config lists them all whether or not the project changed them
 from the defaults.
 
@@ -452,7 +452,7 @@ the data, and carry the serialized pipelines.
        load. See :doc:`data_prep`.
    * - ``meas_filters``, ``sim_filters``
      - Serialized filter pipelines. Stored pending at load and replayed by
-       :py:meth:`~captest.captest.CapTest.run_test`.
+       :py:meth:`~captest.CapTest.run_test`.
 
 **Results and pass/fail.** The only two settings that feed the reported
 result.
@@ -529,8 +529,8 @@ the filter pipeline — nothing in pvcaptest reads them on its own.
        Pass them yourself: ``tst.meas.filter_irr(tst.min_irr, tst.max_irr)``.
    * - ``rep_irr_filter``
      - Fractional reporting-irradiance band. Default ``0.2``. Read the derived
-       :py:attr:`~captest.captest.CapTest.rep_irr_filter_low` /
-       :py:attr:`~captest.captest.CapTest.rep_irr_filter_high` properties
+       :py:attr:`~captest.CapTest.rep_irr_filter_low` /
+       :py:attr:`~captest.CapTest.rep_irr_filter_high` properties
        (``0.8`` / ``1.2``) rather than this value directly.
    * - ``clipping_irr``
      - POA irradiance above which the plant is expected to clip, W/m^2.
@@ -568,7 +568,7 @@ the filter pipeline — nothing in pvcaptest reads them on its own.
     Two constructor arguments are deliberately absent from the yaml surface:
     ``meas_loader`` / ``sim_loader``, which are callables, and
     ``auto_wrap_sim``. Set them when calling
-    :py:meth:`~captest.captest.CapTest.from_params`.
+    :py:meth:`~captest.CapTest.from_params`.
 
 .. _what-setup-does:
 
@@ -576,8 +576,8 @@ What setup does
 ---------------
 When ``CapTest`` has both measured and modeled data, it prepares each
 ``CapData`` object for the selected test setup. This happens automatically when
-using :py:meth:`~captest.captest.CapTest.from_params` or
-:py:meth:`~captest.captest.CapTest.from_yaml` with both datasets present,
+using :py:meth:`~captest.CapTest.from_params` or
+:py:meth:`~captest.CapTest.from_yaml` with both datasets present,
 unless ``run_setup=False`` is passed (see :ref:`load-only`).
 
 The setup step:
@@ -593,7 +593,7 @@ The setup step:
   ``CapData`` objects so calculated columns use the intended assumptions.
 
 If you change a setup value after creating ``tst``, call
-:py:meth:`~captest.captest.CapTest.setup` again before continuing.
+:py:meth:`~captest.CapTest.setup` again before continuing.
 
 .. note::
 
@@ -625,7 +625,7 @@ Step 1 — load the test
 
 The measured and modeled data are loaded, any prep steps saved in the file are
 replayed against the freshly loaded data, and
-:py:meth:`~captest.captest.CapTest.setup` runs: scalar settings are propagated
+:py:meth:`~captest.CapTest.setup` runs: scalar settings are propagated
 to ``tst.meas`` / ``tst.sim``, calculated columns (e.g. ``e_total``) are
 created, and the regression columns are resolved and aggregated. Prep runs
 before ``setup`` so the calculated columns are derived from prepped values
@@ -666,7 +666,7 @@ pending — they have not touched the data.
     to ``setup`` — so this is the point to inspect the loaded data, or add a
     prep step the config does not have, before the calculated columns are
     derived from it. Run ``tst.setup()`` when ready, or call
-    :py:meth:`~captest.captest.CapTest.run_test`, whose first stage is the
+    :py:meth:`~captest.CapTest.run_test`, whose first stage is the
     per-side setup. See :ref:`load-only` for the full state after a load-only
     call.
 
@@ -698,7 +698,7 @@ measurements should be dropped, adjust them now with the prep methods:
 
 Prep steps rewrite values in ``data`` in place and are recorded on
 ``tst.meas.prep`` / ``tst.sim.prep``, so they are written to the config by
-:py:meth:`~captest.captest.CapTest.to_yaml` and re-applied the next time the
+:py:meth:`~captest.CapTest.to_yaml` and re-applied the next time the
 data is loaded. Any prep the config already declared was applied during
 step 1, between the load and ``setup()`` — there is nothing to repeat here.
 
@@ -841,7 +841,7 @@ the CapData API reference.
 
     results = tst.captest_results()
 
-:py:meth:`~captest.captest.CapTest.rep_cond` calculates reporting conditions
+:py:meth:`~captest.CapTest.rep_cond` calculates reporting conditions
 using the selected setup's defaults. For the standard E2848 setup, POA is
 calculated using the 60th percentile of filtered POA, while ambient temperature
 and wind speed use the mean.
@@ -880,15 +880,15 @@ filters anchor on the same value. See :ref:`reporting_conditions` for the full
 reporting-conditions model.
 
 Once the pipelines are in place, save the whole test — settings and both
-pipelines — with :py:meth:`~captest.captest.CapTest.to_yaml` so it can be
+pipelines — with :py:meth:`~captest.CapTest.to_yaml` so it can be
 reproduced later (see :ref:`saving_reproducing`).
 
 .. _running-with-run-test:
 
 Running the whole test with run_test
 ------------------------------------
-:py:meth:`~captest.captest.CapTest.run_test` runs the complete test in one
-call. It runs :py:meth:`~captest.captest.CapTest.setup`, replays each side's
+:py:meth:`~captest.CapTest.run_test` runs the complete test in one
+call. It runs :py:meth:`~captest.CapTest.setup`, replays each side's
 filter pipeline (the ``rc_source`` side first, so its reporting-conditions
 step establishes ``tst.rc`` before the other side's RC-dependent filters
 resolve), fits both regressions, verifies the reporting conditions were
@@ -899,7 +899,7 @@ computed during the run, and returns the results.
     results = tst.run_test()
     results.cap_ratio
 
-Combined with :py:meth:`~captest.captest.CapTest.from_yaml`, this reproduces a
+Combined with :py:meth:`~captest.CapTest.from_yaml`, this reproduces a
 whole capacity test — data loading, setup, filtering, reporting conditions,
 regressions, and results — from a single config file, with each pipeline
 executed exactly once (the load stores the pipelines pending; ``run_test``
@@ -933,9 +933,9 @@ Re-running one side
 Pass ``side='meas'`` or ``side='sim'`` to re-run only one side's setup,
 filter pipeline, and regression, leaving the other side untouched. Per-side
 runs return the ``CapTest`` instance itself rather than results, so a full
-comparison still ends with :py:meth:`~captest.captest.CapTest.captest_results`.
+comparison still ends with :py:meth:`~captest.CapTest.captest_results`.
 
-This pairs well with :py:meth:`~captest.captest.CapTest.reload`, which
+This pairs well with :py:meth:`~captest.CapTest.reload`, which
 re-loads one side's data with the stored loader and keyword arguments and
 re-runs the per-side setup. ``reload`` preserves the side's filter
 definitions: the outgoing applied chain is snapshot into
@@ -970,9 +970,9 @@ and ``to_yaml`` use it:
 
 Loading without running setup
 -----------------------------
-Pass ``run_setup=False`` to :py:meth:`~captest.captest.CapTest.from_params`,
-:py:meth:`~captest.captest.CapTest.from_yaml`, or
-:py:meth:`~captest.captest.CapTest.from_mapping` to load the data and stop
+Pass ``run_setup=False`` to :py:meth:`~captest.CapTest.from_params`,
+:py:meth:`~captest.CapTest.from_yaml`, or
+:py:meth:`~captest.CapTest.from_mapping` to load the data and stop
 there — for example to inspect the raw data or review the column groups
 before the regression mapping is applied:
 
@@ -1139,7 +1139,7 @@ See :ref:`reporting_conditions` for the full description of both warnings.
 Reviewing results
 -----------------
 The main comparison method is
-:py:meth:`~captest.captest.CapTest.captest_results`. It predicts the measured
+:py:meth:`~captest.CapTest.captest_results`. It predicts the measured
 and modeled capacities at the reporting conditions, calculates the capacity
 ratio, and prints a pass/fail summary using the AC nameplate and test
 tolerance stored on your instance of Captest, e.g. ``tst``. It returns a
@@ -1188,7 +1188,7 @@ run:
   (``True`` when the test ran with ``check_pvalues=True``).
 
 The same arguments are accepted by
-:py:meth:`~captest.captest.CapTest.run_test`, which forwards them to
+:py:meth:`~captest.CapTest.run_test`, which forwards them to
 ``captest_results``.
 
 .. note::
@@ -1199,21 +1199,21 @@ The same arguments are accepted by
 
 Additional review methods are available from the same ``CapTest`` object:
 
-- :py:meth:`~captest.captest.CapTest.captest_results_check_pvalues` compares
+- :py:meth:`~captest.CapTest.captest_results_check_pvalues` compares
   results with and without high-p-value coefficients and highlights
   coefficients with p-values above 0.05.
-- :py:meth:`~captest.captest.CapTest.overlay_scatters` overlays the measured
+- :py:meth:`~captest.CapTest.overlay_scatters` overlays the measured
   and modeled regression scatter plots.
-- :py:meth:`~captest.captest.CapTest.residual_plot` compares measured and
+- :py:meth:`~captest.CapTest.residual_plot` compares measured and
   modeled residuals against the regression variables.
-- :py:meth:`~captest.captest.CapTest.get_summary` combines the filter summaries
+- :py:meth:`~captest.CapTest.get_summary` combines the filter summaries
   for ``tst.meas`` and ``tst.sim`` into one table.
-- :py:meth:`~captest.captest.CapTest.determine_pass_or_fail` applies the stored
+- :py:meth:`~captest.CapTest.determine_pass_or_fail` applies the stored
   nameplate and tolerance to a capacity ratio.
 
 Scatter plots
 -------------
-:py:meth:`~captest.captest.CapTest.scatter_plots` creates the scatter plot that
+:py:meth:`~captest.CapTest.scatter_plots` creates the scatter plot that
 matches the selected ``test_setup``. By default it plots the measured data.
 
 .. code-block:: Python

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -116,7 +116,8 @@ The most commonly used options are described below:
     with total irradiance. Rear shading and IAM losses are handled in the
     modeled (PVsyst) data: the modeled rear irradiance is
     ``rpoa_pvsyst = GlobBak + BackShd``, while the measured rear sensor
-    (``irr_rpoa``) is used as-measured (``rear_shade = 0``).
+    (``irr_rpoa``) is used as-measured. Leave ``rear_shade`` at its default
+    ``0`` with this setup (see the warning below).
 
     .. math::
         E_{Total}^{model} = E_{POA} + \left(GlobBak + BackShd\right)\varphi
@@ -130,7 +131,8 @@ The most commonly used options are described below:
     Same regression form as ``bifi_e2848_etotal_rear_shade_sim``, but rear
     shading is applied on the measured side as a flat fraction :math:`s` (the
     ``rear_shade`` factor), while the modeled rear maps directly to PVsyst's
-    unshaded global rear (``GlobBak``).
+    unshaded global rear (``GlobBak``). This is the variant to select when
+    ``rear_shade`` is set to a non-zero value.
 
     .. math::
         E_{Total}^{model} = E_{POA} + GlobBak \cdot \varphi
@@ -170,6 +172,23 @@ total-irradiance setups
 (``bifi_e2848_etotal_rear_shade_sim_spec_corrected``,
 ``bifi_e2848_etotal_rear_shade_meas_spec_corrected``). See :ref:`test-setups`
 in the API reference for their descriptions.
+
+.. warning::
+
+    The ``_sim`` / ``_meas`` suffix on the total-irradiance presets says which
+    side accounts for rear shading, and ``rear_shade`` belongs only with the
+    ``_meas`` variants.
+
+    The two variants share the same measured column mapping, and no preset
+    overrides ``rear_shade``, so a non-zero value reaches the measured
+    ``e_total`` whichever preset is selected — pvcaptest does not reset it for
+    you. Setting ``rear_shade`` alongside a ``_sim`` preset therefore shades
+    the measured rear *in addition to* the shading already carried by
+    ``rpoa_pvsyst`` on the modeled side, double-counting the loss and biasing
+    the capacity ratio.
+
+    Pick the variant that matches where the shading is accounted for, and
+    leave ``rear_shade`` at ``0`` for the ``_sim`` variants.
 
 .. note::
 
@@ -471,7 +490,9 @@ only, because the modeled side handles rear shading through its
      - Fraction of array nameplate power that is bifacial. Default ``1.0``.
    * - ``rear_shade``
      - Fraction of rear irradiance lost to shading, applied on the measured
-       side by ``calcparams.e_total``. Default ``0.0``.
+       side by ``calcparams.e_total``. Default ``0.0``. Set a non-zero value
+       only with a ``*_rear_shade_meas`` preset — see the warning in
+       :ref:`choosing-test-setup`.
    * - ``power_temp_coeff``
      - Power temperature coefficient, percent per °C. Default ``-0.32``.
    * - ``base_temp``

--- a/docs/user_guide/captest.rst
+++ b/docs/user_guide/captest.rst
@@ -228,6 +228,7 @@ If you provide paths to your data, ``CapTest`` will load the data for you.
         test_tolerance='- 4',
         meas_load_kwargs={
             'group_columns': './path-to/column_groups.xlsx',
+            'summary': False,
         },
     )
 
@@ -237,8 +238,10 @@ passed with ``meas_load_kwargs`` and ``sim_load_kwargs``.
 
 .. note::
 
-   You will likely need / want to include meas_load_kwargs to load your
-   column grouping from a file. See the examples.
+   You will likely need / want to include ``meas_load_kwargs`` to load your
+   column grouping from a file. See :ref:`loader-kwargs` for that option, for
+   quieting the loader's progress output, and for how these keys are written
+   in a yaml config.
 
 From loaded data
 ~~~~~~~~~~~~~~~~
@@ -288,6 +291,10 @@ file and loaded with :py:meth:`~captest.captest.CapTest.from_yaml`.
       max_irr: 1400
       fshdbm: 1.0
       bifaciality: 0.15
+      meas_load_kwargs:
+        group_columns: ./data/column_groups.json
+        summary: False
+        verbose: False
 
 .. code-block:: Python
 
@@ -306,6 +313,48 @@ the data only (see :ref:`load-only`).
 Relative ``meas_path`` and ``sim_path`` values are interpreted relative to the
 yaml file location. This makes the yaml file portable with the project folder.
 
+.. _loader-kwargs:
+
+Loader options
+""""""""""""""
+``meas_load_kwargs`` and ``sim_load_kwargs`` are mappings splatted into the
+loader for that side — :py:func:`~captest.io.load_data` for the measured data
+and :py:func:`~captest.io.load_pvsyst` for the modeled data. They are the yaml
+equivalent of the arguments of the same name on
+:py:meth:`~captest.captest.CapTest.from_params`, and they are also used by
+:py:meth:`~captest.captest.CapTest.reload`, so a side re-loaded later is loaded
+the same way.
+
+Two measured-side options are worth setting on most projects:
+
+``group_columns``
+    Path to a saved column-grouping file — ``.json``, ``.yaml``, or ``.xlsx``
+    — used in place of inferring the groups from the column names. This is the
+    usual way to give a project a stable, reviewed set of column groups. See
+    :ref:`col-grouping` for the file formats.
+
+``summary`` and ``verbose``
+    Set both to ``False`` to silence the loader's progress output. ``summary``
+    (default ``True``) prints a ``trying to load`` / ``loaded`` line for each
+    file plus a completion banner, and applies when ``meas_path`` points at a
+    directory of files rather than at a single file. ``verbose`` (default
+    ``False``) adds the per-file reindexing detail and forces ``summary`` on.
+    ``summary`` is not a named argument of :py:func:`~captest.io.load_data`; it
+    passes through its ``**kwargs`` to :py:meth:`~captest.io.DataLoader.load`.
+
+Any other keyword the loader accepts can be set the same way — for example
+``site`` to add modeled clear-sky columns, or a ``sep`` / ``skiprows`` value
+forwarded to ``pandas.read_csv``.
+
+.. warning::
+
+    Unlike ``meas_path`` and ``sim_path``, values inside ``meas_load_kwargs``
+    and ``sim_load_kwargs`` are handed to the loader verbatim — they are
+    **not** resolved relative to the yaml file. A relative ``group_columns``
+    path is interpreted from the working directory of the process reading the
+    config, so use a path that is valid from where the notebook or script runs,
+    or an absolute path.
+
 One yaml file can also contain more than one capacity-test setup. For example,
 the same bifacial project may be reviewed with both the total-irradiance E2848
 setup and the temperature-corrected power setup.
@@ -318,6 +367,9 @@ setup and the temperature-corrected power setup.
       sim_path: ./data/pvsyst.csv
       ac_nameplate: 6_000_000
       bifaciality: 0.15
+      meas_load_kwargs:
+        group_columns: ./data/column_groups.json
+        summary: False
 
     captest_bifi_power_tc:
       test_setup: bifi_power_tc_calc_tbom
@@ -325,6 +377,9 @@ setup and the temperature-corrected power setup.
       sim_path: ./data/pvsyst.csv
       ac_nameplate: 6_000_000
       bifaciality: 0.15
+      meas_load_kwargs:
+        group_columns: ./data/column_groups.json
+        summary: False
 
 .. code-block:: Python
 

--- a/docs/user_guide/custom_test_setups.rst
+++ b/docs/user_guide/custom_test_setups.rst
@@ -12,7 +12,7 @@ parameter calculation functions without modifying the package.
 
 This page explains the structure of those dicts, shows how the built-in
 :py:mod:`captest.calcparams` functions plug into them, and describes the three
-ways to wire a custom dict into a :py:class:`~captest.captest.CapTest`.
+ways to wire a custom dict into a :py:class:`~captest.CapTest`.
 
 The regression column dictionary grammar
 ------------------------------------
@@ -58,7 +58,7 @@ or nested calculated-column tuples:
     )
 
 Nesting is allowed to any depth. During
-:py:meth:`~captest.captest.CapTest.setup`, pvcaptest recursively walks the tree bottom-up:
+:py:meth:`~captest.CapTest.setup`, pvcaptest recursively walks the tree bottom-up:
 each ``(func, kwargs_dict)`` tuple creates a new column named
 ``func.__name__`` in ``CapData.data``, and that name is passed upward as input
 to any parent tuple. For the example above, ``e_total`` is a callable (a function from
@@ -172,10 +172,10 @@ Scalar parameters such as ``power_temp_coeff``, ``base_temp``,
 ``bifaciality``, and ``spectral_module_type`` do not need to appear in the
 dict. When a :py:mod:`captest.calcparams` function has a keyword argument
 whose name matches an attribute on the ``CapData`` instance, pvcaptest injects
-that value automatically. :py:class:`~captest.captest.CapTest` propagates
+that value automatically. :py:class:`~captest.CapTest` propagates
 these scalars onto both ``CapData`` instances during
-:py:meth:`~captest.captest.CapTest.setup`, so setting them on the
-:py:class:`~captest.captest.CapTest` instance is sufficient:
+:py:meth:`~captest.CapTest.setup`, so setting them on the
+:py:class:`~captest.CapTest` instance is sufficient:
 
 .. code-block:: Python
 
@@ -237,7 +237,7 @@ scatter plot, and reporting conditions are inherited:
     )
 
 **Route 3 — assign directly.** Attributes can be set on the instance before
-calling :py:meth:`~captest.captest.CapTest.setup`:
+calling :py:meth:`~captest.CapTest.setup`:
 
 .. code-block:: Python
 

--- a/docs/user_guide/custom_test_setups.rst
+++ b/docs/user_guide/custom_test_setups.rst
@@ -11,7 +11,7 @@ you supply your own ``reg_cols_meas`` and ``reg_cols_sim`` dicts and user-define
 parameter calculation functions without modifying the package.
 
 This page explains the structure of those dicts, shows how the built-in
-:py:mod:`captest.calcparams` functions plug into them, and describes the three
+:doc:`/source/api_reference/calcparams` functions plug into them, and describes the three
 ways to wire a custom dict into a :py:class:`~captest.CapTest`.
 
 The regression column dictionary grammar
@@ -68,7 +68,7 @@ so that ``poa`` now points to ``e_total``.
 
 Using calcparams functions
 --------------------------
-The functions in :py:mod:`captest.calcparams` are the public building blocks
+The functions in :doc:`/source/api_reference/calcparams` are the public building blocks
 for calculated columns. Import the ones you need:
 
 .. code-block:: Python
@@ -88,7 +88,7 @@ If you need to calculate a parameter which does not have a function in the ``cal
 module, you can write your own.
 
 The dictionary accepts plain Python functions that are not part of
-:py:mod:`captest.calcparams`, as long as they follow the same signature
+:doc:`/source/api_reference/calcparams`, as long as they follow the same signature
 convention:
 
 - First positional argument must be ``data``, the source DataFrame.
@@ -170,7 +170,7 @@ Scalar auto-injection
 ---------------------
 Scalar parameters such as ``power_temp_coeff``, ``base_temp``,
 ``bifaciality``, and ``spectral_module_type`` do not need to appear in the
-dict. When a :py:mod:`captest.calcparams` function has a keyword argument
+dict. When a :doc:`/source/api_reference/calcparams` function has a keyword argument
 whose name matches an attribute on the ``CapData`` instance, pvcaptest injects
 that value automatically. :py:class:`~captest.CapTest` propagates
 these scalars onto both ``CapData`` instances during

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -11,7 +11,7 @@ difference is what they do: a filter selects rows and leaves the values alone,
 while a prep step rewrites values (or column identity) in
 :py:attr:`~captest.capdata.CapData.data` in place. Each step that runs is
 appended to the :py:attr:`~captest.capdata.CapData.prep` list, is written to
-the test config by :py:meth:`~captest.captest.CapTest.to_yaml`, and is
+the test config by :py:meth:`~captest.CapTest.to_yaml`, and is
 re-applied automatically the next time the data is loaded.
 
 Where prep sits in the lifecycle
@@ -21,7 +21,7 @@ The lifecycle of a test is:
 **load → prep → setup → filter**
 
 Prep runs after the data is loaded and before
-:py:meth:`~captest.captest.CapTest.setup`. That ordering is deliberate:
+:py:meth:`~captest.CapTest.setup`. That ordering is deliberate:
 ``setup`` resolves regression columns and calculates derived parameters (cell
 temperature, spectral corrections) from the values in ``data``, so the values
 must already be in the units those calculations assume. Filtering comes last,
@@ -30,7 +30,7 @@ because every filter threshold is evaluated against prepped values.
 The prep stage is the only place a data adjustment is *recorded*. Editing
 ``cd.data`` directly in a notebook still works and always has, but nothing
 captures that it happened: the exported yaml does not show it, and
-:py:meth:`~captest.captest.CapTest.reload` re-invokes the loader and silently
+:py:meth:`~captest.CapTest.reload` re-invokes the loader and silently
 discards it. A reviewer reading an exported config can see a recorded prep
 step; they cannot see a hand-edit.
 
@@ -69,9 +69,9 @@ and a PVsyst side needs its power column rescaled:
     sim = ct.load_pvsyst('./pvsyst/VC1_HourlyRes_1.CSV')
     sim.prep_scale(columns=['E_Grid'], factor=0.001)
 
-Within a :py:class:`~captest.captest.CapTest`, load the data without running
+Within a :py:class:`~captest.CapTest`, load the data without running
 ``setup``, prep each side, then call
-:py:meth:`~captest.captest.CapTest.setup`:
+:py:meth:`~captest.CapTest.setup`:
 
 .. code-block:: Python
 
@@ -302,7 +302,7 @@ Three consequences follow:
   populated.
 - There is no ``reset_prep()``. Nothing can undo a mutation, so re-prepping
   means going back to raw data with
-  :py:meth:`~captest.captest.CapTest.reload`:
+  :py:meth:`~captest.CapTest.reload`:
 
   .. code-block:: Python
 
@@ -316,7 +316,7 @@ Three consequences follow:
   overwrites ``sim_prep`` with the applied chain, editing ``tst.sim_prep``
   and then reloading does not change anything. To run a *different* prep,
   rebuild the test from its paths — with
-  :py:meth:`~captest.captest.CapTest.from_yaml` on an edited config, or
+  :py:meth:`~captest.CapTest.from_yaml` on an edited config, or
   ``from_params(..., run_setup=False)`` followed by the ``prep_*`` calls you
   want.
 
@@ -328,7 +328,7 @@ never left behind.
 
 .. note::
 
-    When a :py:class:`~captest.captest.CapTest` is built from a *pre-built*
+    When a :py:class:`~captest.CapTest` is built from a *pre-built*
     :py:class:`~captest.capdata.CapData` rather than a path, a stored
     ``meas_prep`` / ``sim_prep`` config is kept but **not** applied — the
     object may already have been prepped, and prep is not idempotent. A
@@ -385,7 +385,7 @@ groups are aggregated together.
 
 Prep in the config file
 -----------------------
-:py:meth:`~captest.captest.CapTest.to_yaml` writes the applied prep chain for
+:py:meth:`~captest.CapTest.to_yaml` writes the applied prep chain for
 each side under the ``meas_prep`` and ``sim_prep`` keys, alongside the
 ``meas_filters`` / ``sim_filters`` pipelines described in
 :ref:`reproducing-a-test`. The keys are omitted entirely when a side has no
@@ -432,8 +432,8 @@ prep.
       # ...
 
 Unlike the filter pipelines, which are stored as *pending* and replayed by
-:py:meth:`~captest.captest.CapTest.run_test`, prep is applied **at load**.
-:py:meth:`~captest.captest.CapTest.from_yaml` loads each side from its path
+:py:meth:`~captest.CapTest.run_test`, prep is applied **at load**.
+:py:meth:`~captest.CapTest.from_yaml` loads each side from its path
 and immediately replays that side's prep, before ``setup``:
 
 .. code-block:: Python
@@ -446,10 +446,10 @@ and immediately replays that side's prep, before ``setup``:
     Columns index were dropped.
     Columns E_Grid were scaled by 0.001 with an offset of 0.0.
 
-The same replay happens for :py:meth:`~captest.captest.CapTest.from_params`
-and :py:meth:`~captest.captest.CapTest.from_mapping` whenever a side is built
+The same replay happens for :py:meth:`~captest.CapTest.from_params`
+and :py:meth:`~captest.CapTest.from_mapping` whenever a side is built
 from a path, including under ``run_setup=False``, and on every
-:py:meth:`~captest.captest.CapTest.reload`. That is what makes a reload with a
+:py:meth:`~captest.CapTest.reload`. That is what makes a reload with a
 new file safe: the new data gets the same adjustments the old data had.
 
 A single :py:class:`~captest.capdata.CapData` can be round-tripped on its own

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -43,7 +43,7 @@ counts, and prep removes no points. Use
 The prep methods
 ----------------
 :py:class:`~captest.capdata.CapData` provides four prep wrappers, each of
-which builds a step from :py:mod:`captest.prep`, runs it against ``data``, and
+which builds a step from :doc:`/source/api_reference/prep`, runs it against ``data``, and
 appends it to :py:attr:`~captest.capdata.CapData.prep`:
 
 - :py:meth:`~captest.capdata.CapData.prep_convert_units` — convert between

--- a/docs/user_guide/dataload.rst
+++ b/docs/user_guide/dataload.rst
@@ -2,7 +2,7 @@
 
 CapData Workflow
 ================
-The core functionality of pvcaptest is provided by the :py:class:`~captest.capdata.CapData` class, which is a wrapper around two pandas DataFrames, :py:attr:`data` and :py:attr:`data_filtered`. The :py:attr:`data` DataFrame holds the unfiltered data and the :py:attr:`data_filtered` DataFrame is a copy of the data that the :py:class:`~captest.capdata.CapData` filtering methods modify. :py:meth:`~captest.capdata.CapData.reset_filter` can be used to reset the :py:attr:`data_filtered` DataFrame to the unfiltered data. The :py:meth:`~captest.capdata.CapData.fit_regression` method is used to fit the regression equation stored in :py:attr:`regression_formula` to the filtered data. 
+The core functionality of pvcaptest is provided by the :py:class:`~captest.capdata.CapData` class, which holds the loaded data in the :py:attr:`~captest.capdata.CapData.data` DataFrame together with the chain of filters applied to it. :py:attr:`~captest.capdata.CapData.data` always holds the full, unfiltered data — filtering never modifies it. Each filtering method instead appends a step to the :py:attr:`~captest.capdata.CapData.filters` list recording which rows it kept, and :py:attr:`~captest.capdata.CapData.data_filtered` is a derived, read-only property returning a copy of :py:attr:`~captest.capdata.CapData.data` restricted to the rows kept by the last step. :py:meth:`~captest.capdata.CapData.reset_filter` clears that list, so :py:attr:`~captest.capdata.CapData.data_filtered` returns the unfiltered data again. The :py:meth:`~captest.capdata.CapData.fit_regression` method is used to fit the regression equation stored in :py:attr:`~captest.capdata.CapData.regression_formula` to the filtered data.
 
 Conducting a capacity tests with pvcaptest involves the following steps:
 
@@ -47,13 +47,13 @@ Generally, the first step to conducting a capacity test is to load data from the
 
 .. note::
 
-    :py:attr:`loc` and :py:attr:`floc` can be used to access data, see `Accessing Filtered and Unfiltered Data`_.
+    :py:attr:`~captest.capdata.CapData.loc` and :py:attr:`~captest.capdata.CapData.floc` can be used to access data, see `Accessing Filtered and Unfiltered Data`_.
 
 - Sorts the data by the datetime index.
 - Drops any rows where all values in the row are duplicates of the any other row.
 - Reindexes the data so there are no missing time intervals.
-- Attempts to group the columns by measurement type based on the column names and store the resulting groupings in the :py:attr:`column_groups` attribute.
-- If you provide information about the project site (latitude, longitude, elevation, timezone, racking type, racking orientation) it will add modeled clear sky POA and GHI irradiance to the :py:attr:`data` DataFrame.
+- Attempts to group the columns by measurement type based on the column names and store the resulting groupings in the :py:attr:`~captest.capdata.CapData.column_groups` attribute.
+- If you provide information about the project site (latitude, longitude, elevation, timezone, racking type, racking orientation) it will add modeled clear sky POA and GHI irradiance to the :py:attr:`~captest.capdata.CapData.data` DataFrame.
 
 Except for the clear sky modelling, the above describes the default behavior of :py:func:`~captest.io.load_data`, which can be adjusted as needed.
 
@@ -67,7 +67,7 @@ Internally, :py:func:`~captest.io.load_data` uses an instance of the :py:class:`
 
 .. note::
 
-    If it is necessary to modify the :py:attr:`data` DataFrame to add columns or convert units, it best to do that immediately after loading the data. Followed by calling :py:meth:`~captest.capdata.CapData.reset_filter`, which will overwrite the :py:attr:`data_filtered` DataFrame with the modified :py:attr:`data` DataFrame.
+    If it is necessary to modify the :py:attr:`~captest.capdata.CapData.data` DataFrame to add columns or convert units, it is best to do that immediately after loading the data, before any filters are applied. Because :py:attr:`~captest.capdata.CapData.data_filtered` is derived from :py:attr:`~captest.capdata.CapData.data`, the change is picked up automatically — there is nothing to reset. For unit and dtype changes prefer the prep methods (e.g. :py:meth:`~captest.capdata.CapData.prep_convert_units`, :py:meth:`~captest.capdata.CapData.prep_scale`), which record what they did so it can be replayed the next time the data is loaded; see :doc:`data_prep`.
 
 .. note::
 
@@ -77,7 +77,7 @@ Internally, :py:func:`~captest.io.load_data` uses an instance of the :py:class:`
 
 Column grouping
 ---------------
-As mentioned above, much of the functionality of pvcaptest relies on the groupings of the columns of data by measurement type that is stored in :py:attr:`column_groups`, which is an instance of the :py:class:`~captest.columngroups.ColumnGroups` class, but can also be set to a standard python dictionary. :py:attr:`column_groups` maps a label for each group to a list of the column headings that are in each group. 
+As mentioned above, much of the functionality of pvcaptest relies on the groupings of the columns of data by measurement type that is stored in :py:attr:`~captest.capdata.CapData.column_groups`, which is an instance of the :py:class:`~captest.columngroups.ColumnGroups` class, but can also be set to a standard python dictionary. :py:attr:`~captest.capdata.CapData.column_groups` maps a label for each group to a list of the column headings that are in each group. 
 
 For example, the first two groups from the Complete Capacity Test example are shown below:
 
@@ -95,10 +95,10 @@ For example, the first two groups from the Complete Capacity Test example are sh
     }
 
 The :py:class:`~captest.columngroups.ColumnGroups` class provides some convenient features: nice display of the groupings for review and groups as attributes. Having group id as attributes allows groups of columns to be easily accessed using tab completion in Jupyter notebook.
-In addition, when data is loaded with :py:func:`~captest.io.load_data`, each column group is also accessible as an attribute directly on the :py:class:`~captest.capdata.CapData` instance. For example, if there is a group with the key ``poa``, it can be accessed as ``cd.poa``, which returns the corresponding columns of :py:attr:`data` as a DataFrame. This enables tab-completion in Jupyter notebooks for quick exploration of the data. The same behaviour can be enabled on a manually constructed :py:class:`~captest.capdata.CapData` instance by calling :py:meth:`~captest.capdata.CapData.create_column_group_attributes`.
+In addition, when data is loaded with :py:func:`~captest.io.load_data`, each column group is also accessible as an attribute directly on the :py:class:`~captest.capdata.CapData` instance. For example, if there is a group with the key ``poa``, it can be accessed as ``cd.poa``, which returns the corresponding columns of :py:attr:`~captest.capdata.CapData.data` as a DataFrame. This enables tab-completion in Jupyter notebooks for quick exploration of the data. The same behaviour can be enabled on a manually constructed :py:class:`~captest.capdata.CapData` instance by calling :py:meth:`~captest.capdata.CapData.create_column_group_attributes`.
 
-To rename columns consistently across :py:attr:`data`, :py:attr:`data_filtered`, and
-:py:attr:`column_groups`, use :py:meth:`~captest.capdata.CapData.rename_cols`.
+To rename columns consistently across :py:attr:`~captest.capdata.CapData.data`, :py:attr:`~captest.capdata.CapData.data_filtered`, and
+:py:attr:`~captest.capdata.CapData.column_groups`, use :py:meth:`~captest.capdata.CapData.rename_cols`.
 
 Due to the very wide range of conventions for naming in DAS / SCADA systems, the default approach to grouping columns often fails to return a satisfactory grouping of the columns. This can be addressed by providing an explicit mapping of column group ids to column names in an external file. To do this the path to the file should be passed to ``group_columns``. Excel, JSON, and YAML files are all options. JSON and Yaml must parse to a python dictionary with keys that are string ids of the groups and values that are lists of column names.
 
@@ -189,21 +189,28 @@ Identifying Regression Data
 ---------------------------
 To perform the regression pvcaptest uses `statsmodels <https://www.statsmodels.org/stable/index.html>`_, which in turn `relies on patsy <https://www.statsmodels.org/stable/examples/notebooks/generated/formulas.html>`_ to simplify specifying regression equations.
 
-By default the ASTM E2848 regression equation is defined in the :py:attr:`regression_formula` attribute:
+By default the ASTM E2848 regression equation is defined in the :py:attr:`~captest.capdata.CapData.regression_formula` attribute:
 
 .. code-block:: Python
 
         'power ~ poa + I(poa * poa) + I(poa * t_amb) + I(poa * w_vel) - 1'
 
-Patsy and Statsmodels expect to find columns with the `power`, `poa`, `t_amb`, and `w_vel` headings in the DataFrame passed to fit the regression. Rather than requiring those headings to be in the :py:attr:`data` DataFrame, pvcaptest requires the user to specify which columns or *group of columns* are to be used in the regression in :py:attr:`regression_cols`. The :py:meth:`~captest.capdata.CapData.set_regression_cols` method can used to identify column headings or column group ids (:py:attr:`column_groups` keys). Or :py:attr:`regression_cols` can be set to a dictionary mapping the regression terms defined in the :py:attr:`regression_formula` to the column headings or :py:attr:`column_groups` id.
+Patsy and Statsmodels expect to find columns with the `power`, `poa`, `t_amb`, and `w_vel` headings in the DataFrame passed to fit the regression. Rather than requiring those headings to be in the :py:attr:`~captest.capdata.CapData.data` DataFrame, pvcaptest requires the user to specify which columns or *group of columns* are to be used in the regression in :py:attr:`~captest.capdata.CapData.regression_cols`. The :py:meth:`~captest.capdata.CapData.set_regression_cols` method can used to identify column headings or column group ids (:py:attr:`~captest.capdata.CapData.column_groups` keys). Or :py:attr:`~captest.capdata.CapData.regression_cols` can be set to a dictionary mapping the regression terms defined in the :py:attr:`~captest.capdata.CapData.regression_formula` to the column headings or :py:attr:`~captest.capdata.CapData.column_groups` id.
 
 The ability to map a regression term to a group of columns is useful when there are multiple sensors for a given measurement, as described in the next section.
 
 Aggregating Sensors
 -------------------
-:py:meth:`~captest.capdata.CapData.agg_sensors` can be used to aggregate data from multiple sensors into a single column. This is useful when there are multiple sensors for a given measurement. Any combination of groups of columns and aggregation functions can be passed. By default the groups of columns assigned to the ``power``, ``poa``, ``t_amb``, and ``w_vel`` keys in the :py:attr:`regression_cols` attribute are aggregated by summing the power and averaging the POA irradiance, ambient temperature, and wind speed columns.
+:py:meth:`~captest.capdata.CapData.agg_sensors` can be used to aggregate data from multiple sensors into a single column. This is useful when there are multiple sensors for a given measurement. Any combination of groups of columns and aggregation functions can be passed. By default the groups of columns assigned to the ``power``, ``poa``, ``t_amb``, and ``w_vel`` keys in the :py:attr:`~captest.capdata.CapData.regression_cols` attribute are aggregated by summing the power and averaging the POA irradiance, ambient temperature, and wind speed columns.
 
-:py:meth:`~captest.capdata.CapData.agg_sensors` adds the resulting aggregated columns to the :py:attr:`data` and :py:attr:`data_filtered` dataframes. If :py:attr:`regression_cols` included a group of columns that was aggregated, :py:attr:`regression_cols` is updated to map the regression term to the aggregated column. After aggregation, all aggregated columns are also stored under the ``"agg"`` key in :py:attr:`column_groups` and are accessible as :py:class:`~captest.capdata.CapData` attributes prefixed with ``aggs_`` (e.g., ``cd.aggs_irr_poa_mean_agg``).
+:py:meth:`~captest.capdata.CapData.agg_sensors` adds the resulting aggregated columns to :py:attr:`~captest.capdata.CapData.data`; they appear in :py:attr:`~captest.capdata.CapData.data_filtered` automatically, since that is derived from :py:attr:`~captest.capdata.CapData.data`. If :py:attr:`~captest.capdata.CapData.regression_cols` included a group of columns that was aggregated, :py:attr:`~captest.capdata.CapData.regression_cols` is updated to map the regression term to the aggregated column. After aggregation, all aggregated columns are also stored under the ``"agg"`` key in :py:attr:`~captest.capdata.CapData.column_groups` and are accessible as :py:class:`~captest.capdata.CapData` attributes prefixed with ``aggs_`` (e.g., ``cd.aggs_irr_poa_mean_agg``).
+
+.. warning::
+
+    :py:meth:`~captest.capdata.CapData.agg_sensors` clears the
+    :py:attr:`~captest.capdata.CapData.filters` list, so any filters already
+    applied are lost (a ``UserWarning`` says so). Aggregate sensors before
+    filtering.
 
 :py:meth:`~captest.capdata.CapData.agg_sensors` also supports nested subgroup aggregation. If a value in ``agg_map`` is itself a dictionary, its keys are treated as subgroups to aggregate first, and the results are then aggregated together. This is useful when sensors are grouped by met station before being combined into a single representative value. For example:
 
@@ -220,7 +227,7 @@ Aggregating Sensors
 
 This first averages the sensors in ``irr_poa_met1`` and ``irr_poa_met2`` separately, then averages those two results to produce ``irr_poa_mean_agg``.
 
-For example, if the :py:attr:`regression_cols` attribute was set to the following:
+For example, if the :py:attr:`~captest.capdata.CapData.regression_cols` attribute was set to the following:
 
 .. code-block:: Python
 
@@ -231,9 +238,9 @@ For example, if the :py:attr:`regression_cols` attribute was set to the followin
         'w_vel': 'wind',
     }
 
-Where ``irr_poa``, ``temp_amb``, and ``wind`` are the ids of groups of columns in :py:attr:`column_groups`.
+Where ``irr_poa``, ``temp_amb``, and ``wind`` are the ids of groups of columns in :py:attr:`~captest.capdata.CapData.column_groups`.
 
-When agg_sensors is called with the default arguments, :py:attr:`regression_cols` is updated to the following:
+When agg_sensors is called with the default arguments, :py:attr:`~captest.capdata.CapData.regression_cols` is updated to the following:
 
 .. code-block:: Python
 
@@ -244,13 +251,13 @@ When agg_sensors is called with the default arguments, :py:attr:`regression_cols
         'w_vel': 'wind_amb_mean_agg',
     }
 
-where ``irr_poa_mean_agg``, ``temp_amb_mean_agg``, and ``wind_amb_mean_agg`` are the ids of the aggregated columns in :py:attr:`data` and :py:attr:`data_filtered` and these columns will be used when fitting the regression.
+where ``irr_poa_mean_agg``, ``temp_amb_mean_agg``, and ``wind_amb_mean_agg`` are the ids of the aggregated columns in :py:attr:`~captest.capdata.CapData.data` and :py:attr:`~captest.capdata.CapData.data_filtered` and these columns will be used when fitting the regression.
 
 Accessing Filtered and Unfiltered Data
 --------------------------------------
-The methods :py:attr:`loc` and :py:attr:`floc` can be used to access columns of data from the :py:attr:`data` and :py:attr:`data_filtered` DataFrames, respectively.
+The indexers :py:attr:`~captest.capdata.CapData.loc` and :py:attr:`~captest.capdata.CapData.floc` can be used to access columns of data from the :py:attr:`~captest.capdata.CapData.data` and :py:attr:`~captest.capdata.CapData.data_filtered` DataFrames, respectively. Like ``DataFrame.loc``, they are used with square brackets rather than called, e.g. ``cd.loc['poa']``.
 
-Any column heading of the :py:attr:`data` DataFrame, group id from :py:attr:`column_groups`, or regression term from :py:attr:`regression_cols` can be passed to :py:attr:`loc` or :py:attr:`floc`. Or, a list with any combination of these identifiers can be passed. 
+Any column heading of the :py:attr:`~captest.capdata.CapData.data` DataFrame, group id from :py:attr:`~captest.capdata.CapData.column_groups`, or regression term from :py:attr:`~captest.capdata.CapData.regression_cols` can be passed to :py:attr:`~captest.capdata.CapData.loc` or :py:attr:`~captest.capdata.CapData.floc`. Or, a list with any combination of these identifiers can be passed.
 
 
 Filtering
@@ -267,17 +274,17 @@ Filtering
 
 The :py:class:`~captest.capdata.CapData` class provides a variety of methods for filtering as described in ASTM E2848. These methods are all begin with "filter\_" and are well described in the docstrings of each method. For the complete list of filtering methods, see the :ref:`Filtering section <capdata-api-filtering>` of the CapData API reference.
 
-Running filters removes data from :py:attr:`data_filtered`. Each subsequent filtering method called will be applied to :py:attr:`data_filtered`, so the overall filtering is cumulative.
+Running a filter does not remove anything from :py:attr:`~captest.capdata.CapData.data`. Each filtering method appends a step to the :py:attr:`~captest.capdata.CapData.filters` list recording the rows it kept, and each subsequent filter is applied to the rows kept by the step before it, so the overall filtering is cumulative. :py:attr:`~captest.capdata.CapData.data_filtered` returns the rows kept by the last step.
 
-:py:meth:`~captest.capdata.CapData.reset_filter` method can be used to reset the :py:attr:`data_filtered` DataFrame to the unfiltered data.
+:py:meth:`~captest.capdata.CapData.reset_filter` clears the :py:attr:`~captest.capdata.CapData.filters` list, so :py:attr:`~captest.capdata.CapData.data_filtered` returns the unfiltered data again.
 
-Each filter that is run is recorded as a step in the :py:attr:`filters` list. :py:meth:`~captest.capdata.CapData.rerun_filters_from` re-executes part of the applied filter chain without starting over: it restores the data to the state after the step before the given index and then re-runs the remaining steps with their current settings. This is useful for adjusting one filter in the middle of a chain — edit the step's parameters (e.g. ``cd.filters[2].low = 300``) and call ``cd.rerun_filters_from(2)`` to re-apply that step and everything after it. Passing ``0`` re-runs the whole chain.
+:py:meth:`~captest.capdata.CapData.rerun_filters_from` re-executes part of the applied chain without starting over: it restores the state as of the step before the given index and then re-runs the remaining steps with their current settings. This is useful for adjusting one filter in the middle of a chain — edit the step's parameters (e.g. ``cd.filters[2].low = 300``) and call ``cd.rerun_filters_from(2)`` to re-apply that step and everything after it. Passing ``0`` re-runs the whole chain.
 
-The :py:meth:`~captest.capdata.CapData.get_summary` method will return a summary dataframe showing the number of rows in the :py:attr:`data_filtered` DataFrame before and after each filter was applied, the name of the each filter, and the arguments passed when calling each filter.
+The :py:meth:`~captest.capdata.CapData.get_summary` method returns a summary dataframe built from :py:attr:`~captest.capdata.CapData.filters`: one row per step, giving the name of the filter, the rows remaining after it, the rows it removed, and the arguments it was called with.
 
 Reporting conditions
 --------------------
-:py:meth:`~captest.capdata.CapData.rep_cond` can be used to calculate the reporting conditions. ``rep_cond`` is formula-agnostic: its right-hand-side variables are derived from :py:attr:`regression_formula` via :py:func:`~captest.util.parse_regression_formula`, so it supports any regression equation (not just the default ASTM E2848 formula). Results are stored in the :py:attr:`rc` attribute.
+:py:meth:`~captest.capdata.CapData.rep_cond` can be used to calculate the reporting conditions. ``rep_cond`` is formula-agnostic: its right-hand-side variables are derived from :py:attr:`~captest.capdata.CapData.regression_formula` via :py:func:`~captest.util.parse_regression_formula`, so it supports any regression equation (not just the default ASTM E2848 formula). Results are stored in the :py:attr:`~captest.capdata.CapData.rc` attribute.
 
 The ``func`` argument is a dict mapping each right-hand-side variable name to an aggregation function (a pandas agg name or a callable). Omitting ``func`` falls back to ``{var: 'mean' for var in rhs}``. For percentile aggregations use :py:func:`~captest.captest.perc_wrap`, e.g. ``func={'poa': perc_wrap(60), 't_amb': 'mean', 'w_vel': 'mean'}``.
 
@@ -287,7 +294,7 @@ The "Reporting Conditions and Predicted Capacities" example demonstrates the rep
 
 Fitting Regressions
 -------------------
-:py:meth:`~captest.capdata.CapData.fit_regression` is used to fit the regression equation stored in :py:attr:`regression_formula` to the filtered data. The statsmodels `regression results <https://www.statsmodels.org/stable/generated/statsmodels.regression.linear_model.RegressionResults.html#statsmodels.regression.linear_model.RegressionResults>`_ are stored in the :py:attr:`regression_results` attribute.
+:py:meth:`~captest.capdata.CapData.fit_regression` is used to fit the regression equation stored in :py:attr:`~captest.capdata.CapData.regression_formula` to the filtered data. The statsmodels `regression results <https://www.statsmodels.org/stable/generated/statsmodels.regression.linear_model.RegressionResults.html#statsmodels.regression.linear_model.RegressionResults>`_ are stored in the :py:attr:`~captest.capdata.CapData.regression_results` attribute.
 
 By default a summary showing the results of the regression is printed, similar to below:
 

--- a/docs/user_guide/dataload.rst
+++ b/docs/user_guide/dataload.rst
@@ -59,7 +59,7 @@ Except for the clear sky modelling, the above describes the default behavior of 
 
 If you are loading data from multiple files and the column headings to match across the files, then :py:func:`~captest.io.load_data` will create attempt to join the data by taking the union of the row and column indexes for all files.
 
-Internally, :py:func:`~captest.io.load_data` uses an instance of the :py:class:`~capdata.io.DataLoader` class, which is available in the :py:attr:`~captest.capdata.CapData.data_loader` attribute of the returned :py:class:`~captest.capdata.CapData` instance. 
+Internally, :py:func:`~captest.io.load_data` uses an instance of the :py:class:`~captest.io.DataLoader` class, which is available in the :py:attr:`~captest.capdata.CapData.data_loader` attribute of the returned :py:class:`~captest.capdata.CapData` instance. 
 
 .. note::
 
@@ -67,11 +67,11 @@ Internally, :py:func:`~captest.io.load_data` uses an instance of the :py:class:`
 
 .. note::
 
-    If it is necessary to modify the :py:attr:`data` DataFrame to add columns or convert units, it best to do that immediately after loading the data. Followed by calling :py:meth:`~captest.capdata.CapData.reset_filters`, which will overwrite the :py:attr:`data_filtered` DataFrame with the modified :py:attr:`data` DataFrame.
+    If it is necessary to modify the :py:attr:`data` DataFrame to add columns or convert units, it best to do that immediately after loading the data. Followed by calling :py:meth:`~captest.capdata.CapData.reset_filter`, which will overwrite the :py:attr:`data_filtered` DataFrame with the modified :py:attr:`data` DataFrame.
 
 .. note::
 
-    **Automatic year-end wrapping of simulated data.** PVsyst simulated data spans a single calendar year (Jan 1 – Dec 31), so a measured test that crosses a year boundary (e.g. mid-December to mid-January) would not include January. Versions before v0.17.0 handled this with a manual ``wrap_year`` argument on :py:meth:`~captest.capdata.CapData.filter_time`. That argument has been removed; the wrapping is now applied automatically. When a measured and a modeled :py:class:`~captest.capdata.CapData` are bound together in a :py:class:`~captest.captest.CapTest`, :py:meth:`~captest.captest.CapTest.setup` detects a measured test within 60 days of a calendar-year boundary and wraps the simulated data into a contiguous July 1 – June 30 year. This is controlled by the :py:attr:`~captest.captest.CapTest.auto_wrap_sim` parameter (default ``True``). Set ``auto_wrap_sim=False`` and re-run :py:meth:`~captest.captest.CapTest.setup` to load the simulated data without wrapping.
+    **Automatic year-end wrapping of simulated data.** PVsyst simulated data spans a single calendar year (Jan 1 – Dec 31), so a measured test that crosses a year boundary (e.g. mid-December to mid-January) would not include January. Versions before v0.17.0 handled this with a manual ``wrap_year`` argument on :py:meth:`~captest.capdata.CapData.filter_time`. That argument has been removed; the wrapping is now applied automatically. When a measured and a modeled :py:class:`~captest.capdata.CapData` are bound together in a :py:class:`~captest.CapTest`, :py:meth:`~captest.CapTest.setup` detects a measured test within 60 days of a calendar-year boundary and wraps the simulated data into a contiguous July 1 – June 30 year. This is controlled by the :py:attr:`~captest.CapTest.auto_wrap_sim` parameter (default ``True``). Set ``auto_wrap_sim=False`` and re-run :py:meth:`~captest.CapTest.setup` to load the simulated data without wrapping.
 
 .. _col-grouping:
 
@@ -176,10 +176,10 @@ The list of groups and tags can be filtered using regular expressions. The text 
 
 Residual Plots
 ~~~~~~~~~~~~~~
-:py:meth:`~captest.captest.CapTest.residual_plot` creates overlay scatter plots of
+:py:meth:`~captest.CapTest.residual_plot` creates overlay scatter plots of
 regression residuals versus each regression parameter for the measured and
 simulated :py:class:`~captest.capdata.CapData` instances bound to a
-:py:class:`~captest.captest.CapTest`. This makes it easy to visually compare how
+:py:class:`~captest.CapTest`. This makes it easy to visually compare how
 the two models differ across the range of each predictor variable. See
 :ref:`captest` for the full workflow.
 
@@ -281,7 +281,7 @@ Reporting conditions
 
 The ``func`` argument is a dict mapping each right-hand-side variable name to an aggregation function (a pandas agg name or a callable). Omitting ``func`` falls back to ``{var: 'mean' for var in rhs}``. For percentile aggregations use :py:func:`~captest.captest.perc_wrap`, e.g. ``func={'poa': perc_wrap(60), 't_amb': 'mean', 'w_vel': 'mean'}``.
 
-When the test is driven through a :py:class:`~captest.captest.CapTest`, each preset in :py:data:`~captest.captest.TEST_SETUPS` supplies its own default ``rep_conditions`` dict and :py:meth:`~captest.captest.CapTest.rep_cond` forwards it automatically. See :ref:`captest`.
+When the test is driven through a :py:class:`~captest.CapTest`, each preset in :py:data:`~captest.captest.TEST_SETUPS` supplies its own default ``rep_conditions`` dict and :py:meth:`~captest.CapTest.rep_cond` forwards it automatically. See :ref:`captest`.
 
 The "Reporting Conditions and Predicted Capacities" example demonstrates the reporting condition functionality in more detail.
 
@@ -296,7 +296,7 @@ By default a summary showing the results of the regression is printed, similar t
 
 Results
 -------
-After loading, filtering and regressing measured and simulated data in two separate instances of :py:class:`~captest.capdata.CapData`, the two instances are bound together in a :py:class:`~captest.captest.CapTest` and compared using :py:meth:`~captest.captest.CapTest.captest_results`, which returns a :py:class:`~captest.captest.CapTestResults` object holding the capacity ratio, pass/fail result, and the values behind them. :py:meth:`~captest.captest.CapTest.captest_results_check_pvalues` provides a styled summary of the predicted power using the regression coefficients of each :py:class:`~captest.capdata.CapData` instance and the reporting conditions. See :ref:`captest` for construction and the full workflow.
+After loading, filtering and regressing measured and simulated data in two separate instances of :py:class:`~captest.capdata.CapData`, the two instances are bound together in a :py:class:`~captest.CapTest` and compared using :py:meth:`~captest.CapTest.captest_results`, which returns a :py:class:`~captest.captest.CapTestResults` object holding the capacity ratio, pass/fail result, and the values behind them. :py:meth:`~captest.CapTest.captest_results_check_pvalues` provides a styled summary of the predicted power using the regression coefficients of each :py:class:`~captest.capdata.CapData` instance and the reporting conditions. See :ref:`captest` for construction and the full workflow.
 
 The results method will check and warn for potential issues:
 

--- a/docs/user_guide/reporting_conditions.rst
+++ b/docs/user_guide/reporting_conditions.rst
@@ -8,16 +8,16 @@ capacity at a single, agreed-upon set of **reporting conditions** (RCs) — the
 representative irradiance, temperature, and wind speed the plant is rated at.
 Because both regressions are evaluated at the *same* point, pvcaptest models the
 reporting conditions as one value owned by the test:
-:py:attr:`~captest.captest.CapTest.rc`.
+:py:attr:`~captest.CapTest.rc`.
 
 This page explains how the single test RC is established, overridden, tracked,
 used in filtering and results, and persisted across a yaml round-trip. It
-assumes a :py:class:`~captest.captest.CapTest` instance ``tst`` has been created
+assumes a :py:class:`~captest.CapTest` instance ``tst`` has been created
 and set up as described in :ref:`captest`.
 
 The single test reporting conditions
 ------------------------------------
-:py:attr:`~captest.captest.CapTest.rc` is a one-row
+:py:attr:`~captest.CapTest.rc` is a one-row
 :class:`pandas.DataFrame` (or ``None`` before any have been established) holding
 one value per regression variable:
 
@@ -27,7 +27,7 @@ one value per regression variable:
          poa  t_amb  w_vel
     0  805.1   24.7    2.1
 
-Its provenance is tracked by :py:attr:`~captest.captest.CapTest.rc_source`,
+Its provenance is tracked by :py:attr:`~captest.CapTest.rc_source`,
 which is one of ``'meas'``, ``'sim'``, or ``'manual'`` — recording whether the
 conditions were computed from the measured data, computed from the modeled data,
 or supplied directly.
@@ -41,7 +41,7 @@ or supplied directly.
 
 Computing reporting conditions
 ------------------------------
-:py:meth:`~captest.captest.CapTest.rep_cond` computes the reporting conditions
+:py:meth:`~captest.CapTest.rep_cond` computes the reporting conditions
 from one dataset using the selected test setup's default aggregations. For the
 standard E2848 setup, POA uses the 60th percentile of the filtered POA while
 ambient temperature and wind speed use the mean, per ASTM E2939.
@@ -52,8 +52,8 @@ ambient temperature and wind speed use the mean, per ASTM E2939.
     tst.rep_cond(which='sim')   # compute from modeled data  (rc_source -> 'sim')
 
 Whichever side it is computed on becomes the single test RC: the call updates
-:py:attr:`~captest.captest.CapTest.rc` and sets
-:py:attr:`~captest.captest.CapTest.rc_source` accordingly. Calling
+:py:attr:`~captest.CapTest.rc` and sets
+:py:attr:`~captest.CapTest.rc_source` accordingly. Calling
 ``tst.meas.rep_cond()`` (or ``tst.sim.rep_cond()``) directly has the same effect —
 any reporting-conditions calculation on a test member flows up to ``tst.rc``
 (last writer wins). With no ``which`` argument, ``tst.rep_cond()`` defaults to the
@@ -71,15 +71,15 @@ reporting conditions and no longer matches. When such steps exist, the same
 single ``UserWarning`` names them (e.g. ``meas.filters[5] (Irradiance)``) so
 they can be re-run — for example with
 :py:meth:`~captest.capdata.CapData.rerun_filters_from` — against the new conditions.
-:py:meth:`~captest.captest.CapTest.run_test` re-runs both pipelines itself, so
+:py:meth:`~captest.CapTest.run_test` re-runs both pipelines itself, so
 it suppresses this notice for the steps it is about to replay.
 
 Anchoring irradiance filters on the reporting irradiance
 --------------------------------------------------------
 After the reporting conditions are computed it is common to apply a second,
 narrower irradiance filter around the reporting irradiance.
-:py:attr:`~captest.captest.CapTest.rep_irr_filter_low` and
-:py:attr:`~captest.captest.CapTest.rep_irr_filter_high` provide the fractional
+:py:attr:`~captest.CapTest.rep_irr_filter_low` and
+:py:attr:`~captest.CapTest.rep_irr_filter_high` provide the fractional
 bounds (``0.8`` and ``1.2`` with the default ``rep_irr_filter=0.2``), so the
 same window is applied consistently to the measured and modeled data:
 
@@ -109,7 +109,7 @@ Setting reporting conditions manually
 -------------------------------------
 Sometimes the reporting conditions should be supplied directly rather than
 computed — for a sensitivity study, or to reproduce a reviewing party's stated
-values. Assigning to :py:attr:`~captest.captest.CapTest.rc` is the single public
+values. Assigning to :py:attr:`~captest.CapTest.rc` is the single public
 way to do this; it records ``rc_source='manual'``:
 
 .. code-block:: Python
@@ -122,7 +122,7 @@ The value must provide a number for every right-hand-side variable of the
 ``I(poa * t_amb)`` are unwrapped to their component variables. Extra columns are
 preserved. The assignment validates the input and raises:
 
-- ``RuntimeError`` if :py:meth:`~captest.captest.CapTest.setup` has not run (the
+- ``RuntimeError`` if :py:meth:`~captest.CapTest.setup` has not run (the
   regression formula is unknown);
 - ``ValueError`` if the measured and modeled formulas differ, if the value
   resolves to more than one row, or if a required regression variable is
@@ -130,15 +130,15 @@ preserved. The assignment validates the input and raises:
 - ``TypeError`` if the value is not a DataFrame, Series, or dict.
 
 A manual RC is treated as the authoritative value: it is not overwritten when
-:py:meth:`~captest.captest.CapTest.run_test` replays a pipeline containing a
+:py:meth:`~captest.CapTest.run_test` replays a pipeline containing a
 ``RepCond`` step (the replayed step computes a side-local RC only), and a
 later ``rep_cond`` call that would change the source back to a computed value
 emits the source-change warning.
 
 Reporting conditions and results
 --------------------------------
-:py:meth:`~captest.captest.CapTest.captest_results` (and
-:py:meth:`~captest.captest.CapTest.captest_results_check_pvalues`) predict both
+:py:meth:`~captest.CapTest.captest_results` (and
+:py:meth:`~captest.CapTest.captest_results_check_pvalues`) predict both
 the measured and modeled regressions at the single test RC ``tst.rc``. The
 returned :py:class:`~captest.captest.CapTestResults` object carries the
 reporting conditions the predictions were made at (``results.rc``) and their
@@ -149,15 +149,15 @@ reporting conditions have been established, ``captest_results`` raises a
 Saving and restoring reporting conditions
 -----------------------------------------
 The single test RC round-trips through
-:py:meth:`~captest.captest.CapTest.to_yaml` /
-:py:meth:`~captest.captest.CapTest.from_yaml` (see :ref:`saving_reproducing`):
+:py:meth:`~captest.CapTest.to_yaml` /
+:py:meth:`~captest.CapTest.from_yaml` (see :ref:`saving_reproducing`):
 
 - **Computed** reporting conditions are not value-serialized. The ``RepCond``
   step is saved in the ``rc_source`` side's filter pipeline, and the
   conditions are recomputed when that pipeline runs. Because ``from_yaml``
   stores the pipelines as pending rather than applying them, ``tst.rc`` is
   ``None`` after the load; running the test
-  (:py:meth:`~captest.captest.CapTest.run_test`, or a manual
+  (:py:meth:`~captest.CapTest.run_test`, or a manual
   :py:meth:`~captest.capdata.CapData.run_pipeline`) replays the ``RepCond``
   step, so the restored RC reflects the same filtered data.
 - **Manual** reporting conditions carry their values in a
@@ -189,9 +189,9 @@ comes from the selected test setup and can be customized per call (e.g.
 
 See also
 --------
-- :py:attr:`~captest.captest.CapTest.rc`,
-  :py:attr:`~captest.captest.CapTest.rc_source`, and
-  :py:meth:`~captest.captest.CapTest.rep_cond` in the
+- :py:attr:`~captest.CapTest.rc`,
+  :py:attr:`~captest.CapTest.rc_source`, and
+  :py:meth:`~captest.CapTest.rep_cond` in the
   :doc:`CapTest API reference <../source/api_reference/captest>`.
 - :py:meth:`~captest.capdata.CapData.rep_cond` and
   :py:attr:`~captest.capdata.CapData.rep_irr` in the

--- a/docs/user_guide/saving_reproducing.rst
+++ b/docs/user_guide/saving_reproducing.rst
@@ -3,7 +3,7 @@
 ============================
 Saving and Reproducing Tests
 ============================
-A :py:class:`~captest.captest.CapTest` can write its full configuration — the
+A :py:class:`~captest.CapTest` can write its full configuration — the
 test settings and the filter pipelines applied to the measured and modeled
 data — to a single yaml file, and reload that file to reproduce the test
 exactly. This makes a capacity test portable: it can be archived, shared,
@@ -14,7 +14,7 @@ described in :ref:`captest`.
 
 Saving a test setup
 -------------------
-:py:meth:`~captest.captest.CapTest.to_yaml` writes the main test settings back
+:py:meth:`~captest.CapTest.to_yaml` writes the main test settings back
 to a yaml file. This can be useful after adjusting a setup in a notebook and
 wanting to save the settings for a future run.
 
@@ -28,9 +28,9 @@ test settings, data paths, and the filter pipelines applied to the measured and
 modeled data (see :ref:`reproducing-a-test` below). It does not write the
 measured data, modeled data, fitted regression results, or plots.
 
-:py:meth:`~captest.captest.CapTest.to_mapping` returns the same configuration
+:py:meth:`~captest.CapTest.to_mapping` returns the same configuration
 as a plain dictionary instead of writing a file. It is the symmetric inverse
-of :py:meth:`~captest.captest.CapTest.from_mapping` and is useful when the
+of :py:meth:`~captest.CapTest.from_mapping` and is useful when the
 configuration should be inspected, stored, or transformed programmatically
 rather than written straight to yaml.
 
@@ -38,7 +38,7 @@ rather than written straight to yaml.
 
 Reproducing a complete test from a config file
 ----------------------------------------------
-A :py:meth:`~captest.captest.CapTest.to_yaml` config file captures more than the
+A :py:meth:`~captest.CapTest.to_yaml` config file captures more than the
 test settings — it also records the **filter pipeline applied to each dataset**.
 Every filter step run on ``tst.meas`` and ``tst.sim``, including the reporting-
 conditions calculation, is serialized under the ``meas_filters`` and
@@ -92,9 +92,9 @@ measured-side pipeline written by the bifacial example notebook:
         col_name: null
         custom_name: null
 
-Loading the file with :py:meth:`~captest.captest.CapTest.from_yaml` loads the
+Loading the file with :py:meth:`~captest.CapTest.from_yaml` loads the
 measured and modeled data and runs
-:py:meth:`~captest.captest.CapTest.setup` to assign the regression and
+:py:meth:`~captest.CapTest.setup` to assign the regression and
 calculated columns. The recorded filter pipelines are **not** applied at load
 — they are stored on the instance as ``tst.meas_filters_pending`` and
 ``tst.sim_filters_pending``, so a freshly loaded test holds unfiltered data,
@@ -125,7 +125,7 @@ one side at a time (``tst.run_test(side='meas')``) or manually with
 See :ref:`running-with-run-test` for the full description of ``run_test`` —
 including how it chooses between an applied chain and a pending pipeline, and
 re-running a single side after re-loading its data with
-:py:meth:`~captest.captest.CapTest.reload` — and :ref:`captest-typical-workflow`
+:py:meth:`~captest.CapTest.reload` — and :ref:`captest-typical-workflow`
 for the step-by-step states of a loaded test.
 
 .. note::

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -755,11 +755,12 @@ class CapData(param.Parameterized):
     ----------
     name : str
         Name for the CapData object.
-    data : pandas dataframe
-        Used to store measured or simulated data imported from csv.
-    data_filtered : pandas dataframe
-        Holds filtered data.  Filtering methods act on and write to this
-        attribute.
+
+    Attributes
+    ----------
+    data : pandas.DataFrame
+        The loaded measured or simulated data. This is the only frame that is
+        stored; filtering never modifies it.
     column_groups : dictionary
         Assigned by the `group_columns` method, which attempts to infer the
         type of measurement recorded in each column of the dataframe stored in
@@ -783,6 +784,21 @@ class CapData(param.Parameterized):
         String representing error band.  Ex. '+ 3', '+/- 3', '- 5'
         There must be space between the sign and number. Number is
         interpreted as a percent.  For example, 5 percent is 5 not 0.05.
+    loc : LocIndexer
+        Indexer returning columns of `data` by column heading, `column_groups`
+        group id, or `regression_cols` regression term. Used with ``[]``, e.g.
+        ``cd.loc['poa']``.
+    floc : FilteredLocIndexer
+        The same indexer over `data_filtered` rather than `data`.
+    data_loader : DataLoader
+        The `io.DataLoader` instance used to load the data, when the object was
+        built by `io.load_data` or `io.load_pvsyst`.
+
+    See Also
+    --------
+    data_filtered : Derived, read-only view of `data` after the applied filters.
+    filters : The applied filter chain that `data_filtered` is derived from.
+    prep : The applied data-preparation steps.
     """
 
     filters = param.List(
@@ -1360,12 +1376,15 @@ class CapData(param.Parameterized):
 
     def reset_filter(self):
         """
-        Set `data_filtered` to `data` and reset filtering summary.
+        Clear the applied filter chain.
 
-        Parameters
-        ----------
-        data : str
-            'sim' or 'das' determines if filter is on sim or das data.
+        Empties the `filters` list, so `data_filtered` returns all rows of
+        `data` again and the filtering summaries report no steps. `data` is
+        untouched.
+
+        Returns
+        -------
+        None
         """
         self.filters = []
 
@@ -1624,14 +1643,17 @@ class CapData(param.Parameterized):
         Returns
         -------
         None
-            Acts in place on the data, data_filtered, and regression_cols attributes.
+            Acts in place on the `data` and `regression_cols` attributes.
 
         Notes
         -----
         This method is intended to be used before any filtering methods are applied.
-        Filtering steps applied when this method is used will be lost.
+        It clears the `filters` list, so any filtering steps already applied are
+        lost.
 
-        This method modifies the `data`, `data_filtered`, and `regression_cols` attributes.
+        This method modifies the `data` and `regression_cols` attributes. The
+        aggregated columns appear in `data_filtered` automatically, since that is
+        derived from `data`.
         """
         if self.filters:
             warnings.warn(

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -1384,16 +1384,11 @@ class CapTest(param.Parameterized):
         The fully-resolved ``TEST_SETUPS`` entry after ``setup()`` has run.
         Plain instance attribute (not a ``param.*``) so ``setup()`` can be
         called multiple times.
-    rep_irr_filter_low : float
-        Read-only. Lower irradiance fraction bound derived from
-        ``rep_irr_filter``: ``1 - rep_irr_filter``. For example, when
-        ``rep_irr_filter=0.2`` this is ``0.8``. Pass as ``low`` to
-        ``CapData.filter_irr`` together with a ``ref_val``.
-    rep_irr_filter_high : float
-        Read-only. Upper irradiance fraction bound derived from
-        ``rep_irr_filter``: ``1 + rep_irr_filter``. For example, when
-        ``rep_irr_filter=0.2`` this is ``1.2``. Pass as ``high`` to
-        ``CapData.filter_irr`` together with a ``ref_val``.
+
+    See Also
+    --------
+    rep_irr_filter_low : Lower reporting-irradiance fraction bound.
+    rep_irr_filter_high : Upper reporting-irradiance fraction bound.
 
     Notes
     -----
@@ -3422,7 +3417,8 @@ class CapTest(param.Parameterized):
     def rep_irr_filter_low(self):
         """Lower irradiance fraction bound derived from ``rep_irr_filter``.
 
-        Equal to ``1 - rep_irr_filter``. Updates automatically whenever
+        Read-only. Equal to ``1 - rep_irr_filter``; for example, when
+        ``rep_irr_filter=0.2`` this is ``0.8``. Updates automatically whenever
         ``rep_irr_filter`` is reassigned. Pass as the ``low`` argument to
         ``CapData.filter_irr`` with a ``ref_val`` to filter within the
         reporting-irradiance band.
@@ -3433,7 +3429,8 @@ class CapTest(param.Parameterized):
     def rep_irr_filter_high(self):
         """Upper irradiance fraction bound derived from ``rep_irr_filter``.
 
-        Equal to ``1 + rep_irr_filter``. Updates automatically whenever
+        Read-only. Equal to ``1 + rep_irr_filter``; for example, when
+        ``rep_irr_filter=0.2`` this is ``1.2``. Updates automatically whenever
         ``rep_irr_filter`` is reassigned. Pass as the ``high`` argument to
         ``CapData.filter_irr`` with a ``ref_val`` to filter within the
         reporting-irradiance band.

--- a/src/captest/captest.py
+++ b/src/captest/captest.py
@@ -264,9 +264,12 @@ TEST_SETUPS = {
             "Rear shading and IAM losses are handled in the modeled (PVsyst) "
             "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
             "BackShd, while the measured rear sensor (irr_rpoa) is used "
-            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
-            "variant that instead applies rear shading on the measured side, "
-            "see 'bifi_e2848_etotal_rear_shade_meas'. Total irradiance is "
+            "as-measured. Leave CapTest's 'rear_shade' at its default of 0 "
+            "with this setup: the rear shading is already carried by the "
+            "modeled rear irradiance, and a non-zero 'rear_shade' is still "
+            "applied to the measured e_total, double-counting the loss. To "
+            "apply rear shading on the measured side instead, use "
+            "'bifi_e2848_etotal_rear_shade_meas'. Total irradiance is "
             "E_Total = E_POA + E_Rear * bifaciality, following the NREL "
             "modified bifacial approach."
         ),
@@ -316,9 +319,10 @@ TEST_SETUPS = {
             "irradiance maps directly to PVsyst's unshaded global rear "
             "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
             "to the measured side through the e_total 'rear_shade' factor "
-            "(propagated by CapTest to the measured CapData only). Total "
-            "irradiance is E_Total = E_POA + E_Rear * bifaciality * "
-            "(1 - rear_shade)."
+            "(propagated by CapTest to the measured CapData only). This is "
+            "the variant to select when 'rear_shade' is set to a non-zero "
+            "value. Total irradiance is E_Total = E_POA + E_Rear * "
+            "bifaciality * (1 - rear_shade)."
         ),
         "reg_cols_meas": {
             "power": ("real_pwr_mtr", "sum"),
@@ -467,9 +471,12 @@ TEST_SETUPS = {
             "Rear shading and IAM losses are handled in the modeled (PVsyst) "
             "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
             "BackShd, while the measured rear sensor (irr_rpoa) is used "
-            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
-            "variant that instead applies rear shading on the measured side, "
-            "see 'bifi_power_tc_etotal_rear_shade_meas'. Total irradiance is "
+            "as-measured. Leave CapTest's 'rear_shade' at its default of 0 "
+            "with this setup: the rear shading is already carried by the "
+            "modeled rear irradiance, and a non-zero 'rear_shade' is still "
+            "applied to the measured e_total, double-counting the loss. To "
+            "apply rear shading on the measured side instead, use "
+            "'bifi_power_tc_etotal_rear_shade_meas'. Total irradiance is "
             "E_Total = E_POA + E_Rear * bifaciality, following the NREL "
             "modified bifacial approach."
         ),
@@ -536,9 +543,10 @@ TEST_SETUPS = {
             "irradiance maps directly to PVsyst's unshaded global rear "
             "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
             "to the measured side through the e_total 'rear_shade' factor "
-            "(propagated by CapTest to the measured CapData only). Total "
-            "irradiance is E_Total = E_POA + E_Rear * bifaciality * "
-            "(1 - rear_shade)."
+            "(propagated by CapTest to the measured CapData only). This is "
+            "the variant to select when 'rear_shade' is set to a non-zero "
+            "value. Total irradiance is E_Total = E_POA + E_Rear * "
+            "bifaciality * (1 - rear_shade)."
         ),
         "reg_cols_meas": {
             "power": (
@@ -678,9 +686,12 @@ TEST_SETUPS = {
             "Rear shading and IAM losses are handled in the modeled (PVsyst) "
             "data: the modeled rear irradiance is rpoa_pvsyst = GlobBak + "
             "BackShd, while the measured rear sensor (irr_rpoa) is used "
-            "as-measured (no rear_shade factor, i.e. rear_shade = 0). For the "
-            "variant that instead applies rear shading on the measured side, "
-            "see 'bifi_e2848_etotal_rear_shade_meas_spec_corrected'. Total irradiance is "
+            "as-measured. Leave CapTest's 'rear_shade' at its default of 0 "
+            "with this setup: the rear shading is already carried by the "
+            "modeled rear irradiance, and a non-zero 'rear_shade' is still "
+            "applied to the measured e_total, double-counting the loss. To "
+            "apply rear shading on the measured side instead, use "
+            "'bifi_e2848_etotal_rear_shade_meas_spec_corrected'. Total irradiance is "
             "E_Total = E_POA + E_Rear * bifaciality with the spectral correction "
             "applied to E_POA. "
         ),
@@ -781,7 +792,8 @@ TEST_SETUPS = {
             "The modeled rear irradiance maps directly to PVsyst's unshaded global rear "
             "('GlobBak') instead of rpoa_pvsyst, and rear shading is applied "
             "to the measured side through the e_total 'rear_shade' factor "
-            "(propagated by CapTest to the measured CapData only). Total "
+            "(propagated by CapTest to the measured CapData only). This is the "
+            "variant to select when 'rear_shade' is set to a non-zero value. Total "
             "irradiance is E_Total = E_POA + E_Rear * bifaciality * (1 - rear_shade)."
         ),
         "reg_cols_meas": {
@@ -1346,6 +1358,11 @@ class CapTest(param.Parameterized):
         measured CapData instance only (see ``_downstream_attrs_meas_only``).
         Applied by ``calcparams.e_total`` on the measured side; the modeled
         side handles rear shading through its own ``reg_cols_sim`` definition.
+        Belongs with the ``*_rear_shade_meas`` presets. The
+        ``*_rear_shade_sim`` presets already carry rear shading in the modeled
+        rear irradiance (``rpoa_pvsyst``) and expect the default ``0``; since
+        no preset overrides the value, a non-zero ``rear_shade`` shades the
+        measured side there too and double-counts the loss.
     meas_loader, sim_loader : callable or None
         Programmatic-only data-loader callables. Default resolution when
         ``None``: ``captest.io.load_data`` and ``captest.io.load_pvsyst``
@@ -1529,7 +1546,12 @@ class CapTest(param.Parameterized):
         doc=(
             "Fraction of rear irradiance lost due to shading, passed to "
             "calcparams.e_total. Propagated onto the measured CapData "
-            "instance only (see _downstream_attrs_meas_only)."
+            "instance only (see _downstream_attrs_meas_only). Set a non-zero "
+            "value only with the '*_rear_shade_meas' presets; the "
+            "'*_rear_shade_sim' presets carry rear shading in the modeled rear "
+            "irradiance and expect the default 0. No preset overrides this "
+            "value, so a non-zero setting reaches the measured e_total "
+            "whichever preset is selected."
         ),
     )
     power_temp_coeff = param.Number(


### PR DESCRIPTION
## Summary

Documentation-only pass over the `CapTest` and `CapData` user guides ahead of the v0.17.0 release. It addresses two kinds of problem: prose that still described behavior the code no longer has, and cross-references that silently rendered as plain text instead of links.

The `src/captest/` changes are **docstrings only** — no behavior change. Full suite passes (1224 tests).

## Changes

**Config documentation (`user_guide/captest.rst`)**

- Show `meas_load_kwargs` in the "From yaml" examples, covering `group_columns` (loading column groups from a file) and `summary` / `verbose` (quieting the loader). Adds a "Loader options" section with the mechanics: `summary` defaults `True` and only applies to a directory path, `verbose` forces `summary` on, and `summary` reaches `DataLoader.load` through `load_data`'s `**kwargs`.
- Warn that values inside `meas_load_kwargs` / `sim_load_kwargs` are **not** resolved relative to the yaml file, unlike `meas_path` / `sim_path`.
- Add a **Test settings reference** covering every key `to_yaml` writes, grouped by what each does: regression setup and data, the two settings that feed the reported result (`ac_nameplate`, `test_tolerance`), the ten calculation scalars propagated to both `CapData` objects at `setup()`, and the nine test-requirement values that nothing in pvcaptest reads — those are carried for the user to reference when filtering. Several of these (`clipping_irr`, `hrs_req`, `irrad_stability`, `inv_ac_nameplate`, …) had no explanation anywhere outside the autosummary attribute list.

**`rear_shade` guidance (`TEST_SETUPS` descriptions + both guides)**

The `*_rear_shade_sim` descriptions read "the measured rear sensor is used as-measured (no rear_shade factor, i.e. `rear_shade = 0`)", which presents that as a property of the preset. It is only the param default: `reg_cols_meas` is identical between the `_sim` and `_meas` variants — they differ solely in the modeled rear mapping — and `CapData.custom_param` auto-injects `rear_shade` from the propagated attribute either way. A non-zero `rear_shade` paired with a `_sim` preset therefore shades the measured rear on top of the shading already carried by `rpoa_pvsyst`, double-counting the loss and biasing the capacity ratio.

Confirmed against the bifacial example data: measured `e_total` is identical across the two variants at a given `rear_shade`, and changes with it under both. Reworded so the suffix means what it says and `rear_shade` is tied to the `_meas` variants, with a warning in the user guide and API reference.

**`data_filtered` model (`user_guide/dataload.rst` + `CapData` docstring)**

The guide still described the pre-v0.16 design in which `data_filtered` was a second stored DataFrame that filtering methods wrote to. Corrected the statements that `CapData` "is a wrapper around two pandas DataFrames", that filters "remove data from `data_filtered`", that `reset_filter` "overwrites `data_filtered`", and that `agg_sensors` adds columns to both frames. The root was the `CapData` class docstring, which listed instance attributes under `Parameters` and said filtering methods "act on and write to" `data_filtered`; split into `Parameters` / `Attributes` and corrected. Also surfaced that `agg_sensors` clears the `filters` list, previously documented only in its docstring Notes, and rewrote `reset_filter`'s docstring, which documented a `data` parameter the method does not accept.

**Cross-references**

The `api_reference` restructure registers members under `currentmodule:: captest` as `captest.CapTest.<member>`, but the prose kept writing `captest.captest.CapTest.<member>` from the old `source/captest.rst` automodule tree (since removed). Sphinx does not warn on unresolved python references unless nitpicky mode is on, so **107 references across eight files rendered as plain literal text** — every `CapTest` reference in the user guide was dead, while neighbouring `captest.io` / `captest.capdata` references worked.

- Rewrote those to `captest.CapTest.*` (`CapTestResults` is genuinely registered at `captest.captest.CapTestResults` and is left alone).
- Added the missing anchors: attributes referenced from prose had no target at all, so renaming alone would have left them dead. `CapTest.rc_source` / `rear_shade` / `auto_wrap_sim` via autosummary; the `CapData` instance attributes (`data`, `column_groups`, `loc`, `floc`, …) via the corrected class-docstring `Attributes` section, which napoleon renders as `.. attribute::` directives.
- Fixed references naming things that do not exist: `CapData.reset_filters` → `reset_filter`, `capdata.io.DataLoader` → `captest.io.DataLoader`.
- Documented three public callables referenced from prose but absent from the API reference: `CapData.create_column_group_attributes`, `plotting.find_default_groups`, `plotting.parse_combine`.
- Converted `:py:mod:` references that never resolved to the `:doc:` links used elsewhere.
- Resolved the duplicate `rep_irr_filter_low` / `_high` object descriptions (documented both in the class docstring and by their autosummary stubs).

## Testing

- `just lint`, `just fmt`, `just test` — 1224 passed.
- `just docs` builds clean. Verified by parsing the built HTML rather than trusting the build, since Sphinx is silent on unresolved python refs by default: unlinked python references on the prose pages drop from **84 to 4**, and clean-build warnings from **97 to 91** with no new ones. A temporary `nitpicky = True` build was used to enumerate the breakages, then reverted — it is too noisy to keep on (176 hits on `default` alone from docstring type annotations).
- The remaining 4 unlinked references are external (`pandas.DataFrame`, `pandas.Series`, `pathlib.Path`, `UserWarning`) and would need `intersphinx`; left as-is deliberately.

## Notes

- No behavior change — the only `src/` edits are docstrings.
- The `rear_shade` double-count is documented, not closed. If you would rather close it, the `_sim` presets could pin `rear_shade: 0` in their `reg_cols_meas` `e_total` kwargs (explicit kwargs win over injection in `custom_param`), or `setup()` could warn when `rear_shade != 0` with a `_sim` preset. Either is a behavior change and wants its own PR and tests.
- `docs/examples/captest_class_bifi.ipynb` uses `ts` for the `CapTest` instance where the project convention is `tst`. Left alone — notebooks need a kernel run.
