### PR TITLE
fix: carry site and tolerance through CapData.copy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- `CapData.copy()` now carries over the `site` and `tolerance` attributes,
+which it previously dropped. Copies are the basis of the load-once,
+copy-per-run pattern, and a dropped `site` made `filter_backtracking` (and the
+solar-position `calcparams` helpers) silently degrade to a no-op on the copy,
+while a dropped `tolerance` broke `predict_capacities`. A copy now always
+exposes `site`, set to `None` when the source has none.
 
 [0.17.0]: https://github.com/pvcaptest/pvcaptest/compare/v0.16.0...v0.17.0
 ## [0.17.0] - 2026-07-30

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -793,6 +793,11 @@ class CapData(param.Parameterized):
     data_loader : DataLoader
         The `io.DataLoader` instance used to load the data, when the object was
         built by `io.load_data` or `io.load_pvsyst`.
+    site : dict or None
+        Site location (`'loc'`) and system (`'sys'`) definition, set by
+        `io.load_data` when its `site` argument is given. Used by the
+        clear-sky modeling, `filter_backtracking`, and the solar-position
+        `calcparams` helpers. `None` when no site information was supplied.
 
     See Also
     --------
@@ -934,6 +939,12 @@ class CapData(param.Parameterized):
         cd_c.rc = copy.copy(self.rc)
         cd_c.regression_results = copy.deepcopy(self.regression_results)
         cd_c.regression_formula = copy.copy(self.regression_formula)
+        cd_c.tolerance = copy.copy(self.tolerance)
+        # `site` is set by `io.load_data`, not `__init__`, so it may be absent;
+        # the copy always carries the attribute (None when unset) so consumers
+        # get one shape. Deep-copied because the `loc`/`sys` sub-dicts are
+        # mutated in place by `CapTest._propagate_sim_site`.
+        cd_c.site = copy.deepcopy(getattr(self, "site", None))
         cd_c.pre_agg_cols = copy.copy(self.pre_agg_cols)
         cd_c.pre_agg_trans = copy.deepcopy(self.pre_agg_trans)
         cd_c.pre_agg_reg_trans = copy.deepcopy(self.pre_agg_reg_trans)

--- a/tests/test_CapData.py
+++ b/tests/test_CapData.py
@@ -1133,6 +1133,146 @@ class TestCapDataCopy:
         assert col_to_drop not in pvsyst_copy.column_groups["pvsyt_losses--"]
         assert pvsyst.column_groups["pvsyt_losses--"] == original_group
 
+    def test_copy_carries_site(self, meas_cd_spec_corrected):
+        """`site` survives `copy()` and is deep-copied.
+
+        Consumers that copy a CapData before filtering (e.g. a sweep runner
+        loading once and copying per parameter combination) previously lost
+        `site`, which makes `filter_backtracking` and the solar-position
+        `calcparams` helpers silently degrade.
+        """
+        cd = meas_cd_spec_corrected
+        cd_copy = cd.copy()
+        assert cd_copy.site == cd.site
+        assert cd_copy.site is not cd.site
+        assert cd_copy.site["loc"] is not cd.site["loc"]
+        cd_copy.site["loc"]["tz"] = "Etc/GMT+6"
+        cd_copy.site["sys"]["surface_tilt"] = 35
+        assert cd.site["loc"]["tz"] == "America/Chicago"
+        assert cd.site["sys"]["surface_tilt"] == 20
+
+    def test_copy_site_is_none_when_source_has_no_site(self, pvsyst):
+        """A copy always exposes `site`, as None when the source had none."""
+        assert not hasattr(pvsyst, "site")
+        assert pvsyst.copy().site is None
+
+    def test_copy_carries_tolerance(self, pvsyst):
+        pvsyst.tolerance = "+/- 4"
+        assert pvsyst.copy().tolerance == "+/- 4"
+
+
+def _values_equal(copied, expected):
+    """Compare two attribute values, handling pandas objects."""
+    if isinstance(expected, (pd.DataFrame, pd.Series, pd.Index)):
+        return type(copied) is type(expected) and copied.equals(expected)
+    return copied == expected
+
+
+def _steps_equal(copied, expected):
+    """Compare two step chains structurally; step objects have no `__eq__`."""
+    return [step.to_config() for step in copied] == [
+        step.to_config() for step in expected
+    ]
+
+
+class TestCapDataCopyCompleteness:
+    """`copy()` must carry over every attribute a CapData holds.
+
+    The covered set is derived from the live object (`vars()` plus the
+    class-level params) rather than hard-coded, so adding an attribute to
+    `CapData` fails this test until it is either given a sentinel here and
+    copied, or listed in `NOT_COPIED` with a reason.
+    """
+
+    # Attributes that `copy()` deliberately does not carry over.
+    NOT_COPIED = {
+        "_captest": "back-reference to the owning CapTest; a copy is standalone",
+        "_param__private": "param internals; the copy builds its own",
+        "loc": "indexer bound to the instance; __init__ rebinds it to the copy",
+        "floc": "indexer bound to the instance; __init__ rebinds it to the copy",
+        "name": "carried through the `CapData(self.name)` constructor call",
+        "data_loader": (
+            "holds every source DataFrame in `loaded_files`; deep-copying it "
+            "would multiply the memory cost of each copy"
+        ),
+    }
+
+    # `site` is set by `io.load_data`, not `__init__`, so it never shows up in
+    # `vars()` of a bare CapData; it is a copyable attribute all the same.
+    NOT_IN_VARS = {"site"}
+
+    @staticmethod
+    def sentinels():
+        """Non-default value and comparator for every copyable attribute."""
+        return {
+            "data": (
+                pd.DataFrame(
+                    {"poa": [500.0, 750.0]},
+                    index=pd.date_range("1/1/2021", freq="h", periods=2),
+                ),
+                _values_equal,
+            ),
+            "column_groups": ({"irr_poa_": ["poa"]}, _values_equal),
+            "regression_cols": ({"poa": "irr_poa_"}, _values_equal),
+            "rc": (pd.DataFrame({"poa": [800.0]}), _values_equal),
+            "regression_results": ("fitted-model-sentinel", _values_equal),
+            "regression_formula": ("power ~ poa - 1", _values_equal),
+            "tolerance": ("+/- 4", _values_equal),
+            "site": (
+                {"loc": {"latitude": 35.0, "tz": "Etc/GMT+7"}, "sys": {"gcr": 0.4}},
+                _values_equal,
+            ),
+            "pre_agg_cols": (pd.Index(["poa"]), _values_equal),
+            "pre_agg_trans": ({"irr_poa_": ["poa"]}, _values_equal),
+            "pre_agg_reg_trans": ({"poa": "irr_poa_"}, _values_equal),
+            "filters": ([filters.Irradiance(low=200, high=800)], _steps_equal),
+            "prep": ([prep.Scale(columns=["poa"], factor=2.0)], _steps_equal),
+        }
+
+    def test_every_attribute_is_covered_by_this_test(self):
+        """Guard the guard: the sentinel set must match the live attributes."""
+        source = pvc.CapData("source")
+        tracked = (
+            set(vars(source)) | set(source.param) | self.NOT_IN_VARS
+        ) - self.NOT_COPIED.keys()
+        sentinels = set(self.sentinels())
+        assert tracked == sentinels, (
+            "CapData's attributes and this test's sentinels have diverged: "
+            f"uncovered={sorted(tracked - sentinels)}, "
+            f"stale={sorted(sentinels - tracked)}. Add a sentinel value here "
+            "and make sure CapData.copy() carries the attribute, or list it in "
+            "NOT_COPIED with the reason it is dropped."
+        )
+
+    def test_copy_carries_every_attribute(self):
+        source = pvc.CapData("source")
+        sentinels = self.sentinels()
+        for attr, (value, _) in sentinels.items():
+            setattr(source, attr, value)
+
+        cd_copy = source.copy()
+
+        default = pvc.CapData("default")
+        for attr, (value, equal) in sentinels.items():
+            copied = getattr(cd_copy, attr)
+            assert equal(copied, value), (
+                f"CapData.copy() did not carry over `{attr}`; the copy holds "
+                f"{copied!r} rather than {value!r}."
+            )
+            # The sentinel has to differ from the default, or the assert above
+            # would pass on an attribute copy() never touched.
+            assert not equal(getattr(default, attr, None), value), (
+                f"The sentinel for `{attr}` equals a fresh CapData's default, "
+                "so this test cannot detect a dropped copy."
+            )
+        assert cd_copy.name == source.name
+
+    def test_copy_leaves_captest_back_reference_unset(self):
+        """`_captest` is intentionally dropped: a copy is a standalone CapData."""
+        source = pvc.CapData("source")
+        source._captest = object()
+        assert source.copy()._captest is None
+
 
 class TestCapDataMethodsSim:
     """Test for top level irr_rc_balanced function."""

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -1389,6 +1389,20 @@ class TestFilterBacktracking:
         f._execute(cd_backtrack)
         assert f.cross_axis_tilt_resolved == 0
 
+    def test_filters_a_copy_of_the_capdata(self, cd_backtrack):
+        """A copied CapData keeps the site the filter needs.
+
+        `copy()` used to drop `site`, so filtering a copy — the load-once,
+        copy-per-run pattern — warned and removed nothing instead of raising.
+        """
+        expected = Backtracking()._execute(cd_backtrack)
+        cd_copy = cd_backtrack.copy()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            kept = Backtracking()._execute(cd_copy)
+        assert kept.equals(expected)
+        assert len(kept) < cd_copy.data_filtered.shape[0]
+
     def test_no_site_warns_and_keeps_all(self, cd_backtrack):
         cd_backtrack.site = None
         n_before = cd_backtrack.data_filtered.shape[0]


### PR DESCRIPTION
## Summary

`CapData.copy()` rebuilds a `CapData` attribute by attribute and silently omitted two of them: `tolerance` and `site`. Both bite the load-once, copy-per-run pattern — copy a loaded dataset, then filter each copy differently — because the copy comes back subtly less capable than its source rather than erroring.

- A dropped `tolerance` makes `predict_capacities()` raise `AttributeError` on a copy (`capdata.py` does `self.tolerance.split(" ")`, and the copy's `tolerance` is `None`).
- A dropped `site` is worse, because it fails quietly: `filter_backtracking()` reads `capdata.site` and, finding none, warns and removes nothing. The solar-position `calcparams` helpers that auto-inject from `cd.site` degrade the same way. A filtered copy therefore looks successfully filtered while no rows were removed.

## Changes

- `CapData.copy()` now carries `tolerance` (`copy.copy`) and `site` (`copy.deepcopy`).
  - `site` is set by `io.load_data`, not `__init__`, so it may be absent on the source. The copy always exposes the attribute, set to `None` when the source has none, so consumers see one shape. Every existing reader already goes through `getattr(cd, "site", None)`, so the no-site case is unchanged.
  - The deep copy is deliberate: `CapTest._propagate_sim_site` mutates the `loc` sub-dict in place, so a shared reference would let a copy's tz conversion reach back into the original.
- Documented `site` in the `CapData` class docstring's Attributes section (it was previously undocumented despite being set by `load_data` and read by three subsystems).
- `data_loader` is deliberately still not copied — it holds every source DataFrame in `loaded_files`, so deep-copying it would multiply the memory cost of each copy. This is now recorded as an explicit, reasoned exclusion rather than an oversight.

## Testing

`just test`: 1231 passed. `just lint` and `just fmt` clean.

New tests, each verified to fail without the fix:

- `tests/test_CapData.py::TestCapDataCopy` — `site` survives `copy()` and is independent (mutating the copy's `loc`/`sys` leaves the source untouched); `site is None` when the source had none; `tolerance` survives.
- `tests/test_CapData.py::TestCapDataCopyCompleteness` — a copy-completeness invariant. Rather than hard-coding an attribute list, it derives the tracked set from the live object (`vars()` plus the class-level params) minus a `NOT_COPIED` mapping that pairs each deliberate exclusion with its reason (`_captest`, `loc`/`floc`, `name`, `data_loader`). A separate guard asserts that derived set equals the test's sentinel set, so **adding an attribute to `CapData` fails this test** until it is either copied or explicitly excused. Each sentinel is also asserted to differ from a fresh `CapData`'s default, so the test cannot pass vacuously on an attribute `copy()` never touched.
- `tests/test_filter_classes.py::TestFilterBacktracking::test_filters_a_copy_of_the_capdata` — the behavioral regression: run `Backtracking` on a copy with warnings escalated to errors and assert it keeps the same rows as on the original.

## Notes

No API or behavior change for existing callers beyond the two attributes now being preserved; `copy()` gains no parameters. The only observable difference for a source without site information is that `hasattr(copy, "site")` is now `True` with a value of `None`, which no in-tree reader distinguishes.

Motivation: a downstream parameter-sweep runner loads a dataset once and copies it per parameter combination, which is exactly the pattern these two omissions break.