### PR TITLE
feat: TimeOfDay filter step and column_regex prep selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `TimeOfDay` filter step (and `CapData.filter_time_of_day()` wrapper) —
+keep or drop a daily clock-time window via `DataFrame.between_time`. The
+first-class, serializable replacement for
+`filter_custom(pd.DataFrame.between_time, start, end)`: built from `param`
+parameters, with an `explanation` and full config round-trip through
+`FILTER_REGISTRY`.
+- Prep steps gain a fourth mutually exclusive column selector, `column_regex`,
+matching column *names* with a case-insensitive regex search (the same
+semantics as the Overlay plot's columns filter), where `group_regex` matches
+`column_groups` ids. Accepted by `prep_convert_units`, `prep_scale`, and
+`prep_astype`; `RenameColumns` continues to reject all selectors in favor of
+`column_map`.
+
 ### Fixed
 - `CapData.copy()` now carries over the `site` and `tolerance` attributes,
 which it previously dropped. Copies are the basis of the load-once,

--- a/docs/source/api_reference/capdata.rst
+++ b/docs/source/api_reference/capdata.rst
@@ -130,6 +130,7 @@ current parameter values. See :doc:`filters` for the underlying step classes.
    capdata.CapData.filter_pvsyst
    capdata.CapData.filter_shade
    capdata.CapData.filter_time
+   capdata.CapData.filter_time_of_day
    capdata.CapData.filter_days
    capdata.CapData.filter_outliers
    capdata.CapData.filter_pf

--- a/docs/source/api_reference/filters.rst
+++ b/docs/source/api_reference/filters.rst
@@ -44,6 +44,7 @@ Each step removes rows from ``CapData.data_filtered``. The corresponding
    filters.Pvsyst
    filters.Shade
    filters.Time
+   filters.TimeOfDay
    filters.Days
    filters.Outliers
    filters.PowerFactor

--- a/docs/source/api_reference/generated/captest.capdata.CapData.filter_time_of_day.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.filter_time_of_day.rst
@@ -1,0 +1,6 @@
+﻿captest.capdata.CapData.filter\_time\_of\_day
+=============================================
+
+.. currentmodule:: captest.capdata
+
+.. automethod:: CapData.filter_time_of_day

--- a/docs/source/api_reference/generated/captest.capdata.CapData.rst
+++ b/docs/source/api_reference/generated/captest.capdata.CapData.rst
@@ -47,6 +47,7 @@
       ~CapData.filter_shade
       ~CapData.filter_threshold
       ~CapData.filter_time
+      ~CapData.filter_time_of_day
       ~CapData.filters_to_config
       ~CapData.fit_regression
       ~CapData.get_filtering_table

--- a/docs/source/api_reference/generated/captest.filters.TimeOfDay.rst
+++ b/docs/source/api_reference/generated/captest.filters.TimeOfDay.rst
@@ -1,0 +1,38 @@
+﻿captest.filters.TimeOfDay
+=========================
+
+.. currentmodule:: captest.filters
+
+.. autoclass:: TimeOfDay
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~TimeOfDay.__init__
+      ~TimeOfDay.from_config
+      ~TimeOfDay.run
+      ~TimeOfDay.to_config
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~TimeOfDay.args_repr
+      ~TimeOfDay.custom_name
+      ~TimeOfDay.drop
+      ~TimeOfDay.end_time
+      ~TimeOfDay.explanation
+      ~TimeOfDay.name
+      ~TimeOfDay.param
+      ~TimeOfDay.start_time
+   
+   

--- a/docs/source/api_reference/generated/captest.prep.AsType.rst
+++ b/docs/source/api_reference/generated/captest.prep.AsType.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~AsType.args_repr
+      ~AsType.column_regex
       ~AsType.columns
       ~AsType.custom_name
       ~AsType.dtype

--- a/docs/source/api_reference/generated/captest.prep.BasePrepStep.rst
+++ b/docs/source/api_reference/generated/captest.prep.BasePrepStep.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~BasePrepStep.args_repr
+      ~BasePrepStep.column_regex
       ~BasePrepStep.columns
       ~BasePrepStep.custom_name
       ~BasePrepStep.explanation

--- a/docs/source/api_reference/generated/captest.prep.ConvertUnits.rst
+++ b/docs/source/api_reference/generated/captest.prep.ConvertUnits.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~ConvertUnits.args_repr
+      ~ConvertUnits.column_regex
       ~ConvertUnits.columns
       ~ConvertUnits.custom_name
       ~ConvertUnits.explanation

--- a/docs/source/api_reference/generated/captest.prep.Custom.rst
+++ b/docs/source/api_reference/generated/captest.prep.Custom.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~Custom.args_repr
+      ~Custom.column_regex
       ~Custom.columns
       ~Custom.custom_name
       ~Custom.explanation

--- a/docs/source/api_reference/generated/captest.prep.DropColumns.rst
+++ b/docs/source/api_reference/generated/captest.prep.DropColumns.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~DropColumns.args_repr
+      ~DropColumns.column_regex
       ~DropColumns.columns
       ~DropColumns.custom_name
       ~DropColumns.explanation

--- a/docs/source/api_reference/generated/captest.prep.RenameColumns.rst
+++ b/docs/source/api_reference/generated/captest.prep.RenameColumns.rst
@@ -28,6 +28,7 @@
    
       ~RenameColumns.args_repr
       ~RenameColumns.column_map
+      ~RenameColumns.column_regex
       ~RenameColumns.columns
       ~RenameColumns.custom_name
       ~RenameColumns.explanation

--- a/docs/source/api_reference/generated/captest.prep.Scale.rst
+++ b/docs/source/api_reference/generated/captest.prep.Scale.rst
@@ -27,6 +27,7 @@
    .. autosummary::
    
       ~Scale.args_repr
+      ~Scale.column_regex
       ~Scale.columns
       ~Scale.custom_name
       ~Scale.explanation

--- a/docs/source/api_reference/prep.rst
+++ b/docs/source/api_reference/prep.rst
@@ -29,7 +29,8 @@ Base Class
 ----------
 
 :py:class:`~captest.prep.BasePrepStep` owns the ``run()`` lifecycle, the
-three-way column selector (``columns`` / ``group`` / ``group_regex``), the
+four-way column selector (``columns`` / ``group`` / ``group_regex`` /
+``column_regex``), the
 ``custom_name`` label, and the guard that refuses a value-rewriting step once
 filters have been applied.
 

--- a/docs/user_guide/data_prep.rst
+++ b/docs/user_guide/data_prep.rst
@@ -121,7 +121,7 @@ than a half-applied change.
 Selecting columns
 -----------------
 ``prep_convert_units``, ``prep_scale``, and ``prep_astype`` take exactly one
-of three column selectors:
+of four column selectors:
 
 ``columns``
     An explicit list of column names, acted on in the order given.
@@ -148,14 +148,22 @@ of three column selectors:
         import re
         [gid for gid in das.column_groups if re.search('^temp_(amb|bom)$', gid)]
 
-The group selectors expand to column names in ``column_groups`` order, with
-duplicates removed. Passing more than one selector, or none, is an error:
+``column_regex``
+    A regular expression matched against the column *names* themselves rather
+    than the ``column_groups`` ids, with a case-insensitive search — the same
+    semantics as the interactive plot's columns filter. Use it when the
+    columns you mean share a naming convention that no group captures, e.g.
+    ``'VAL_BP$'`` for every barometric-pressure column.
+
+The group selectors expand to column names in ``column_groups`` order, and
+``column_regex`` in ``data.columns`` order, with duplicates removed. Passing
+more than one selector, or none, is an error:
 
 .. code-block:: Python
 
     das.prep_scale(factor=0.001)
-    # ValueError: Scale requires exactly one of 'columns', 'group', or
-    # 'group_regex'; got none.
+    # ValueError: Scale requires exactly one of 'columns', 'group',
+    # 'group_regex', or 'column_regex'; got none.
 
 Selectors are resolved **at run time**, not when the step is constructed. A
 step that runs after an earlier drop or rename sees the current columns, which

--- a/src/captest/capdata.py
+++ b/src/captest/capdata.py
@@ -44,6 +44,7 @@ from captest.filters import (
     Sensors,
     Shade,
     Time,
+    TimeOfDay,
     filter_grps,
     filter_irr,
     fit_model,
@@ -1950,6 +1951,32 @@ class CapData(param.Parameterized):
         )
         flt.run(self)
 
+    def filter_time_of_day(self, start_time, end_time, drop=False, custom_name=None):
+        """Keep (or drop) the intervals inside a daily clock-time window.
+
+        Backed by ``DataFrame.between_time`` — the first-class replacement for
+        ``filter_custom(pd.DataFrame.between_time, start, end)``.
+
+        Parameters
+        ----------
+        start_time : str
+            Window start clock time, e.g. ``'08:30'``. Inclusive.
+        end_time : str
+            Window end clock time, e.g. ``'18:40'``. Inclusive. A window that
+            wraps midnight (start later than end) selects the wrapped span.
+        drop : bool, default False
+            Remove the daily window instead of keeping it.
+        custom_name : str, default None
+            Optional display label for the recorded filter step.
+        """
+        flt = TimeOfDay(
+            start_time=start_time,
+            end_time=end_time,
+            drop=drop,
+            custom_name=custom_name,
+        )
+        flt.run(self)
+
     def filter_days(self, days, drop=False, custom_name=None):
         """Keep or drop the timestamps belonging to a list of days.
 
@@ -2361,6 +2388,7 @@ class CapData(param.Parameterized):
         columns=None,
         group=None,
         group_regex=None,
+        column_regex=None,
         from_units=None,
         to_units=None,
         custom_name=None,
@@ -2370,7 +2398,7 @@ class CapData(param.Parameterized):
         Parameters
         ----------
         columns : list of str, optional
-            Explicit column names. Mutually exclusive with the group selectors.
+            Explicit column names. Mutually exclusive with the other selectors.
         group : str or list of str, optional
             ``column_groups`` id, or list of ids.
         group_regex : str, optional
@@ -2378,6 +2406,9 @@ class CapData(param.Parameterized):
             ``"^temp_(amb|bom)$"`` to reach ``temp_amb`` and ``temp_bom`` at
             once. Anchor the pattern: a loose ``"^temp"`` also matches
             inverter-temperature groups such as ``temp_inv``.
+        column_regex : str, optional
+            Regex matched (case-insensitive search) against column *names*
+            rather than group ids.
         from_units, to_units : str
             Source and target units; see :data:`captest.prep.UNIT_CONVERSIONS`.
         custom_name : str, optional
@@ -2387,6 +2418,7 @@ class CapData(param.Parameterized):
             columns=columns,
             group=group,
             group_regex=group_regex,
+            column_regex=column_regex,
             from_units=from_units,
             to_units=to_units,
             custom_name=custom_name,
@@ -2397,6 +2429,7 @@ class CapData(param.Parameterized):
         columns=None,
         group=None,
         group_regex=None,
+        column_regex=None,
         factor=1.0,
         offset=0.0,
         custom_name=None,
@@ -2405,7 +2438,7 @@ class CapData(param.Parameterized):
 
         Parameters
         ----------
-        columns, group, group_regex : optional
+        columns, group, group_regex, column_regex : optional
             Column selector; exactly one is required. See
             :meth:`prep_convert_units`.
         factor : float, default 1.0
@@ -2419,6 +2452,7 @@ class CapData(param.Parameterized):
             columns=columns,
             group=group,
             group_regex=group_regex,
+            column_regex=column_regex,
             factor=factor,
             offset=offset,
             custom_name=custom_name,
@@ -2429,6 +2463,7 @@ class CapData(param.Parameterized):
         columns=None,
         group=None,
         group_regex=None,
+        column_regex=None,
         dtype="float64",
         custom_name=None,
     ):
@@ -2436,7 +2471,7 @@ class CapData(param.Parameterized):
 
         Parameters
         ----------
-        columns, group, group_regex : optional
+        columns, group, group_regex, column_regex : optional
             Column selector; exactly one is required. See
             :meth:`prep_convert_units`.
         dtype : str, default "float64"
@@ -2448,6 +2483,7 @@ class CapData(param.Parameterized):
             columns=columns,
             group=group,
             group_regex=group_regex,
+            column_regex=column_regex,
             dtype=dtype,
             custom_name=custom_name,
         ).run(self)

--- a/src/captest/filters.py
+++ b/src/captest/filters.py
@@ -1008,6 +1008,57 @@ class Time(BaseFilter):
         return None
 
 
+class TimeOfDay(BaseFilter):
+    """Keep (or drop) the intervals inside a daily clock-time window.
+
+    Applies ``DataFrame.between_time(start_time, end_time)`` — the first-class
+    equivalent of ``Custom(pd.DataFrame.between_time, start, end)``, which is
+    how notebooks have expressed a fixed daily shading window. Both bounds are
+    inclusive clock times (``"HH:MM"``). A window that wraps midnight
+    (``start_time`` later than ``end_time``) selects the wrapped span, matching
+    ``between_time``. By default the window is kept; set ``drop=True`` to
+    remove it and keep everything else.
+    """
+
+    start_time = param.String(
+        default=None,
+        allow_None=True,
+        doc="Window start clock time, e.g. '08:30'. Inclusive.",
+    )
+    end_time = param.String(
+        default=None,
+        allow_None=True,
+        doc="Window end clock time, e.g. '18:40'. Inclusive.",
+    )
+    drop = param.Boolean(
+        default=False,
+        doc="Remove the daily window from the data instead of keeping it.",
+    )
+
+    def _execute(self, capdata):
+        if self.start_time is None or self.end_time is None:
+            raise ValueError("TimeOfDay requires both start_time and end_time.")
+        df = capdata.data_filtered
+        window_ix = df.between_time(self.start_time, self.end_time).index
+        if self.drop:
+            return df.index.difference(window_ix)
+        return window_ix
+
+    @property
+    def explanation(self):
+        if not hasattr(self, "ix_after"):
+            return None
+        if self.drop:
+            return (
+                f"Intervals between {self.start_time} and {self.end_time} "
+                "each day were removed."
+            )
+        return (
+            f"Intervals outside {self.start_time} to {self.end_time} "
+            "each day were removed."
+        )
+
+
 class Custom(BaseFilter):
     """Apply an arbitrary callable to ``capdata.data_filtered`` as a row filter.
 
@@ -1824,6 +1875,7 @@ FILTER_REGISTRY = {
     "Pvsyst": Pvsyst,
     "Shade": Shade,
     "Time": Time,
+    "TimeOfDay": TimeOfDay,
     "Days": Days,
     "Outliers": Outliers,
     "PowerFactor": PowerFactor,

--- a/src/captest/prep.py
+++ b/src/captest/prep.py
@@ -59,10 +59,15 @@ def restore_prep_state(capdata, snapshot):
     capdata.data, capdata.column_groups = snapshot
 
 
+#: The mutually exclusive column-selector parameter names on
+#: :class:`BasePrepStep`; exactly one must be set on any selector-taking step.
+SELECTOR_PARAMS = ("columns", "group", "group_regex", "column_regex")
+
+
 class BasePrepStep(util.StrictAttrs, param.Parameterized):
     """Common ancestor for data-preparation steps.
 
-    Holds the shared lifecycle (``run``), the three-way column selector, and
+    Holds the shared lifecycle (``run``), the four-way column selector, and
     the ``explanation`` rendering that ``describe_prep`` prints.
     Subclasses implement ``_execute(capdata, columns)``, which mutates
     ``capdata.data`` in place and returns nothing.
@@ -97,6 +102,12 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         default=None,
         allow_None=True,
         doc="Regex matched against column_groups ids. Mutually exclusive with others.",
+    )
+    column_regex = param.String(
+        default=None,
+        allow_None=True,
+        doc="Regex matched (case-insensitive search) against column *names*, "
+        "not group ids. Mutually exclusive with the other selectors.",
     )
 
     # Class-intrinsic human-readable template; set by concrete subclasses.
@@ -133,7 +144,8 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
             If this step rewrites values and ``capdata.filters`` is non-empty.
         ValueError
             If the column selector is not exactly one of ``columns`` /
-            ``group`` / ``group_regex``, or resolves to no columns.
+            ``group`` / ``group_regex`` / ``column_regex``, or resolves to no
+            columns.
         """
         self._check_not_filtered(capdata)
         cols = self._resolve_columns(capdata)
@@ -204,10 +216,10 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
     def _settings_for_duplicate_check(self):
         """Return the params that make two steps equivalent.
 
-        Excludes the three selectors (the duplicate check compares resolved
+        Excludes the selectors (the duplicate check compares resolved
         columns instead) and the presentation-only ``custom_name``.
         """
-        ignored = {"columns", "group", "group_regex", "custom_name"}
+        ignored = {*SELECTOR_PARAMS, "custom_name"}
         return {
             k: v for k, v in util.params_to_config(self).items() if k not in ignored
         }
@@ -238,20 +250,20 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
         -------
         list of str
             Column names this step acts on, in ``column_groups`` order for the
-            group selectors and in the given order for ``columns``.
+            group selectors, in ``data.columns`` order for ``column_regex``,
+            and in the given order for ``columns``.
         """
-        chosen = [
-            name
-            for name in ("columns", "group", "group_regex")
-            if getattr(self, name) is not None
-        ]
+        chosen = [name for name in SELECTOR_PARAMS if getattr(self, name) is not None]
         if len(chosen) != 1:
             raise ValueError(
                 f"{type(self).__name__} requires exactly one of 'columns', "
-                f"'group', or 'group_regex'; got {chosen or 'none'}."
+                f"'group', 'group_regex', or 'column_regex'; got "
+                f"{chosen or 'none'}."
             )
         if self.columns is not None:
             cols = list(self.columns)
+        elif self.column_regex is not None:
+            cols = self._columns_from_column_regex(capdata)
         else:
             cols = self._columns_from_groups(capdata)
         missing = [c for c in cols if c not in capdata.data.columns]
@@ -293,6 +305,21 @@ class BasePrepStep(util.StrictAttrs, param.Parameterized):
             for col in groups[group_id]:
                 if col not in cols:
                     cols.append(col)
+        return cols
+
+    def _columns_from_column_regex(self, capdata):
+        """Expand the ``column_regex`` selector to the column names it matches.
+
+        Matches column *names* with a case-insensitive search
+        (``util.tags_by_regex`` — the same semantics as the Overlay plot's
+        columns filter), where ``group_regex`` matches ``column_groups`` ids.
+        """
+        cols = util.tags_by_regex(list(capdata.data.columns), self.column_regex)
+        if not cols:
+            raise ValueError(
+                f"column_regex {self.column_regex!r} matched no column. "
+                f"Columns: {util.format_name_list(sorted(capdata.data.columns))}."
+            )
         return cols
 
     def _execute(self, capdata, columns):
@@ -573,7 +600,7 @@ class DropColumns(BasePrepStep):
 class RenameColumns(BasePrepStep):
     """Rename columns in ``data`` and ``column_groups``.
 
-    Takes its columns from ``column_map`` rather than the three-way selector;
+    Takes its columns from ``column_map`` rather than the column selector;
     passing a selector is an error. Delegates to :meth:`CapData.rename_cols`.
     """
 
@@ -587,9 +614,7 @@ class RenameColumns(BasePrepStep):
     def _resolve_columns(self, capdata):
         """Return the map's keys; reject the inherited selectors."""
         selectors = [
-            name
-            for name in ("columns", "group", "group_regex")
-            if getattr(self, name) is not None
+            name for name in SELECTOR_PARAMS if getattr(self, name) is not None
         ]
         if selectors:
             raise ValueError(
@@ -651,11 +676,7 @@ class Custom(BasePrepStep):
         only keeps a selector set by direct attribute assignment from
         crashing on the base class's "exactly one of" check.
         """
-        given = [
-            name
-            for name in ("columns", "group", "group_regex")
-            if getattr(self, name) is not None
-        ]
+        given = [name for name in SELECTOR_PARAMS if getattr(self, name) is not None]
         if not given:
             return []
         return super()._resolve_columns(capdata)

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -36,6 +36,7 @@ from captest.filters import (
     Sensors,
     Shade,
     Time,
+    TimeOfDay,
     _backtracking_geometry_error,
     abs_diff_from_average,
     backtracking_active,
@@ -736,6 +737,84 @@ class TestFilterTimeWrapper:
         cd_time.filter_time(start="2023-02-01", end="2023-02-15")
         assert len(cd_time.filters) == 1
         assert isinstance(cd_time.filters[0], Time)
+
+
+@pytest.fixture
+def cd_tod():
+    """A CapData with two days of hourly data for time-of-day tests."""
+    cd = CapData("tod")
+    idx = pd.date_range("2023-06-01", periods=48, freq="h")
+    cd.data = pd.DataFrame({"power": range(48)}, index=idx)
+    return cd
+
+
+class TestTimeOfDay:
+    def test_execute_keeps_daily_window_inclusive(self, cd_tod):
+        kept = TimeOfDay(start_time="08:00", end_time="10:00")._execute(cd_tod)
+        assert len(kept) == 6  # 08/09/10 on each of the two days
+        assert all(8 <= ts.hour <= 10 for ts in kept)
+
+    def test_execute_drop_removes_daily_window(self, cd_tod):
+        kept = TimeOfDay(start_time="08:00", end_time="10:00", drop=True)._execute(
+            cd_tod
+        )
+        assert len(kept) == 42
+        assert not any(8 <= ts.hour <= 10 for ts in kept)
+
+    def test_execute_window_wrapping_midnight(self, cd_tod):
+        kept = TimeOfDay(start_time="22:00", end_time="02:00")._execute(cd_tod)
+        assert all(ts.hour >= 22 or ts.hour <= 2 for ts in kept)
+        assert len(kept) == 10  # 00/01/02 + 22/23 on each of the two days
+
+    def test_matches_the_custom_between_time_it_replaces(self, cd_tod):
+        first_class = TimeOfDay(start_time="08:31", end_time="18:40")._execute(cd_tod)
+        custom = Custom(pd.DataFrame.between_time, "08:31", "18:40")._execute(cd_tod)
+        assert first_class.equals(custom)
+
+    def test_missing_bound_raises(self, cd_tod):
+        with pytest.raises(ValueError, match="start_time and end_time"):
+            TimeOfDay(start_time="08:00")._execute(cd_tod)
+        with pytest.raises(ValueError, match="start_time and end_time"):
+            TimeOfDay(end_time="10:00")._execute(cd_tod)
+
+    def test_config_round_trip(self):
+        step = TimeOfDay(
+            start_time="08:31", end_time="18:40", drop=True, custom_name="shading"
+        )
+        config = step.to_config()
+        assert config["type"] == "TimeOfDay"
+        rebuilt = step_from_config(config)
+        assert isinstance(rebuilt, TimeOfDay)
+        assert rebuilt.start_time == "08:31"
+        assert rebuilt.end_time == "18:40"
+        assert rebuilt.drop is True
+        assert rebuilt.custom_name == "shading"
+
+    def test_explanation_keep_and_drop(self, cd_tod):
+        keep = TimeOfDay(start_time="08:00", end_time="10:00")
+        assert keep.explanation is None  # not run yet
+        keep.run(cd_tod)
+        assert keep.explanation == (
+            "Intervals outside 08:00 to 10:00 each day were removed."
+        )
+        drop = TimeOfDay(start_time="08:00", end_time="10:00", drop=True)
+        drop.run(cd_tod)
+        assert drop.explanation == (
+            "Intervals between 08:00 and 10:00 each day were removed."
+        )
+
+    def test_registered(self):
+        assert FILTER_REGISTRY["TimeOfDay"] is TimeOfDay
+
+
+class TestFilterTimeOfDayWrapper:
+    def test_wrapper_records_step_with_custom_name(self, cd_tod):
+        cd_tod.filter_time_of_day("08:00", "10:00", custom_name="daylight")
+        assert len(cd_tod.filters) == 1
+        step = cd_tod.filters[0]
+        assert isinstance(step, TimeOfDay)
+        assert step.custom_name == "daylight"
+        assert len(cd_tod.data_filtered) == 6
 
 
 class TestFilterCustom:

--- a/tests/test_prep_classes.py
+++ b/tests/test_prep_classes.py
@@ -126,6 +126,49 @@ class TestSelectors:
         with pytest.raises(ValueError, match="absent"):
             prep.Scale(columns=["not_a_column"], factor=1.0).run(cd)
 
+    def test_column_regex_matches_column_names(self, cd):
+        step = prep.Scale(column_regex="^temp", factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["temp_amb_1", "temp_bom_1"]
+
+    def test_column_regex_is_case_insensitive_search(self, cd):
+        """Overlay-tab semantics (util.tags_by_regex): IGNORECASE + search."""
+        step = prep.Scale(column_regex="TEMP_AMB", factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["temp_amb_1"]
+
+    def test_column_regex_matches_names_not_group_ids(self, cd):
+        # 'real_pwr' is a group id; the column is 'power_1'.
+        with pytest.raises(ValueError, match="matched no column"):
+            prep.Scale(column_regex="^real_pwr", factor=1.0).run(cd)
+        step = prep.Scale(column_regex="^power", factor=1.0)
+        step.run(cd)
+        assert step.columns_resolved == ["power_1"]
+
+    def test_column_regex_matching_nothing_raises(self, cd):
+        with pytest.raises(ValueError, match="matched no column"):
+            prep.Scale(column_regex="nomatch", factor=1.0).run(cd)
+
+    def test_column_regex_plus_group_raises(self, cd):
+        with pytest.raises(ValueError, match="exactly one"):
+            prep.Scale(column_regex="^temp", group="wind", factor=1.0).run(cd)
+
+    def test_column_regex_config_round_trip(self, cd):
+        step = prep.Scale(column_regex="^temp", factor=2.0)
+        rebuilt = prep.prep_step_from_config(step.to_config())
+        assert isinstance(rebuilt, prep.Scale)
+        assert rebuilt.column_regex == "^temp"
+        assert rebuilt.factor == 2.0
+
+    def test_rename_columns_rejects_column_regex(self, cd):
+        with pytest.raises(ValueError, match="column_map"):
+            prep.RenameColumns(column_regex="^temp", column_map={"a": "b"}).run(cd)
+
+    def test_wrappers_forward_column_regex(self, cd):
+        cd.prep_scale(column_regex="^wind", factor=2.0)
+        assert cd.data["wind_1"].tolist() == [20.0, 40.0, 60.0, 80.0]
+        assert cd.prep[-1].column_regex == "^wind"
+
 
 class TestAtomicFailure:
     def test_failed_step_restores_data_and_records_nothing(self, cd):


### PR DESCRIPTION
Two additions driven by the captest GUI, each usable on its own.

## TimeOfDay filter step

A new `TimeOfDay` step in `captest.filters` (plus a `CapData.filter_time_of_day()` wrapper) that keeps — or with `drop=True`, removes — the intervals inside a daily clock-time window via `DataFrame.between_time`. It is the first-class equivalent of `Custom(pd.DataFrame.between_time, start, end)`, which is how notebooks have expressed fixed daily shading windows until now:

- Built from `param` Parameters (`start_time`, `end_time`, `drop`), so a `pn.Param` form, param watchers, and live preview all work against it.
- Carries an `explanation` and round-trips through `to_config()` / `FILTER_REGISTRY` / `step_from_config` like every other step (a `Custom` step serializes only by qualname).
- Midnight-wrapping windows (`start_time` later than `end_time`) behave as `between_time` does; a test pins the equivalence to the `Custom` form it replaces.

## `column_regex` prep selector

`prep.BasePrepStep` gains a fourth mutually exclusive column selector, `column_regex`, matching column **names** with a case-insensitive regex search — the same semantics as the Overlay plot's columns filter (`util.tags_by_regex`) — where the existing `group_regex` matches `column_groups` ids.

- The selector names now live in one shared `SELECTOR_PARAMS` tuple, used by the base resolver, the duplicate-check exclusions, and the `RenameColumns` / `Custom` overrides (checked: `RenameColumns._resolve_columns` rejects it alongside the other selectors, `Custom` ignores it).
- A `column_regex` matching nothing raises, like the other selectors; matched columns resolve in `data.columns` order.
- `prep_convert_units`, `prep_scale`, and `prep_astype` forward the new kwarg.

## Tests

`just test`: 1249 passed. New coverage: `TestTimeOfDay` / `TestFilterTimeOfDayWrapper` in `test_filter_classes.py`, and column-regex selector tests in `test_prep_classes.py::TestSelectors` (names-not-groups, case-insensitivity, no-match, exclusivity, config round-trip, wrapper forwarding, RenameColumns rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtGzAePfW1gk77oBxmSfU9